### PR TITLE
Added default tags to iam.User

### DIFF
--- a/pkg/clients/iam/fake/user.go
+++ b/pkg/clients/iam/fake/user.go
@@ -27,12 +27,21 @@ import (
 // this ensures that the mock implements the client interface
 var _ clientset.UserClient = (*MockUserClient)(nil)
 
+// MockUserInput holds the input structures for test inspections
+type MockUserInput struct {
+	TagUserInput   *iam.TagUserInput
+	UntagUserInput *iam.UntagUserInput
+}
+
 // MockUserClient is a type that implements all the methods for RoleClient interface
 type MockUserClient struct {
+	MockUserInput  MockUserInput
 	MockGetUser    func(ctx context.Context, input *iam.GetUserInput, opts []func(*iam.Options)) (*iam.GetUserOutput, error)
 	MockCreateUser func(ctx context.Context, input *iam.CreateUserInput, opts []func(*iam.Options)) (*iam.CreateUserOutput, error)
 	MockDeleteUser func(ctx context.Context, input *iam.DeleteUserInput, opts []func(*iam.Options)) (*iam.DeleteUserOutput, error)
 	MockUpdateUser func(ctx context.Context, input *iam.UpdateUserInput, opts []func(*iam.Options)) (*iam.UpdateUserOutput, error)
+	MockTagUser    func(ctx context.Context, input *iam.TagUserInput, opt []func(*iam.Options)) (*iam.TagUserOutput, error)
+	MockUntagUser  func(ctx context.Context, input *iam.UntagUserInput, opts []func(*iam.Options)) (*iam.UntagUserOutput, error)
 }
 
 // GetUser mocks GetUser method
@@ -53,4 +62,16 @@ func (m *MockUserClient) DeleteUser(ctx context.Context, input *iam.DeleteUserIn
 // UpdateUser mocks UpdateUser method
 func (m *MockUserClient) UpdateUser(ctx context.Context, input *iam.UpdateUserInput, opts ...func(*iam.Options)) (*iam.UpdateUserOutput, error) {
 	return m.MockUpdateUser(ctx, input, opts)
+}
+
+// TagUser mocks TagUser method
+func (m *MockUserClient) TagUser(ctx context.Context, input *iam.TagUserInput, opts ...func(*iam.Options)) (*iam.TagUserOutput, error) {
+	m.MockUserInput.TagUserInput = input
+	return m.MockTagUser(ctx, input, opts)
+}
+
+// UntagUser mocks UntagUser method
+func (m *MockUserClient) UntagUser(ctx context.Context, input *iam.UntagUserInput, opts ...func(*iam.Options)) (*iam.UntagUserOutput, error) {
+	m.MockUserInput.UntagUserInput = input
+	return m.MockUntagUser(ctx, input, opts)
 }

--- a/pkg/clients/iam/user.go
+++ b/pkg/clients/iam/user.go
@@ -17,6 +17,8 @@ type UserClient interface {
 	CreateUser(ctx context.Context, input *iam.CreateUserInput, opts ...func(*iam.Options)) (*iam.CreateUserOutput, error)
 	DeleteUser(ctx context.Context, input *iam.DeleteUserInput, opts ...func(*iam.Options)) (*iam.DeleteUserOutput, error)
 	UpdateUser(ctx context.Context, input *iam.UpdateUserInput, opts ...func(*iam.Options)) (*iam.UpdateUserOutput, error)
+	TagUser(ctx context.Context, params *iam.TagUserInput, opts ...func(*iam.Options)) (*iam.TagUserOutput, error)
+	UntagUser(ctx context.Context, params *iam.UntagUserInput, opts ...func(*iam.Options)) (*iam.UntagUserOutput, error)
 }
 
 // NewUserClient returns a new client using AWS credentials as JSON encoded data.

--- a/pkg/controller/iam/user/controller.go
+++ b/pkg/controller/iam/user/controller.go
@@ -23,6 +23,7 @@ import (
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,6 +50,8 @@ const (
 	errDelete = "cannot delete the IAM User resource"
 	errUpdate = "cannot update the IAM User resource"
 	errSDK    = "empty IAM User received from IAM API"
+	errTag    = "cannot tag the IAM User resource"
+	errUntag  = "cannot remove tags from the IAM User resource"
 
 	errKubeUpdateFailed = "cannot late initialize IAM User"
 )
@@ -69,6 +72,9 @@ func SetupUser(mgr ctrl.Manager, o controller.Options) error {
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.UserGroupVersionKind),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewUserClient}),
+			managed.WithInitializers(
+				managed.NewNameAsExternalName(mgr.GetClient()),
+				&tagger{kube: mgr.GetClient()}),
 			managed.WithConnectionPublishers(),
 			managed.WithPollInterval(o.PollInterval),
 			managed.WithLogger(o.Logger.WithValues("controller", name)),
@@ -128,9 +134,16 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		UserID: aws.ToString(user.UserId),
 	}
 
