### PR TITLE
replicationgroup: Allow unmanaged NumCacheClusters

### DIFF
--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -491,7 +491,7 @@ func DiffTags(rgtags []v1beta1.Tag, tags []elasticachetypes.Tag) (add map[string
 // ReplicationGroupNumCacheClustersNeedsUpdate determines if the number of Cache Clusters
 // in a replication group needs to be updated
 func ReplicationGroupNumCacheClustersNeedsUpdate(kube v1beta1.ReplicationGroupParameters, ccList []elasticachetypes.CacheCluster) bool {
-	return aws.ToInt(kube.NumCacheClusters) != len(ccList)
+	return kube.NumCacheClusters != nil && aws.ToInt(kube.NumCacheClusters) != len(ccList)
 }
 
 // GenerateObservation produces a ReplicationGroupObservation object out of

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -1611,7 +1611,7 @@ func TestReplicationGroupNumCacheClustersNeedsUpdate(t *testing.T) {
 					{EngineVersion: aws.String(engineVersion)},
 				},
 			},
-			want: want{res: true},
+			want: want{res: false},
 		},
 	}
 

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -55,6 +55,7 @@ const (
 	errModifyReplicationGroup              = "cannot modify ElastiCache replication group"
 	errDeleteReplicationGroup              = "cannot delete ElastiCache replication group"
 	errModifyReplicationGroupSC            = "cannot modify ElastiCache replication group shard configuration"
+	errModifyReplicationGroupCC            = "cannot modify ElastiCache replication group num cache clusters"
 	errListReplicationGroupTags            = "cannot list ElastiCache replication group tags"
 	errUpdateReplicationGroupTags          = "cannot update ElastiCache replication group tags"
 	errReplicationGroupCacheClusterMinimum = "at least 1 replica is required"
@@ -236,7 +237,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if elasticache.ReplicationGroupNumCacheClustersNeedsUpdate(cr.Spec.ForProvider, ccList) {
 		err := e.updateReplicationGroupNumCacheClusters(ctx, meta.GetExternalName(cr), len(ccList), aws.ToInt(cr.Spec.ForProvider.NumCacheClusters))
 		if err != nil {
-			return managed.ExternalUpdate{}, awsclient.Wrap(err, errModifyReplicationGroup)
+			return managed.ExternalUpdate{}, awsclient.Wrap(err, errModifyReplicationGroupCC)
 		}
 		return managed.ExternalUpdate{}, nil
 	}


### PR DESCRIPTION
### Description of your changes

NumCacheClusters should not be set in many cases, so we should not
assume nil = 0.

Also update the error message to quickly be able to find which API call fails, it reused the error from another API call and cloud trail was not helpful in this case either (no log entry).
    
cc @stevendborrelli 

Fixes #1384
Related #1294

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests updated. Ran on real installation and checked that unsynced cluster is now synced.

[contribution process]: https://git.io/fj2m9
