### PR TITLE
Update handling of Elasticache versions

### DIFF
--- a/examples/cache/replicationgroup.yaml
+++ b/examples/cache/replicationgroup.yaml
@@ -11,12 +11,12 @@ spec:
     replicationGroupDescription: "An example replication group"
     applyModificationsImmediately: true
     engine: "redis"
-    engineVersion: "5.0.6"
+    engineVersion: "6.2"
     port: 6379
     cacheSubnetGroupNameRef:
       name: sample-cache-subnet-group
     numCacheClusters: 3
-    cacheParameterGroupName: default.redis5.0
+    cacheParameterGroupName: default.redis6.x
     cacheNodeType: cache.t3.medium
     automaticFailoverEnabled: true
   writeConnectionSecretToRef:

--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -18,7 +18,6 @@ package elasticache
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -364,7 +363,7 @@ func ParseVersion(ver *string) (*PartialSemanticVersion, error) {
 
 // For versions before 6.x, the version string can be exact (i.e. 5.0.6)
 // For versions 6, 6.2, 6.x, etc., we only need a major version
-func versionMatches(kubeVersion *string, awsVersion *string) bool {
+func versionMatches(kubeVersion *string, awsVersion *string) bool { //nolint: gocyclo
 
 	if clients.StringValue(kubeVersion) == clients.StringValue(awsVersion) {
 		return true
@@ -407,7 +406,6 @@ func versionMatches(kubeVersion *string, awsVersion *string) bool {
 func cacheClusterNeedsUpdate(kube v1beta1.ReplicationGroupParameters, cc elasticachetypes.CacheCluster) bool { // nolint:gocyclo
 	// AWS will set and return a default version if we don't specify one.
 	if !versionMatches(kube.EngineVersion, cc.EngineVersion) {
-		fmt.Println("Version does not match:", aws.ToString(kube.EngineVersion), aws.ToString(cc.EngineVersion))
 		return true
 	}
 	if pg, name := cc.CacheParameterGroup, kube.CacheParameterGroupName; pg != nil && !reflect.DeepEqual(name, pg.CacheParameterGroupName) {

--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -18,6 +18,7 @@ package elasticache
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -317,22 +318,96 @@ func multiAZEnabled(maz elasticachetypes.MultiAZStatus) *bool {
 	}
 }
 
-func versionMatches(kubeVersion *string, awsVersion *string) bool {
-	switch {
-	case clients.StringValue(kubeVersion) == clients.StringValue(awsVersion):
-		return true
+// PartialSemanticVersion is semantic version that does not fulfill
+// the specification. This allows for partial matching.
+type PartialSemanticVersion struct {
+	Major *int64
+	Minor *int64
+	Patch *int64
+}
 
-	case kubeVersion == nil || awsVersion == nil:
-		return false
-
-	default:
-		return strings.HasSuffix(*kubeVersion, ".x") && strings.HasPrefix(*awsVersion, strings.TrimSuffix(*kubeVersion, "x"))
+// ParseVersion parses the semantic version of an Elasticache Cluster
+// See https://docs.aws.amazon.com/memorydb/latest/devguide/engine-versions.html
+func ParseVersion(ver *string) (*PartialSemanticVersion, error) {
+	if ver == nil || aws.ToString(ver) == "" {
+		return nil, errors.New("empty string")
 	}
+
+	parts := strings.Split(strings.TrimSpace(aws.ToString(ver)), ".")
+
+	major, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return nil, errors.New("major version must be a number")
+	}
+
+	p := &PartialSemanticVersion{Major: aws.Int64(major)}
+
+	if len(parts) > 1 {
+		minor, err := strconv.ParseInt(parts[1], 10, 64)
+		// if not a digit (i.e. .x, ignore)
+		if err != nil {
+			return p, nil
+		}
+		p.Minor = aws.Int64(minor)
+	}
+
+	if len(parts) > 2 {
+		patch, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			return p, nil
+		}
+		p.Patch = aws.Int64(patch)
+	}
+
+	return p, nil
+}
+
+// For versions before 6.x, the version string can be exact (i.e. 5.0.6)
+// For versions 6, 6.2, 6.x, etc., we only need a major version
+func versionMatches(kubeVersion *string, awsVersion *string) bool {
+
+	if clients.StringValue(kubeVersion) == clients.StringValue(awsVersion) {
+		return true
+	}
+
+	if kubeVersion == nil || awsVersion == nil {
+		return false
+	}
+
+	kv, err := ParseVersion(kubeVersion)
+	if err != nil {
+		return false
+	}
+
+	av, err := ParseVersion(awsVersion)
+	if err != nil {
+		return false
+	}
+
+	if aws.ToInt64(kv.Major) != aws.ToInt64(av.Major) {
+		return false
+	}
+
+	if kv.Minor != nil {
+		if aws.ToInt64(kv.Minor) != aws.ToInt64(av.Minor) {
+			return false
+		}
+	}
+
+	// Setting the patch level is valid for Redis versions < 6
+	if kv.Patch != nil && aws.ToInt64(kv.Major) < 6 {
+		if aws.ToInt64(kv.Patch) != aws.ToInt64(av.Patch) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func cacheClusterNeedsUpdate(kube v1beta1.ReplicationGroupParameters, cc elasticachetypes.CacheCluster) bool { // nolint:gocyclo
 	// AWS will set and return a default version if we don't specify one.
 	if !versionMatches(kube.EngineVersion, cc.EngineVersion) {
+		fmt.Println("Version does not match:", aws.ToString(kube.EngineVersion), aws.ToString(cc.EngineVersion))
 		return true
 	}
 	if pg, name := cc.CacheParameterGroup, kube.CacheParameterGroupName; pg != nil && !reflect.DeepEqual(name, pg.CacheParameterGroupName) {


### PR DESCRIPTION
### Description of your changes

Starting with the 6.x version of Redis clusters, Elasticache now only uses the first 2 digits or a wildcard to specify the engine version. (i.e., 6.2, or 6.x to generate a 6.2.6 cluster). See [redis-version-6.0](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html#redis-version-6.0).  

This PR updates the Engineversion check to match the API behavior. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Created a replication group using the examples/cache/replicationGroup.yaml

with versions:

- 6.2
- 6.x

And ensured the cluster was created and did not enter an UpdateRequired loop. 

[contribution process]: https://git.io/fj2m9