+	crTagMap := make(map[string]string, len(cr.Spec.ForProvider.Tags))
+	for _, v := range cr.Spec.ForProvider.Tags {
+		crTagMap[v.Key] = v.Value
+	}
+	_, _, areTagsUpdated := iam.DiffIAMTags(crTagMap, observed.User.Tags)
+
 	return managed.ExternalObservation{
-		ResourceExists:   true,
-		ResourceUpToDate: aws.ToString(cr.Spec.ForProvider.Path) == aws.ToString(user.Path),
+		ResourceExists: true,
+		ResourceUpToDate: aws.ToString(cr.Spec.ForProvider.Path) == aws.ToString(user.Path) &&
+			areTagsUpdated,
 	}, nil
 }
 
@@ -162,6 +175,38 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		UserName: aws.String(meta.GetExternalName(cr)),
 	})
 
+	if err != nil {
+		return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
+	}
+
+	observed, err := e.client.GetUser(ctx, &awsiam.GetUserInput{
+		UserName: aws.String(meta.GetExternalName(cr)),
+	})
+
+	if err != nil {
+		return managed.ExternalUpdate{}, awsclient.Wrap(err, errGet)
+	}
+
+	add, remove, _ := iam.DiffIAMTagsWithUpdates(cr.Spec.ForProvider.Tags, observed.User.Tags)
+
+	if len(add) > 0 {
+		if _, err := e.client.TagUser(ctx, &awsiam.TagUserInput{
+			UserName: aws.String(meta.GetExternalName(cr)),
+			Tags:     add,
+		}); err != nil {
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errTag)
+		}
+	}
+
+	if len(remove) > 0 {
+		if _, err := e.client.UntagUser(ctx, &awsiam.UntagUserInput{
+			TagKeys:  remove,
+			UserName: aws.String(meta.GetExternalName(cr)),
+		}); err != nil {
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errUntag)
+		}
+	}
+
 	return managed.ExternalUpdate{}, awsclient.Wrap(err, errUpdate)
 }
 
@@ -178,4 +223,35 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 	})
 
 	return awsclient.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDelete)
+}
+
+type tagger struct {
+	kube client.Client
+}
+
+func (t *tagger) Initialize(ctx context.Context, mgd resource.Managed) error {
+	cr, ok := mgd.(*v1beta1.User)
+	if !ok {
+		return errors.New(errUnexpectedObject)
+	}
+
+	added := false
+	defaultTags := resource.GetExternalTags(mgd)
+
+	for i, t := range cr.Spec.ForProvider.Tags {
+		if v, ok := defaultTags[t.Key]; ok && v != t.Value {
+			cr.Spec.ForProvider.Tags[i].Value = v
+			added = true
+			delete(defaultTags, t.Key)
+		}
+	}
+
+	for k, v := range defaultTags {
+		cr.Spec.ForProvider.Tags = append(cr.Spec.ForProvider.Tags, v1beta1.Tag{Key: k, Value: v})
+		added = true
+	}
+	if !added {
+		return nil
+	}
+	return errors.Wrap(t.kube.Update(ctx, cr), errKubeUpdateFailed)
 }

--- a/pkg/controller/iam/user/controller_test.go
+++ b/pkg/controller/iam/user/controller_test.go
@@ -20,22 +20,24 @@ import (
 	"context"
 	"testing"
 
-	"github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
 	awsiamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
+	"github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1"
 	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
-	"github.com/crossplane-contrib/provider-aws/pkg/clients/iam"
 	"github.com/crossplane-contrib/provider-aws/pkg/clients/iam/fake"
 )
 
