### PR TITLE
[Documentation] update trust relationship in assumeRoleWithWebIdentity

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -448,7 +448,7 @@ $ cat > trust.yaml <<EOF
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::${PROVIDER_POD_AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+        "Federated": "arn:aws:iam::${TARGET_AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

I follow the direction in the documentation and hit the following error:
```
Not authorized to perform sts:AssumeRoleWithWebIdentity
```

I noticed we are creating an OIDC provider in the target account but we don't use it. Switching to `TARGET_AWS_ACCOUNT_ID` solved the permission issue and I was able to create resources.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [N/A] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
