### PR TITLE
DBCluster auto generates password

### DIFF
--- a/apis/rds/v1alpha1/custom_types.go
+++ b/apis/rds/v1alpha1/custom_types.go
@@ -160,6 +160,15 @@ type DBParameterGroupFamilyNameSelector struct {
 // CustomDBClusterParameters are custom parameters for DBCluster
 type CustomDBClusterParameters struct {
 
+	// AutogeneratePassword indicates whether the controller should generate
+	// a random password for the master user if one is not provided via
+	// MasterUserPasswordSecretRef.
+	//
+	// If a password is generated, it will
+	// be stored as a secret at the location specified by MasterUserPasswordSecretRef.
+	// +optional
+	AutogeneratePassword bool `json:"autogeneratePassword,omitempty"`
+
 	// DomainIAMRoleNameRef is a reference to an IAMRole used to set
 	// DomainIAMRoleName.
 	// +optional
@@ -181,8 +190,9 @@ type CustomDBClusterParameters struct {
 	// The password for the master database user. This password can contain any
 	// printable ASCII character except "/", """, or "@".
 	//
-	// Constraints: Must contain from 8 to 41 characters. Required.
-	MasterUserPasswordSecretRef xpv1.SecretKeySelector `json:"masterUserPasswordSecretRef"`
+	// Constraints: Must contain from 8 to 41 characters.
+	// +optional
+	MasterUserPasswordSecretRef *xpv1.SecretKeySelector `json:"masterUserPasswordSecretRef"`
 
 	// A list of EC2 VPC security groups to associate with this DB cluster.
 	VPCSecurityGroupIDs []string `json:"vpcSecurityGroupIDs,omitempty"`

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -61,6 +61,12 @@ spec:
               forProvider:
                 description: DBClusterParameters defines the desired state of DBCluster
                 properties:
+                  autogeneratePassword:
+                    description: "AutogeneratePassword indicates whether the controller should generate a 
+                      random password for the master user if one is not provided via MasterUserPasswordSecretRef. 
+                      \n If a password is generated, it will be stored as a secret at the location specified 
+                      by MasterUserPasswordSecretRef."
+                    type: boolean                
                   applyImmediately:
                     description: "A value that indicates whether the modifications
                       in this request and any pending modifications are asynchronously
@@ -567,7 +573,7 @@ spec:
                     description: "The password for the master database user. This
                       password can contain any printable ASCII character except \"/\",
                       \"\"\", or \"@\". \n Constraints: Must contain from 8 to 41
-                      characters. Required."
+                      characters."
                     properties:
                       key:
                         description: The key to select.

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -61,12 +61,6 @@ spec:
               forProvider:
                 description: DBClusterParameters defines the desired state of DBCluster
                 properties:
-                  autogeneratePassword:
-                    description: "AutogeneratePassword indicates whether the controller should generate a 
-                      random password for the master user if one is not provided via MasterUserPasswordSecretRef. 
-                      \n If a password is generated, it will be stored as a secret at the location specified 
-                      by MasterUserPasswordSecretRef."
-                    type: boolean                
                   applyImmediately:
                     description: "A value that indicates whether the modifications
                       in this request and any pending modifications are asynchronously
@@ -80,6 +74,13 @@ spec:
                       window. All other changes are applied immediately, regardless
                       of the value of the ApplyImmediately parameter. \n By default,
                       this parameter is disabled."
+                    type: boolean
+                  autogeneratePassword:
+                    description: "AutogeneratePassword indicates whether the controller
+                      should generate a random password for the master user if one
+                      is not provided via MasterUserPasswordSecretRef. \n If a password
+                      is generated, it will be stored as a secret at the location
+                      specified by MasterUserPasswordSecretRef."
                     type: boolean
                   availabilityZones:
                     description: A list of Availability Zones (AZs) where instances
@@ -810,7 +811,6 @@ spec:
                     type: array
                 required:
                 - engine
-                - masterUserPasswordSecretRef
                 - region
                 type: object
               providerConfigRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When a secret with the master password is not given, the resource will autogenerate an initial password

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #667
Replaces #671 which seems to be stuck

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Compiled locally and tested in a sandbox cluster launching a few Aurora databases
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