@@ -44,10 +46,37 @@ var (
 	userName       = "some user"
 
 	errBoom = errors.New("boom")
+
+	sortTags = cmpopts.SortSlices(func(a, b v1beta1.Tag) bool {
+		return a.Key > b.Key
+	})
+
+	tagComparer = cmp.Comparer(func(expected, actual awsiamtypes.Tag) bool {
+		return cmp.Equal(expected.Key, actual.Key) &&
+			cmp.Equal(expected.Value, actual.Value)
+	})
+
+	tagInputComparer = cmp.Comparer(func(expected, actual *awsiam.TagUserInput) bool {
+		return cmp.Equal(expected.UserName, actual.UserName) &&
+			cmp.Equal(expected.Tags, actual.Tags, tagComparer, sortIAMTags)
+	})
+
+	untagInputComparer = cmp.Comparer(func(expected, actual *awsiam.UntagUserInput) bool {
+		return cmp.Equal(expected.UserName, actual.UserName) &&
+			cmp.Equal(expected.TagKeys, actual.TagKeys, sortStrings)
+	})
+
+	sortIAMTags = cmpopts.SortSlices(func(a, b awsiamtypes.Tag) bool {
+		return *a.Key > *b.Key
+	})
+
+	sortStrings = cmpopts.SortSlices(func(x, y string) bool {
+		return x < y
+	})
 )
 
 type args struct {
-	iam iam.UserClient
+	iam *fake.MockUserClient
 	cr  resource.Managed
 }
 
