### PR TITLE
refactor bucketnotfound error for bucketpolicy

### DIFF
--- a/pkg/clients/s3/bucketpolicy.go
+++ b/pkg/clients/s3/bucketpolicy.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 
 	"github.com/crossplane-contrib/provider-aws/apis/s3/v1alpha3"
@@ -49,8 +48,8 @@ func IsErrorPolicyNotFound(err error) bool {
 
 // IsErrorBucketNotFound returns true if the error code indicates that the bucket was not found
 func IsErrorBucketNotFound(err error) bool {
-	var nsb *s3types.NoSuchBucket
-	return errors.As(err, &nsb)
+	var awsErr smithy.APIError
+	return errors.As(err, &awsErr) && awsErr.ErrorCode() == "NoSuchBucket"
 }
 
 // Serialize is the custom marshaller for the BucketPolicyParameters


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Refactor the handling of the BucketNotFound error for BucketPolicy query.  The previous code was not recognizing the error when it happened.

Fixes #1353 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Code was run in our local environment and cleaned up several dozen stuck BucketPolicy objects that were in this condition.

[contribution process]: https://git.io/fj2m9
