### PR TITLE
rdsinstance: AWS Backup might also manage PreferredBackupWindow

### DIFF
--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -333,9 +333,17 @@ func CreatePatch(in *rdstypes.DBInstance, target *v1beta1.RDSInstanceParameters)
 		currentParams.AllocatedStorage = target.AllocatedStorage
 	}
 
-	// AWS Backup takes ownership of backupRetentionPeriod if it is in use, so we need to exclude the field in the diff
-	if in.AwsBackupRecoveryPointArn != nil && target.BackupRetentionPeriod != nil {
-		currentParams.BackupRetentionPeriod = target.BackupRetentionPeriod
+	// AWS Backup takes ownership of backupRetentionPeriod and
+	// preferredBackupWindow if it is in use, so we need to exclude
+	// the field in the diff
+	if in.AwsBackupRecoveryPointArn != nil {
+		if target.BackupRetentionPeriod != nil {
+			currentParams.BackupRetentionPeriod = target.BackupRetentionPeriod
+		}
+
+		if target.PreferredBackupWindow != nil {
+			currentParams.PreferredBackupWindow = target.PreferredBackupWindow
+		}
 	}
 
 	jsonPatch, err := awsclients.CreateJSONPatch(currentParams, target)


### PR DESCRIPTION
### Description of your changes

We already have special case handling for BackupRetentionPeriod when AWS
Backup is enabled. Add similar handling for PreferredBackupWindow. This
attribute is ready only when AWS Backup is enabled.

We run into issues like this because of late initialization which sets
fields into the spec which in some cases are more like status fields.

Related: #1356

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* unit test
* ran against real cluster and checked that the error is gone

[contribution process]: https://git.io/fj2m9
