### PR TITLE
[FIX] `fifoTopic`-property doesn't get properly stored in k8s

### DIFF
--- a/pkg/clients/sns/topic.go
+++ b/pkg/clients/sns/topic.go
@@ -105,7 +105,7 @@ func LateInitializeTopicAttr(in *v1beta1.TopicParameters, attrs map[string]strin
 
 	in.FifoTopic = nil
 	fifoTopic, err := strconv.ParseBool(attrs[string(TopicFifoTopic)])
-	if err != nil && fifoTopic {
+	if err == nil && fifoTopic {
 		in.FifoTopic = awsclients.LateInitializeBoolPtr(in.FifoTopic, aws.Bool(fifoTopic))
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

I did miss something on: https://github.com/crossplane-contrib/provider-aws/pull/1291 
There is a wrong check which results in the `fifoTopic`-property never stored in by k8s-api.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [/] Read and followed Crossplane's [contribution process].
- [/] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
