### PR TITLE
Export VPC ID to VPC status

### DIFF
--- a/apis/ec2/v1beta1/vpc_types.go
+++ b/apis/ec2/v1beta1/vpc_types.go
@@ -142,6 +142,9 @@ type VPCObservation struct {
 
 	// VPCState is the current state of the VPC.
 	VPCState string `json:"vpcState,omitempty"`
+
+	// The ID of the VPC.
+	VPCID string `json:"vpcId,omitempty"`
 }
 
 // A VPCStatus represents the observed state of a VPC.

--- a/package/crds/ec2.aws.crossplane.io_vpcs.yaml
+++ b/package/crds/ec2.aws.crossplane.io_vpcs.yaml
@@ -373,6 +373,9 @@ spec:
                   ownerId:
                     description: The ID of the AWS account that owns the VPC.
                     type: string
+                  vpcId:
+                    description: The ID of the VPC.
+                    type: string
                   vpcState:
                     description: VPCState is the current state of the VPC.
                     type: string

--- a/pkg/clients/ec2/vpc.go
+++ b/pkg/clients/ec2/vpc.go
@@ -64,6 +64,7 @@ func GenerateVpcObservation(vpc ec2types.Vpc) v1beta1.VPCObservation {
 		DHCPOptionsID: aws.ToString(vpc.DhcpOptionsId),
 		OwnerID:       aws.ToString(vpc.OwnerId),
 		VPCState:      string(vpc.State),
+		VPCID:         aws.ToString(vpc.VpcId),
 	}
 
 	if len(vpc.CidrBlockAssociationSet) > 0 {

--- a/pkg/clients/ec2/vpc_test.go
+++ b/pkg/clients/ec2/vpc_test.go
@@ -32,6 +32,7 @@ func TestGenerateVPCObservation(t *testing.T) {
 				IsDefault: boolFalse,
 				OwnerID:   vpcOwner,
 				VPCState:  vpcStateAvailable,
+				VPCID:     vpcID,
 			},
 		},
 		"NoOwner": {
@@ -43,6 +44,7 @@ func TestGenerateVPCObservation(t *testing.T) {
 			out: v1beta1.VPCObservation{
 				IsDefault: boolFalse,
 				VPCState:  vpcStateAvailable,
+				VPCID:     vpcID,
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Harvey Xia <harvey.xia@reddit.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Exports the VPC ID to the VPC status. This is a slightly more readable + ergonomic way to retrieve the VPC's ID than using the `crossplane.io/external-name` annotation.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I added a test for the new field and executed them with `make test`.

[contribution process]: https://git.io/fj2m9
