### PR TITLE
kafka cluster: configurationInfo is optional

### DIFF
--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -128,9 +128,11 @@ func preCreate(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.CreateClu
 			},
 		},
 	}
-	obj.ConfigurationInfo = &svcsdk.ConfigurationInfo{
-		Arn:      cr.Spec.ForProvider.CustomConfigurationInfo.ARN,
-		Revision: cr.Spec.ForProvider.CustomConfigurationInfo.Revision,
+	if cr.Spec.ForProvider.CustomConfigurationInfo != nil {
+		obj.ConfigurationInfo = &svcsdk.ConfigurationInfo{
+			Arn:      cr.Spec.ForProvider.CustomConfigurationInfo.ARN,
+			Revision: cr.Spec.ForProvider.CustomConfigurationInfo.Revision,
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

provider-aws would panic if the CR did not contain the optional
configurationInfo field. Add nil check.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

@petteja / @niralmehtasb1 did you test this or do you always want a config object from now on?

[contribution process]: https://git.io/fj2m9
