### PR TITLE
split GenerateUpdateClusterConfigInput in 2 methods: Logging and VPC

### DIFF
--- a/pkg/clients/eks/eks.go
+++ b/pkg/clients/eks/eks.go
@@ -176,26 +176,32 @@ func CreatePatch(in *ekstypes.Cluster, target *v1beta1.ClusterParameters) (*v1be
 	return patch, nil
 }
 
-// GenerateUpdateClusterConfigInput from ClusterParameters.
-func GenerateUpdateClusterConfigInput(name string, p *v1beta1.ClusterParameters) *eks.UpdateClusterConfigInput {
+// GenerateUpdateClusterConfigInputForLogging from ClusterParameters.
+func GenerateUpdateClusterConfigInputForLogging(name string, p *v1beta1.ClusterParameters) *eks.UpdateClusterConfigInput {
 	u := &eks.UpdateClusterConfigInput{
 		Name: awsclients.String(name),
 	}
 
-	if p.Logging != nil {
-		u.Logging = &ekstypes.Logging{
-			ClusterLogging: make([]ekstypes.LogSetup, len(p.Logging.ClusterLogging)),
+	u.Logging = &ekstypes.Logging{
+		ClusterLogging: make([]ekstypes.LogSetup, len(p.Logging.ClusterLogging)),
+	}
+	for i, cl := range p.Logging.ClusterLogging {
+		types := make([]ekstypes.LogType, len(cl.Types))
+		for j, t := range cl.Types {
+			types[j] = ekstypes.LogType(t)
 		}
-		for i, cl := range p.Logging.ClusterLogging {
-			types := make([]ekstypes.LogType, len(cl.Types))
-			for j, t := range cl.Types {
-				types[j] = ekstypes.LogType(t)
-			}
-			u.Logging.ClusterLogging[i] = ekstypes.LogSetup{
-				Enabled: cl.Enabled,
-				Types:   types,
-			}
+		u.Logging.ClusterLogging[i] = ekstypes.LogSetup{
+			Enabled: cl.Enabled,
+			Types:   types,
 		}
+	}
+	return u
+}
+
+// GenerateUpdateClusterConfigInputForVPC from ClusterParameters.
+func GenerateUpdateClusterConfigInputForVPC(name string, p *v1beta1.ClusterParameters) *eks.UpdateClusterConfigInput {
+	u := &eks.UpdateClusterConfigInput{
+		Name: awsclients.String(name),
 	}
 
 	// NOTE(muvaf): SecurityGroupIds and SubnetIds cannot be updated. They are

--- a/pkg/controller/eks/cluster.go
+++ b/pkg/controller/eks/cluster.go
@@ -193,7 +193,11 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		_, err := e.client.UpdateClusterVersion(ctx, &awseks.UpdateClusterVersionInput{Name: awsclient.String(meta.GetExternalName(cr)), Version: patch.Version})
 		return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateVersionFailed)
 	}
-	_, err = e.client.UpdateClusterConfig(ctx, eks.GenerateUpdateClusterConfigInput(meta.GetExternalName(cr), patch))
+	if patch.Logging != nil {
+		_, err = e.client.UpdateClusterConfig(ctx, eks.GenerateUpdateClusterConfigInputForLogging(meta.GetExternalName(cr), patch))
+		return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateVersionFailed)
+	}
+	_, err = e.client.UpdateClusterConfig(ctx, eks.GenerateUpdateClusterConfigInputForVPC(meta.GetExternalName(cr), patch))
 	return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateConfigFailed)
 }
 


### PR DESCRIPTION
Signed-off-by: Adrien Zieba <adrien.zieba@splashthat.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
AWS CLI prevents us from updating the VPC config and the Logging in the same call. This PR is splitting the method `GenerateUpdateClusterConfigInput` in 2 distinct ones: `GenerateUpdateClusterConfigInputForLogging`, `GenerateUpdateClusterConfigInputForVPC`
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1014

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review. The test steps is failing on my laptop with the following error `package github.com/crossplane-contrib/provider-aws/pkg/clients/mock: build constraints exclude all Go`

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Create a cluster with Logging enabled
```
...
        forProvider:
          logging:
            clusterLogging:
              - enabled: true
                types:
                  - api
                  - audit
                  - authenticator
                  - controllerManager
                  - scheduler
...
```

Then change the configuration to disable one of the type
```
...
        forProvider:
          logging:
            clusterLogging:
              - enabled: true
                types:
                  - api
                  - audit
                  - authenticator
                  - controllerManager
                  - scheduler
              - enabled: false
                types:
                  - controllerManager
...
```

*NOTE*: I noticed that the types needs to be in alphabetical order or the provider detects a constant drift with the aws resource.
[contribution process]: https://git.io/fj2m9
