### PR TITLE
fix: Updated status output of sgr to show ready, synced, id and sg

### DIFF
--- a/apis/ec2/manualv1alpha1/securitygrouprule_types.go
+++ b/apis/ec2/manualv1alpha1/securitygrouprule_types.go
@@ -116,6 +116,10 @@ type SecurityGroupRuleStatus struct {
 // +kubebuilder:object:root=true
 
 // A SecurityGroupRule is a managed resource that represents an SecurityGroupRule
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="ID",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
+// +kubebuilder:printcolumn:name="SG",type="string",JSONPath=".spec.forProvider.securityGroupId"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}
 type SecurityGroupRule struct {

--- a/package/crds/ec2.aws.crossplane.io_securitygrouprules.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygrouprules.yaml
@@ -19,7 +19,20 @@ spec:
     singular: securitygrouprule
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNCED
+      type: string
+    - jsonPath: .metadata.annotations.crossplane\.io/external-name
+      name: ID
+      type: string
+    - jsonPath: .spec.forProvider.securityGroupId
+      name: SG
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: A SecurityGroupRule is a managed resource that represents an


### PR DESCRIPTION
Signed-off-by: André Kesser <andre.kesser@dkb.de>



### Description of your changes

Updated the status output of securitygrouprules to show ready, synced, id and sg


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
