### PR TITLE
Fix routetable isuptodate logic for multiple cidr and associations

### DIFF
--- a/apis/ec2/v1beta1/referencers.go
+++ b/apis/ec2/v1beta1/referencers.go
@@ -121,7 +121,7 @@ func (mg *Subnet) ResolveReferences(ctx context.Context, c client.Reader) error 
 }
 
 // ResolveReferences of this RouteTable
-func (mg *RouteTable) ResolveReferences(ctx context.Context, c client.Reader) error {
+func (mg *RouteTable) ResolveReferences(ctx context.Context, c client.Reader) error { // nolint:gocyclo
 	r := reference.NewAPIResolver(c, mg)
 
 	// Resolve spec.forProvider.vpcId
@@ -140,50 +140,56 @@ func (mg *RouteTable) ResolveReferences(ctx context.Context, c client.Reader) er
 
 	// Resolve spec.forProvider.routes[].gatewayId
 	for i := range mg.Spec.ForProvider.Routes {
-		rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
-			CurrentValue: aws.StringValue(mg.Spec.ForProvider.Routes[i].GatewayID),
-			Reference:    mg.Spec.ForProvider.Routes[i].GatewayIDRef,
-			Selector:     mg.Spec.ForProvider.Routes[i].GatewayIDSelector,
-			To:           reference.To{Managed: &InternetGateway{}, List: &InternetGatewayList{}},
-			Extract:      reference.ExternalName(),
-		})
-		if err != nil {
-			return errors.Wrapf(err, "spec.forProvider.routes[%d].gatewayId", i)
+		if mg.Spec.ForProvider.Routes[i].GatewayIDRef != nil || mg.Spec.ForProvider.Routes[i].GatewayIDSelector != nil {
+			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: aws.StringValue(mg.Spec.ForProvider.Routes[i].GatewayID),
+				Reference:    mg.Spec.ForProvider.Routes[i].GatewayIDRef,
+				Selector:     mg.Spec.ForProvider.Routes[i].GatewayIDSelector,
+				To:           reference.To{Managed: &InternetGateway{}, List: &InternetGatewayList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrapf(err, "spec.forProvider.routes[%d].gatewayId", i)
+			}
+			mg.Spec.ForProvider.Routes[i].GatewayID = aws.String(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Routes[i].GatewayIDRef = rsp.ResolvedReference
 		}
-		mg.Spec.ForProvider.Routes[i].GatewayID = aws.String(rsp.ResolvedValue)
-		mg.Spec.ForProvider.Routes[i].GatewayIDRef = rsp.ResolvedReference
 	}
 
 	// Resolve spec.forProvider.routes[].natGatewayId
 	for i := range mg.Spec.ForProvider.Routes {
-		rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
-			CurrentValue: aws.StringValue(mg.Spec.ForProvider.Routes[i].NatGatewayID),
-			Reference:    mg.Spec.ForProvider.Routes[i].NatGatewayIDRef,
-			Selector:     mg.Spec.ForProvider.Routes[i].NatGatewayIDSelector,
-			To:           reference.To{Managed: &NATGateway{}, List: &NATGatewayList{}},
-			Extract:      reference.ExternalName(),
-		})
-		if err != nil {
-			return errors.Wrapf(err, "spec.forProvider.routes[%d].natGatewayId", i)
+		if mg.Spec.ForProvider.Routes[i].NatGatewayIDRef != nil || mg.Spec.ForProvider.Routes[i].NatGatewayIDSelector != nil {
+			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: aws.StringValue(mg.Spec.ForProvider.Routes[i].NatGatewayID),
+				Reference:    mg.Spec.ForProvider.Routes[i].NatGatewayIDRef,
+				Selector:     mg.Spec.ForProvider.Routes[i].NatGatewayIDSelector,
+				To:           reference.To{Managed: &NATGateway{}, List: &NATGatewayList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrapf(err, "spec.forProvider.routes[%d].natGatewayId", i)
+			}
+			mg.Spec.ForProvider.Routes[i].NatGatewayID = aws.String(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Routes[i].NatGatewayIDRef = rsp.ResolvedReference
 		}
-		mg.Spec.ForProvider.Routes[i].NatGatewayID = aws.String(rsp.ResolvedValue)
-		mg.Spec.ForProvider.Routes[i].NatGatewayIDRef = rsp.ResolvedReference
 	}
 
 	// Resolve spec.associations[].subnetId
 	for i := range mg.Spec.ForProvider.Associations {
-		rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
-			CurrentValue: aws.StringValue(mg.Spec.ForProvider.Associations[i].SubnetID),
-			Reference:    mg.Spec.ForProvider.Associations[i].SubnetIDRef,
-			Selector:     mg.Spec.ForProvider.Associations[i].SubnetIDSelector,
-			To:           reference.To{Managed: &Subnet{}, List: &SubnetList{}},
-			Extract:      reference.ExternalName(),
-		})
-		if err != nil {
-			return errors.Wrapf(err, "spec.forProvider.associations[%d].subnetId", i)
+		if mg.Spec.ForProvider.Associations[i].SubnetIDRef != nil || mg.Spec.ForProvider.Associations[i].SubnetIDSelector != nil {
+			rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
+				CurrentValue: aws.StringValue(mg.Spec.ForProvider.Associations[i].SubnetID),
+				Reference:    mg.Spec.ForProvider.Associations[i].SubnetIDRef,
+				Selector:     mg.Spec.ForProvider.Associations[i].SubnetIDSelector,
+				To:           reference.To{Managed: &Subnet{}, List: &SubnetList{}},
+				Extract:      reference.ExternalName(),
+			})
+			if err != nil {
+				return errors.Wrapf(err, "spec.forProvider.associations[%d].subnetId", i)
+			}
+			mg.Spec.ForProvider.Associations[i].SubnetID = aws.String(rsp.ResolvedValue)
+			mg.Spec.ForProvider.Associations[i].SubnetIDRef = rsp.ResolvedReference
 		}
