### PR TITLE
fix: Fixed generation of flowlog

### DIFF
--- a/apis/ec2/generator-config.yaml
+++ b/apis/ec2/generator-config.yaml
@@ -123,7 +123,7 @@ ignore:
     - CreateFlowLogsInput.ResourceIds
     - CreateFlowLogsInput.ResourceType
     - CreateFlowLogsInput.TagSpecifications
-    - CreateFlowLogsInput.DeliverLogsPermissionARN
+    - CreateFlowLogsInput.DeliverLogsPermissionArn
     - DescribeFlowLogsInput.FlowLogIds
     - DescribeFlowLogsInput.DryRun
     - CreateFlowLogsOutput.FlowLogIds

--- a/apis/ec2/v1alpha1/custom_types.go
+++ b/apis/ec2/v1alpha1/custom_types.go
@@ -527,7 +527,10 @@ type CustomFlowLogParameters struct {
 	// +optional
 	NetworkInterfaceID *string `json:"networkInterfaceId"`
 
-	// The Amazon Resource Names (ARNs) of an IAM Role.
+	// The ARN for the IAM role that permits Amazon EC2
+	// to publish flow logs to a CloudWatch Logs log group in your
+	// account. \n If you specify LogDestinationType as s3, do not
+	// specify DeliverLogsPermissionArn or LogGroupName.
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1.Role
 	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1.RoleARN()
 	DeliverLogsPermissionARN *string `json:"deliverLogsPermissionArn,omitempty"`

--- a/apis/ec2/v1alpha1/zz_flow_log.go
+++ b/apis/ec2/v1alpha1/zz_flow_log.go
@@ -32,12 +32,6 @@ type FlowLogParameters struct {
 	// Unique, case-sensitive identifier that you provide to ensure the idempotency
 	// of the request. For more information, see How to ensure idempotency (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Run_Instance_Idempotency.html).
 	ClientToken *string `json:"clientToken,omitempty"`
-	// The ARN for the IAM role that permits Amazon EC2 to publish flow logs to
-	// a CloudWatch Logs log group in your account.
-	//
-	// If you specify LogDestinationType as s3, do not specify DeliverLogsPermissionArn
-	// or LogGroupName.
-	DeliverLogsPermissionARN *string `json:"deliverLogsPermissionARN,omitempty"`
 	// The destination options.
 	DestinationOptions *DestinationOptionsRequest `json:"destinationOptions,omitempty"`
 	// The destination to which the flow log data is to be published. Flow log data

--- a/apis/ec2/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1alpha1/zz_generated.deepcopy.go
@@ -5346,11 +5346,6 @@ func (in *FlowLogParameters) DeepCopyInto(out *FlowLogParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DeliverLogsPermissionARN != nil {
-		in, out := &in.DeliverLogsPermissionARN, &out.DeliverLogsPermissionARN
-		*out = new(string)
-		**out = **in
-	}
 	if in.DestinationOptions != nil {
 		in, out := &in.DestinationOptions, &out.DestinationOptions
 		*out = new(DestinationOptionsRequest)

--- a/package/crds/ec2.aws.crossplane.io_flowlogs.yaml
+++ b/package/crds/ec2.aws.crossplane.io_flowlogs.yaml
@@ -145,14 +145,11 @@ spec:
                             type: string
                         type: object
                     type: object
-                  deliverLogsPermissionARN:
-                    description: "The ARN for the IAM role that permits Amazon EC2
+                  deliverLogsPermissionArn:
+                    description: The ARN for the IAM role that permits Amazon EC2
                       to publish flow logs to a CloudWatch Logs log group in your
                       account. \n If you specify LogDestinationType as s3, do not
-                      specify DeliverLogsPermissionArn or LogGroupName."
-                    type: string
-                  deliverLogsPermissionArn:
-                    description: The Amazon Resource Names (ARNs) of an IAM Role.
+                      specify DeliverLogsPermissionArn or LogGroupName.
                     type: string
                   deliverLogsPermissionArnRef:
                     description: DeliverLogsPermissionARNRef is a reference to DeliverLogsPermissionARN

--- a/pkg/controller/ec2/flowlog/setup.go
+++ b/pkg/controller/ec2/flowlog/setup.go
@@ -153,6 +153,10 @@ func preCreate(_ context.Context, cr *svcapitypes.FlowLog, obj *svcsdk.CreateFlo
 		obj.LogDestination = cr.Spec.ForProvider.CloudWatchLogDestination
 	}
 
+	if cr.Spec.ForProvider.DeliverLogsPermissionARN != nil {
+		obj.DeliverLogsPermissionArn = cr.Spec.ForProvider.DeliverLogsPermissionARN
+	}
+
 	if cr.Spec.ForProvider.Tags != nil {
 
 		obj.SetTagSpecifications(generateTagSpecifications(cr))

--- a/pkg/controller/ec2/flowlog/zz_conversions.go
+++ b/pkg/controller/ec2/flowlog/zz_conversions.go
@@ -48,11 +48,6 @@ func GenerateFlowLog(resp *svcsdk.DescribeFlowLogsOutput) *svcapitypes.FlowLog {
 		} else {
 			cr.Status.AtProvider.CreationTime = nil
 		}
-		if elem.DeliverLogsPermissionArn != nil {
-			cr.Spec.ForProvider.DeliverLogsPermissionARN = elem.DeliverLogsPermissionArn
-		} else {
-			cr.Spec.ForProvider.DeliverLogsPermissionARN = nil
-		}
 		if elem.DeliverLogsStatus != nil {
 			cr.Status.AtProvider.DeliverLogsStatus = elem.DeliverLogsStatus
 		} else {
@@ -151,21 +146,18 @@ func GenerateCreateFlowLogsInput(cr *svcapitypes.FlowLog) *svcsdk.CreateFlowLogs
 	if cr.Spec.ForProvider.ClientToken != nil {
 		res.SetClientToken(*cr.Spec.ForProvider.ClientToken)
 	}
-	if cr.Spec.ForProvider.DeliverLogsPermissionARN != nil {
-		res.SetDeliverLogsPermissionArn(*cr.Spec.ForProvider.DeliverLogsPermissionARN)
-	}
 	if cr.Spec.ForProvider.DestinationOptions != nil {
-		f2 := &svcsdk.DestinationOptionsRequest{}
+		f1 := &svcsdk.DestinationOptionsRequest{}
 		if cr.Spec.ForProvider.DestinationOptions.FileFormat != nil {
-			f2.SetFileFormat(*cr.Spec.ForProvider.DestinationOptions.FileFormat)
+			f1.SetFileFormat(*cr.Spec.ForProvider.DestinationOptions.FileFormat)
 		}
 		if cr.Spec.ForProvider.DestinationOptions.HiveCompatiblePartitions != nil {
-			f2.SetHiveCompatiblePartitions(*cr.Spec.ForProvider.DestinationOptions.HiveCompatiblePartitions)
+			f1.SetHiveCompatiblePartitions(*cr.Spec.ForProvider.DestinationOptions.HiveCompatiblePartitions)
 		}
 		if cr.Spec.ForProvider.DestinationOptions.PerHourPartition != nil {
-			f2.SetPerHourPartition(*cr.Spec.ForProvider.DestinationOptions.PerHourPartition)
+			f1.SetPerHourPartition(*cr.Spec.ForProvider.DestinationOptions.PerHourPartition)
 		}
-		res.SetDestinationOptions(f2)
+		res.SetDestinationOptions(f1)
 	}
 	if cr.Spec.ForProvider.LogDestination != nil {
 		res.SetLogDestination(*cr.Spec.ForProvider.LogDestination)


### PR DESCRIPTION
Signed-off-by: André Kesser <andre.kesser@dkb.de>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Due to a mismatching upper and lowercase letters, the DeliverLogsPermissionArn property was not filled when creating a flow log. This pull request fixes this.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested manually


[contribution process]: https://git.io/fj2m9
