### PR TITLE
fix(s3.bucket): Fixes #1165, discrepancy QueueConfiguration.Filter.Ke…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.12.0
 	github.com/aws/smithy-go v1.11.2
+	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/crossplane/crossplane-runtime v0.17.0-rc.0.0.20220616115400-a520b60f1661
 	github.com/crossplane/crossplane-tools v0.0.0-20220310165030-1f43fc12793e
 	github.com/evanphx/json-patch v4.12.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.12.0/go.mod h1:UV2N5HaPfdbDpkgkz4sRz
 github.com/aws/smithy-go v1.9.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
+github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
+github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/pkg/controller/s3/bucket/notificationConfig.go
+++ b/pkg/controller/s3/bucket/notificationConfig.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/barkimedes/go-deepcopy"
+
 	"github.com/aws/smithy-go/document"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
@@ -97,7 +99,7 @@ func IsNotificationConfigurationUpToDate(cr *v1beta1.NotificationConfiguration, 
 	// The AWS API returns QueueConfiguration.Filter.Key.FilterRules.Name as "Prefix"/"Suffix" but expects
 	// "prefix"/"suffix" this leads to inconsistency and a constant diff. Fixes
 	// https://github.com/crossplane-contrib/provider-aws/issues/1165
-	sanitizedQueueConfigurations(external.QueueConfigurations)
+	external.QueueConfigurations = sanitizedQueueConfigurations(external.QueueConfigurations)
 
 	if cmp.Equal(external.LambdaFunctionConfigurations, generated.LambdaFunctionConfigurations, cmpopts.IgnoreTypes(document.NoSerde{}, types.LambdaFunctionConfiguration{}.Id), cmpopts.EquateEmpty()) &&
 		cmp.Equal(external.QueueConfigurations, generated.QueueConfigurations, cmpopts.IgnoreTypes(document.NoSerde{}, types.QueueConfiguration{}.Id), cmpopts.EquateEmpty()) &&
@@ -135,13 +137,28 @@ func sortTopic(configs []types.TopicConfiguration) {
 	})
 }
 
-func sanitizedQueueConfigurations(configs []types.QueueConfiguration) {
-	for c := range configs {
-		for r := range configs[c].Filter.Key.FilterRules {
-			name := string(configs[c].Filter.Key.FilterRules[r].Name)
-			configs[c].Filter.Key.FilterRules[r].Name = types.FilterRuleName(strings.ToLower(name))
+func sanitizedQueueConfigurations(configs []types.QueueConfiguration) []types.QueueConfiguration {
+	rawConfig, err := deepcopy.Anything(configs)
+	if err != nil {
+		return configs
+	}
+
+	sConfig := rawConfig.([]types.QueueConfiguration)
+
+	for c := range sConfig {
+		if sConfig[c].Filter == nil {
+			continue
+		}
+		if sConfig[c].Filter.Key == nil {
+			continue
+		}
+		for r := range sConfig[c].Filter.Key.FilterRules {
+			name := string(sConfig[c].Filter.Key.FilterRules[r].Name)
+			sConfig[c].Filter.Key.FilterRules[r].Name = types.FilterRuleName(strings.ToLower(name))
 		}
 	}
+
+	return sConfig
 }
 
 // GenerateLambdaConfiguration creates []awss3.LambdaFunctionConfiguration from the local NotificationConfiguration


### PR DESCRIPTION
### Description of your changes
The AWS API returns QueueConfiguration.Filter.Key.FilterRules.Name as "Prefix"/"Suffix" but expects "prefix"/"suffix", this leads to inconsistency and a constant diff.

Privious MR would panic if some or all of the keys (e.g. Key or Filter) are not there. This additon handles these cases. Additional tests for these cases were added.

Fixes #1165

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Test were added, see diff.

[contribution process]: https://git.io/fj2m9
