### PR TITLE
normalize iam policy actions

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -649,6 +649,15 @@ func LateInitializeBoolPtr(in *bool, from *bool) *bool {
 	return from
 }
 
+// CompactJSON removes space characters from a JSON string.
+func CompactJSON(s string) (string, error) {
+	buffer := new(bytes.Buffer)
+	if err := json.Compact(buffer, []byte(s)); err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
+}
+
 // CompactAndEscapeJSON removes space characters and URL-encodes the JSON string.
 func CompactAndEscapeJSON(s string) (string, error) {
 	buffer := new(bytes.Buffer)

--- a/pkg/clients/iam/iampolicy_test.go
+++ b/pkg/clients/iam/iampolicy_test.go
@@ -35,6 +35,19 @@ var (
 		  }
 		]
 	   }`
+
+	document3 = `{
+		"Version": "2012-10-17",
+		"Statement": [
+		  {
+			"Effect": "Allow",
+			"Principal": {
+			  "Service": "eks.amazonaws.com"
+			},
+			"Action": ["sts:AssumeRole"]
+		  }
+		]
+	   }`
 )
 
 func TestIsPolicyUpToDate(t *testing.T) {
@@ -54,6 +67,17 @@ func TestIsPolicyUpToDate(t *testing.T) {
 				},
 				version: iamtypes.PolicyVersion{
 					Document: &document1,
+				},
+			},
+			want: true,
+		},
+		"SameFieldsSingleAction": {
+			args: args{
+				p: v1alpha1.IAMPolicyParameters{
+					Document: document1,
+				},
+				version: iamtypes.PolicyVersion{
+					Document: &document3,
 				},
 			},
 			want: true,
@@ -83,6 +107,45 @@ func TestIsPolicyUpToDate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got, _ := IsPolicyUpToDate(tc.args.p, tc.args.version)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReplaceActionArray(t *testing.T) {
+	type args struct {
+		p string
+	}
+
+	cases := map[string]struct {
+		args args
+		want string
+	}{
+		"ActionString": {
+			args: args{
+				p: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+			},
+			want: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+		},
+		"ActionSingleItem": {
+			args: args{
+				p: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":[\"sts:AssumeRole\"]}]}",
+			},
+			want: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+		},
+		"ActionMultipleItems": {
+			args: args{
+				p: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":[\"sts:AssumeRole\",\"sts:*\"]}]}",
+			},
+			want: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"eks.amazonaws.com\"},\"Action\":[\"sts:AssumeRole\",\"sts:*\"]}]}",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := replaceActionArray(tc.args.p)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}


### PR DESCRIPTION
Signed-off-by: smcavallo <smcavallo@hotmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Enhanced policy comparison.  See linked issue.
Converts `Action` with a single item from array to string for comparison purposes:
`"Action":["sts:AssumeRoleWithWebIdentity"]` to `"Action":"sts:AssumeRoleWithWebIdentity"` 

In effect this is the same permission but the current comparison interpret them as different.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #
https://github.com/crossplane/provider-aws/issues/932

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Unit tests

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
