### PR TITLE
fix(LogGroup): Fix observe in case of more than 50 loggroups

### DIFF
--- a/pkg/controller/cloudwatchlogs/loggroup/setup.go
+++ b/pkg/controller/cloudwatchlogs/loggroup/setup.go
@@ -53,6 +53,7 @@ func SetupLogGroup(mgr ctrl.Manager, o controller.Options) error {
 			u := &updater{client: e.client}
 			e.isUpToDate = u.isUpToDate
 			e.update = u.update
+			e.preObserve = preObserve
 		},
 	}
 
@@ -89,6 +90,11 @@ func filterList(cr *svcapitypes.LogGroup, obj *svcsdk.DescribeLogGroupsOutput) *
 		}
 	}
 	return resp
+}
+
+func preObserve(ctx context.Context, cr *svcapitypes.LogGroup, obj *svcsdk.DescribeLogGroupsInput) error {
+	obj.SetLogGroupNamePrefix(meta.GetExternalName(cr))
+	return nil
 }
 
 func postObserve(_ context.Context, cr *svcapitypes.LogGroup, obj *svcsdk.DescribeLogGroupsOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {


### PR DESCRIPTION
### Description of your changes
DescribeLogGroup returns maximum 50 loggroups pr default, which can lead to cases where loggroup exists but doesn't get returned and Crossplane will then attempt to create the resource, rather than taking ownership of the loggroup.
 
This adds the external name as LogGroupNamePrefix to the Describe call which will return loggroups that has external name as prefix.

Fixes #1188 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
This has been tested out of cluster and also in our test- and production environments.