@@ -59,6 +88,24 @@ func withConditions(c ...xpv1.Condition) userModifier {
 
 func withExternalName(name string) userModifier {
 	return func(r *v1beta1.User) { meta.SetExternalName(r, name) }
+}
+
+func withTags(tagMaps ...map[string]string) userModifier {
+	var tagList []v1beta1.Tag
+	for _, tagMap := range tagMaps {
+		for k, v := range tagMap {
+			tagList = append(tagList, v1beta1.Tag{Key: k, Value: v})
+		}
+	}
+	return func(r *v1beta1.User) {
+		r.Spec.ForProvider.Tags = tagList
+	}
+}
+
+func withGroupVersionKind() userModifier {
+	return func(iamRole *v1beta1.User) {
+		iamRole.TypeMeta.SetGroupVersionKind(v1beta1.PolicyGroupVersionKind)
+	}
 }
 
 func user(m ...userModifier) *v1beta1.User {
@@ -81,7 +128,7 @@ func TestObserve(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				iam: &fake.MockUserClient{
 					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
@@ -124,6 +171,31 @@ func TestObserve(t *testing.T) {
 				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
+		"DifferentTags": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{
+								Tags: []awsiamtypes.Tag{
+									{Key: aws.String("k1"), Value: aws.String("v1")},
+								},
+							},
+						}, nil
+					},
+				},
+				cr: user(withExternalName(userName), withTags(map[string]string{"k1": "v2"})),
+			},
+			want: want{
+				cr: user(withExternalName(userName),
+					withConditions(xpv1.Available()),
+					withTags(map[string]string{"k1": "v2"})),
+				result: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -156,7 +228,7 @@ func TestCreate(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				iam: &fake.MockUserClient{
 					MockCreateUser: func(ctx context.Context, input *awsiam.CreateUserInput, opts []func(*awsiam.Options)) (*awsiam.CreateUserOutput, error) {
@@ -226,11 +298,25 @@ func TestUpdate(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"InValidInput": {
+			args: args{
+				cr: unexpectedItem,
+			},
+			want: want{
+				cr:  unexpectedItem,
+				err: errors.New(errUnexpectedObject),
+			},
+		},
+		"ValidInput": {
 			args: args{
 				iam: &fake.MockUserClient{
 					MockUpdateUser: func(ctx context.Context, input *awsiam.UpdateUserInput, opts []func(*awsiam.Options)) (*awsiam.UpdateUserOutput, error) {
 						return &awsiam.UpdateUserOutput{}, nil
+					},
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{},
+						}, nil
 					},
 				},
 				cr: user(withExternalName(userName)),
@@ -239,13 +325,35 @@ func TestUpdate(t *testing.T) {
 				cr: user(withExternalName(userName)),
 			},
 		},
-		"InValidInput": {
+		"UpdateUserError": {
 			args: args{
-				cr: unexpectedItem,
+				iam: &fake.MockUserClient{
+					MockUpdateUser: func(ctx context.Context, input *awsiam.UpdateUserInput, opts []func(*awsiam.Options)) (*awsiam.UpdateUserOutput, error) {
+						return nil, errBoom
+					},
+				},
+				cr: user(withExternalName(userName)),
 			},
 			want: want{
-				cr:  unexpectedItem,
-				err: errors.New(errUnexpectedObject),
+				cr:  user(withExternalName(userName)),
+				err: awsclient.Wrap(errBoom, errUpdate),
+			},
+		},
+		"GetUserError": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockUpdateUser: func(ctx context.Context, input *awsiam.UpdateUserInput, opts []func(*awsiam.Options)) (*awsiam.UpdateUserOutput, error) {
+						return &awsiam.UpdateUserOutput{}, nil
+					},
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return nil, errBoom
+					},
+				},
+				cr: user(withExternalName(userName)),
+			},
+			want: want{
+				cr:  user(withExternalName(userName)),
+				err: awsclient.Wrap(errBoom, errGet),
 			},
 		},
 	}
@@ -268,6 +376,218 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdate_Tags(t *testing.T) {
+
+	type want struct {
+		cr         resource.Managed
+		result     managed.ExternalUpdate
+		err        error
+		tagInput   *awsiam.TagUserInput
+		untagInput *awsiam.UntagUserInput
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"AddTagsError": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{},
+						}, nil
+					},
+					MockTagUser: func(ctx context.Context, params *awsiam.TagUserInput, opt []func(*awsiam.Options)) (*awsiam.TagUserOutput, error) {
+						return nil, errBoom
+					},
+				},
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key": "value",
+					})),
+			},
+			want: want{
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key": "value",
+					})),
+				err: awsclient.Wrap(errBoom, errTag),
+			},
+		},
+		"AddTagsSuccess": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{},
+						}, nil
+					},
+					MockTagUser: func(ctx context.Context, params *awsiam.TagUserInput, opt []func(*awsiam.Options)) (*awsiam.TagUserOutput, error) {
+						return nil, nil
+					},
+				},
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key": "value",
+					})),
+			},
+			want: want{
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key": "value",
+					})),
+				tagInput: &awsiam.TagUserInput{
+					UserName: aws.String(userName),
+					Tags: []awsiamtypes.Tag{
+						{Key: aws.String("key"), Value: aws.String("value")},
+					},
+				},
+			},
+		},
+		"UpdateTagsSuccess": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{
+								Tags: []awsiamtypes.Tag{
+									{Key: aws.String("key1"), Value: aws.String("value1")},
+									{Key: aws.String("key2"), Value: aws.String("value2")},
+								},
+							},
+						}, nil
+					},
+					MockTagUser: func(ctx context.Context, input *awsiam.TagUserInput, opts []func(*awsiam.Options)) (*awsiam.TagUserOutput, error) {
+						return nil, nil
+					},
+				},
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key1": "value1",
+						"key2": "value1",
+					})),
+			},
+			want: want{
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key2": "value1",
+						"key1": "value1",
+					})),
+				tagInput: &awsiam.TagUserInput{
+					UserName: aws.String(userName),
+					Tags: []awsiamtypes.Tag{
+						{Key: aws.String("key2"), Value: aws.String("value1")},
+					},
+				},
+			},
+		},
+		"RemoveTagsError": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{
+								Tags: []awsiamtypes.Tag{
+									{Key: aws.String("key1"), Value: aws.String("value1")},
+									{Key: aws.String("key2"), Value: aws.String("value2")},
+								},
+							},
+						}, nil
+					},
+					MockUntagUser: func(ctx context.Context, input *awsiam.UntagUserInput, opts []func(*awsiam.Options)) (*awsiam.UntagUserOutput, error) {
+						return nil, errBoom
+					},
+				},
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key2": "value2",
+					})),
+			},
+			want: want{
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key2": "value2",
+					})),
+				err: awsclient.Wrap(errBoom, errUntag),
+			},
+		},
+		"RemoveTagsSuccess": {
+			args: args{
+				iam: &fake.MockUserClient{
+					MockGetUser: func(ctx context.Context, input *awsiam.GetUserInput, opts []func(*awsiam.Options)) (*awsiam.GetUserOutput, error) {
+						return &awsiam.GetUserOutput{
+							User: &awsiamtypes.User{
+								Tags: []awsiamtypes.Tag{
+									{Key: aws.String("key1"), Value: aws.String("value1")},
+									{Key: aws.String("key2"), Value: aws.String("value2")},
+								},
+							},
+						}, nil
+					},
+					MockUntagUser: func(ctx context.Context, input *awsiam.UntagUserInput, opts []func(*awsiam.Options)) (*awsiam.UntagUserOutput, error) {
+						return nil, nil
+					},
+				},
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key2": "value2",
+					})),
+			},
+			want: want{
+				cr: user(
+					withExternalName(userName),
+					withTags(map[string]string{
+						"key2": "value2",
+					})),
+				untagInput: &awsiam.UntagUserInput{
+					UserName: aws.String(userName),
+					TagKeys:  []string{"key1"},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.iam.MockUpdateUser = func(ctx context.Context, input *awsiam.UpdateUserInput, opts []func(*awsiam.Options)) (*awsiam.UpdateUserOutput, error) {
+				return nil, nil
+			}
+
+			e := &external{client: tc.iam}
+			o, err := e.Update(context.Background(), tc.args.cr)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.cr, tc.args.cr, test.EquateConditions(), sortTags); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.result, o); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+			if tc.want.tagInput != nil {
+				if diff := cmp.Diff(tc.want.tagInput, tc.iam.MockUserInput.TagUserInput, tagInputComparer); diff != "" {
+					t.Errorf("r: -want, +got:\n%s", diff)
+				}
+			}
+			if tc.want.untagInput != nil {
+				if diff := cmp.Diff(tc.want.untagInput, tc.iam.MockUserInput.UntagUserInput, untagInputComparer); diff != "" {
+					t.Errorf("r: -want, +got:\n%s", diff)
+				}
+			}
+		})
+	}
+}
 func TestDelete(t *testing.T) {
 
 	type want struct {
@@ -279,7 +599,7 @@ func TestDelete(t *testing.T) {
 		args
 		want
 	}{
-		"VaildInput": {
+		"ValidInput": {
 			args: args{
 				iam: &fake.MockUserClient{
 					MockDeleteUser: func(ctx context.Context, input *awsiam.DeleteUserInput, opts []func(*awsiam.Options)) (*awsiam.DeleteUserOutput, error) {
@@ -328,6 +648,92 @@ func TestDelete(t *testing.T) {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.want.cr, tc.args.cr, test.EquateConditions()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTagger_Initialize(t *testing.T) {
+	type args struct {
+		cr   resource.Managed
+		kube client.Client
+	}
+	type want struct {
+		cr  *v1beta1.User
+		err error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Unexpected": {
+			args: args{
+				cr:   unexpectedItem,
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			},
+			want: want{
+				err: errors.New(errUnexpectedObject),
+			},
+		},
+		"Successful": {
+			args: args{
+				cr: user(
+					withExternalName(userName),
+					withGroupVersionKind(),
+					withTags(map[string]string{"foo": "bar"})),
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			},
+			want: want{
+				cr: user(
+					withExternalName(userName),
+					withGroupVersionKind(),
+					withTags(resource.GetExternalTags(user(withGroupVersionKind())), map[string]string{"foo": "bar"})),
+			},
+		},
+		"DefaultTags": {
+			args: args{
+				cr: user(withExternalName(userName),
+					withTags(map[string]string{"foo": "bar"}), withGroupVersionKind()),
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			},
+			want: want{
+				cr: user(withExternalName(userName),
+					withTags(resource.GetExternalTags(user(withGroupVersionKind())), map[string]string{"foo": "bar"}), withGroupVersionKind()),
+			},
+		},
+		"UpdateDefaultTags": {
+			args: args{
+				cr: user(withExternalName(userName),
+					withTags(map[string]string{resource.ExternalResourceTagKeyKind: "bar"}), withGroupVersionKind()),
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			},
+			want: want{
+				cr: user(withExternalName(userName),
+					withTags(resource.GetExternalTags(user(withGroupVersionKind()))), withGroupVersionKind()),
+			},
+		},
+		"UpdateFailed": {
+			args: args{
+				cr:   user(),
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errKubeUpdateFailed),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := &tagger{kube: tc.kube}
+			err := e.Initialize(context.Background(), tc.args.cr)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.cr, tc.args.cr, cmpopts.SortSlices(func(a, b v1beta1.Tag) bool { return a.Key > b.Key })); err == nil && diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Cecilia Bernardi <cbernardi@expediagroup.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1232
Fixes #1233

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Unit Tests
- Manual Tests (in a kind cluster configured with an AWS account)
    - Creation scenario: a `iam.User` was created with a "k1":"v1" tag. All the default tags were added and Crossplane created the User successfully, reconciling all the 4 tags (3 default tags + 1 custom tag)
    - Update scenario: the same `iam.User` created above was patched to:
        - change the custom tag from "k1":"v1" to "k1":"v2" (the value change was correctly applied to the AWS resource)
        - change the custom tag from "k1":"v1" to "k2":"v1" (a new tag was added to the AWS resource, and the previous one was removed)
        - add a new "k3":"v3" tag. The AWS resource was tagged with the new tag
        - remove the tag with key "k2". The AWS resource was untagged
        - change the default tag "crossplane-name": "someuser" to "crossplane-name":"someuser2", the controller reverted the change and no changes were applied to the AWS resource
        - remove the default tag "crossplane-name". The controller reverted the change and no changes were applied to the AWS resource
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