-		mg.Spec.ForProvider.Associations[i].SubnetID = aws.String(rsp.ResolvedValue)
-		mg.Spec.ForProvider.Associations[i].SubnetIDRef = rsp.ResolvedReference
 	}
 
 	return nil

--- a/apis/ec2/v1beta1/routetable_types.go
+++ b/apis/ec2/v1beta1/routetable_types.go
@@ -119,6 +119,9 @@ type RouteState struct {
 
 	// The ID of a VPC peering connection.
 	VpcPeeringConnectionID string `json:"vpcPeeringConnectionId,omitempty"`
+
+	// Describes how the route was created
+	Origin string `json:"origin,omitempty"`
 }
 
 // Association describes an association between a route table and a subnet.

--- a/pkg/clients/ec2/routetable_test.go
+++ b/pkg/clients/ec2/routetable_test.go
@@ -11,11 +11,14 @@ import (
 )
 
 var (
-	rtVPC      = "some vpc"
-	otherRtVPC = "some other vpc"
-	rtID       = "some RT Id"
-	rtSubnetID = "some subnet"
-	rtOwner    = "some owner"
+	rtVPC                  = "some vpc"
+	otherRtVPC             = "some other vpc"
+	rtID                   = "some RT Id"
+	rtSubnetID             = "some subnet"
+	rtOtherSubnetID        = "other subnet"
+	rtOwner                = "some owner"
+	rtDestinationCIDR      = "0.0.0.0/0"
+	rtOtherDestinationCIDR = "1.1.1.1/1"
 )
 
 func specAssociations() []v1beta1.Association {
@@ -51,6 +54,100 @@ func TestIsRTUpToDate(t *testing.T) {
 				},
 				p: v1beta1.RouteTableParameters{
 					VPCID: aws.String(rtVPC),
+				},
+			},
+			want: true,
+		},
+		"SameFieldsDifferentOrders": {
+			args: args{
+				rt: ec2.RouteTable{
+					VpcId: aws.String(rtVPC),
+					Associations: []ec2.RouteTableAssociation{
+						{
+							SubnetId: aws.String(rtSubnetID),
+						},
+						{
+							SubnetId: aws.String(rtOtherSubnetID),
+						},
+					},
+					Routes: []ec2.Route{
+						{
+							DestinationCidrBlock: aws.String(rtDestinationCIDR),
+						},
+						{
+							DestinationCidrBlock: aws.String(rtOtherDestinationCIDR),
+						},
+					},
+				},
+				p: v1beta1.RouteTableParameters{
+					VPCID: aws.String(rtVPC),
+					Associations: []v1beta1.Association{
+						{
+							SubnetID: aws.String(rtOtherSubnetID),
+						},
+						{
+							SubnetID: aws.String(rtSubnetID),
+						},
+					},
+					Routes: []v1beta1.Route{
+						{
+							DestinationCIDRBlock: aws.String(rtOtherDestinationCIDR),
+						},
+						{
+							DestinationCIDRBlock: aws.String(rtDestinationCIDR),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"SameFieldsMultipleDefault": {
+			args: args{
+				rt: ec2.RouteTable{
+					VpcId: aws.String(rtVPC),
+					Associations: []ec2.RouteTableAssociation{
+						{
+							SubnetId: aws.String(rtSubnetID),
+						},
+						{
+							SubnetId: aws.String(rtOtherSubnetID),
+						},
+					},
+					Routes: []ec2.Route{
+						{
+							DestinationCidrBlock: aws.String(rtDestinationCIDR),
+						},
+						{
+							DestinationCidrBlock: aws.String(rtOtherDestinationCIDR),
+						},
+						{
+							DestinationCidrBlock: aws.String(rtDestinationCIDR),
+							Origin:               ec2.RouteOriginCreateRouteTable,
+						},
+						{
+							DestinationCidrBlock: aws.String(rtOtherDestinationCIDR),
+							Origin:               ec2.RouteOriginCreateRouteTable,
+						},
+					},
+				},
+				p: v1beta1.RouteTableParameters{
+					VPCID: aws.String(rtVPC),
+					Associations: []v1beta1.Association{
+						{
+							SubnetID: aws.String(rtOtherSubnetID),
+						},
+						{
+							SubnetID: aws.String(rtSubnetID),
+						},
+					},
+					Routes: []v1beta1.Route{
+						{
+							DestinationCIDRBlock: aws.String(rtOtherDestinationCIDR),
+						},
+						{
+							DestinationCIDRBlock: aws.String(rtDestinationCIDR),
+						},
+					},
 				},
 			},
 			want: true,

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -273,7 +273,7 @@ func (e *external) deleteRoutes(ctx context.Context, tableID string, desired []v
 				break
 			}
 		}
-		if !found && rt.GatewayID != ec2.DefaultLocalGatewayID {
+		if !found && rt.Origin != string(awsec2.RouteOriginCreateRouteTable) {
 			if rt.DestinationCIDRBlock != "" {
 				_, err := e.client.DeleteRouteRequest(&awsec2.DeleteRouteInput{
 					RouteTableId:         aws.String(tableID),


### PR DESCRIPTION
Signed-off-by: chris <cvodak@ea.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Fixes isUpToDate logic for routetables with multiple associations and in VPC's with multiple CIDR Blocks. IsRtUpTodate was always returning false due to the additional subnet association and default routes added. Also changed the resolvereferences logic so that it will only be attempted if there is something to resolve.

Just saw https://github.com/crossplane/provider-aws/issues/657 so ideally this logic won't be needed forever but in the meantime. 


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested by scaling down deployed provider and running locally to ensure the isUpToDate was returning the expected values on routetables that exist in VPC with multiple CIDR blocks.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
