### PR TITLE
let aws go sdk detect partition and region in irsa

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -605,6 +605,9 @@ func UsePodServiceAccountV1AssumeRole(ctx context.Context, _ []byte, pc *v1beta1
 	}
 	stsclient := sts.NewFromConfig(cfg)
 	stsAssumeRoleOptions := SetAssumeRoleOptions(pc)
+	if region == GlobalRegion {
+		region = cfg.Region
+	}
 	cnf, err := config.LoadDefaultConfig(
 		ctx,
 		userAgentV2,
@@ -681,7 +684,6 @@ func UsePodServiceAccountV1(ctx context.Context, _ []byte, pc *v1beta1.ProviderC
 	cfg, err := config.LoadDefaultConfig(
 		ctx,
 		userAgentV2,
-		config.WithRegion(region),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load default AWS config")
@@ -689,6 +691,9 @@ func UsePodServiceAccountV1(ctx context.Context, _ []byte, pc *v1beta1.ProviderC
 	v2creds, err := cfg.Credentials.Retrieve(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to retrieve credentials")
+	}
+	if region == GlobalRegion {
+		region = cfg.Region
 	}
 	v1creds := credentialsv1.NewStaticCredentials(
 		v2creds.AccessKeyID,

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -356,22 +356,20 @@ func UseProviderSecretAssumeRole(ctx context.Context, data []byte, profile, regi
 // assume Cross account IAM roles
 // https://aws.amazon.com/blogs/containers/cross-account-iam-roles-for-kubernetes-service-accounts/
 func UsePodServiceAccountAssumeRole(ctx context.Context, _ []byte, _, region string, pc *v1beta1.ProviderConfig) (*aws.Config, error) {
-	cfg, err := config.LoadDefaultConfig(ctx, userAgentV2)
+	cfg, err := UsePodServiceAccount(ctx, []byte{}, DefaultSection, region)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load default AWS config")
 	}
-
 	roleArn, err := GetAssumeRoleARN(pc.Spec.DeepCopy())
 	if err != nil {
 		return nil, err
 	}
-
-	stsclient := sts.NewFromConfig(cfg)
+	stsclient := sts.NewFromConfig(*cfg)
 	stsAssumeRoleOptions := SetAssumeRoleOptions(pc)
 	cnf, err := config.LoadDefaultConfig(
 		ctx,
 		userAgentV2,
-		config.WithRegion(region),
+		config.WithRegion(cfg.Region),
 		config.WithCredentialsProvider(aws.NewCredentialsCache(
 			stscreds.NewAssumeRoleProvider(
 				stsclient,
@@ -425,13 +423,20 @@ func UsePodServiceAccountAssumeRoleWithWebIdentity(ctx context.Context, _ []byte
 // UsePodServiceAccount assumes an IAM role configured via a ServiceAccount.
 // https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 func UsePodServiceAccount(ctx context.Context, _ []byte, _, region string) (*aws.Config, error) {
+	if region == GlobalRegion {
+		cfg, err := config.LoadDefaultConfig(
+			ctx,
+			userAgentV2,
+		)
+		return &cfg, errors.Wrap(err, "failed to load default AWS config")
+	}
 	cfg, err := config.LoadDefaultConfig(
 		ctx,
 		userAgentV2,
 		config.WithRegion(region),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to load default AWS config")
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to load default AWS config with region %s", region))
 	}
 	return &cfg, err
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Although changes introduced in https://github.com/crossplane-contrib/provider-aws/pull/1329 allow for IAM and Route53 resources to be provisioned in non `aws` partitions, it requires specific endpoint configurations in `ProviderConfig` to do so. 

This PR aims to allow for non `aws` partition users who run this provider in EKS with IRSA to provision global resources without endpoint configuration. 

Some background:
1. Cross partition assume role is not possible. e.g. assume role from IAM principals in `aws` partition to `aws-cn` is not possible.
2. If IRSA is used, EKS injects token and some [AWS specific environment variables into pod](https://github.com/aws/amazon-eks-pod-identity-webhook#eks-walkthrough)

Given these, I think it makes sense to let AWS SDK detect region and correct partition if reconciliation request is for a global resource. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Created EKS clusters in China and AWS partitions with IRSA configuration enabled. Tested global and regional resource creations using these clusters. 

Prior to this change, reconciliation fails with messages similar to the following:
```
Warning  CannotCreateExternalResource  118s (x25 over 4m4s)  managed/hostedzone.route53.aws.crossplane.io  failed to create the Hosted Zone resource: InvalidIdentityToken: No OpenIDConnect provider found in your account for https://oidc.eks.cn-north-1.amazonaws.com.cn/id/ABCDEFGHIJKLMN

```

After this change, reconciliation works as expected:
```
Normal   CreatedExternalResource      53s   managed/hostedzone.route53.aws.crossplane.io  Successfully requested creation of external resource
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
