### PR TITLE
Observe existing OpenIDConnectProvider

### DIFF
--- a/pkg/clients/iam/fake/openidconnectprovider.go
+++ b/pkg/clients/iam/fake/openidconnectprovider.go
@@ -29,9 +29,11 @@ var _ clientset.OpenIDConnectProviderClient = (*MockOpenIDConnectProviderClient)
 
 // MockOpenIDConnectProviderInput holds the input structures for future inspections
 type MockOpenIDConnectProviderInput struct {
-	CreateOIDCProviderInput         *iam.CreateOpenIDConnectProviderInput
-	TagOpenIDConnectProviderInput   *iam.TagOpenIDConnectProviderInput
-	UntagOpenIDConnectProviderInput *iam.UntagOpenIDConnectProviderInput
+	CreateOIDCProviderInput            *iam.CreateOpenIDConnectProviderInput
+	TagOpenIDConnectProviderInput      *iam.TagOpenIDConnectProviderInput
+	UntagOpenIDConnectProviderInput    *iam.UntagOpenIDConnectProviderInput
+	ListOpenIDConnectProvidersInput    *iam.ListOpenIDConnectProvidersInput
+	ListOpenIDConnectProviderTagsInput *iam.ListOpenIDConnectProviderTagsInput
 }
 
 // MockOpenIDConnectProviderClient is a type that implements all the methods for OpenIDConnectProviderClient interface
@@ -45,6 +47,8 @@ type MockOpenIDConnectProviderClient struct {
 	MockDeleteOpenIDConnectProvider             func(ctx context.Context, input *iam.DeleteOpenIDConnectProviderInput, opts []func(*iam.Options)) (*iam.DeleteOpenIDConnectProviderOutput, error)
 	MockTagOpenIDConnectProvider                func(ctx context.Context, input *iam.TagOpenIDConnectProviderInput, opts []func(*iam.Options)) (*iam.TagOpenIDConnectProviderOutput, error)
 	MockUntagOpenIDConnectProvider              func(ctx context.Context, input *iam.UntagOpenIDConnectProviderInput, opts []func(*iam.Options)) (*iam.UntagOpenIDConnectProviderOutput, error)
+	MockListOpenIDConnectProviders              func(ctx context.Context, input *iam.ListOpenIDConnectProvidersInput, opts []func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error)
+	MockListOpenIDConnectProviderTags           func(ctx context.Context, input *iam.ListOpenIDConnectProviderTagsInput, opts []func(*iam.Options)) (*iam.ListOpenIDConnectProviderTagsOutput, error)
 }
 
 // GetOpenIDConnectProvider mocks client call.
@@ -88,4 +92,16 @@ func (m *MockOpenIDConnectProviderClient) TagOpenIDConnectProvider(ctx context.C
 func (m *MockOpenIDConnectProviderClient) UntagOpenIDConnectProvider(ctx context.Context, input *iam.UntagOpenIDConnectProviderInput, opts ...func(*iam.Options)) (*iam.UntagOpenIDConnectProviderOutput, error) {
 	m.MockOpenIDConnectProviderInput.UntagOpenIDConnectProviderInput = input
 	return m.MockUntagOpenIDConnectProvider(ctx, input, opts)
+}
+
+// ListOpenIDConnectProviders mocks client call
+func (m *MockOpenIDConnectProviderClient) ListOpenIDConnectProviders(ctx context.Context, input *iam.ListOpenIDConnectProvidersInput, opts ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	m.MockOpenIDConnectProviderInput.ListOpenIDConnectProvidersInput = input
+	return m.MockListOpenIDConnectProviders(ctx, input, opts)
+}
+
+// ListOpenIDConnectProviderTags mocks client call
+func (m *MockOpenIDConnectProviderClient) ListOpenIDConnectProviderTags(ctx context.Context, input *iam.ListOpenIDConnectProviderTagsInput, opts ...func(*iam.Options)) (*iam.ListOpenIDConnectProviderTagsOutput, error) {
+	m.MockOpenIDConnectProviderInput.ListOpenIDConnectProviderTagsInput = input
+	return m.MockListOpenIDConnectProviderTags(ctx, input, opts)
 }

--- a/pkg/clients/iam/openidconnectprovider.go
+++ b/pkg/clients/iam/openidconnectprovider.go
@@ -43,6 +43,8 @@ type OpenIDConnectProviderClient interface {
 	DeleteOpenIDConnectProvider(ctx context.Context, input *iam.DeleteOpenIDConnectProviderInput, opts ...func(*iam.Options)) (*iam.DeleteOpenIDConnectProviderOutput, error)
 	TagOpenIDConnectProvider(ctx context.Context, input *iam.TagOpenIDConnectProviderInput, opts ...func(*iam.Options)) (*iam.TagOpenIDConnectProviderOutput, error)
 	UntagOpenIDConnectProvider(ctx context.Context, input *iam.UntagOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.UntagOpenIDConnectProviderOutput, error)
+	ListOpenIDConnectProviders(ctx context.Context, input *iam.ListOpenIDConnectProvidersInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProvidersOutput, error)
+	ListOpenIDConnectProviderTags(ctx context.Context, input *iam.ListOpenIDConnectProviderTagsInput, optFns ...func(*iam.Options)) (*iam.ListOpenIDConnectProviderTagsOutput, error)
 }
 
 // GenerateOIDCProviderObservation is used to produce v1alpha1.OpenIDConnectProvider


### PR DESCRIPTION
Allow Crossplane to transfer ownership of previously
created OpenIDConnectProvider. The provider instance is derived from
the Crossplane tags.

Signed-off-by: Otto Nordander <otto.nordander@resurs.se>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Check for existing OpenIDConnectProviders with the same `crossplane-name` tag during `Observe` to allow transferring ownership of the provider.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1280 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Added unittests and manual testing using:
```yaml
apiVersion: iam.aws.crossplane.io/v1beta1
kind: OpenIDConnectProvider
metadata:
  name: test-oidc-provider
spec:
  deletionPolicy: Orphan
  providerConfigRef:
    name: example
  forProvider:
    thumbprintList:
      - 9e99a48a9960b14926bb7f3b02e22da2b0ab7280
    url: https://mytesturl.provider.aws.crossplane
 ```
```bash
kubectl apply -f oidc-provider.yaml
kubectl get openidconnectprovider.iam.aws.crossplane.io
kubectl delete -f oidc-provider.yaml # Orphaned
kubectl apply -f oidc-provider.yaml # Takes ownership of previously created provider
```