### PR TITLE
Ensure masterUserPasswordSecretRef is still required

### DIFF
--- a/apis/rds/v1alpha1/custom_types.go
+++ b/apis/rds/v1alpha1/custom_types.go
@@ -190,8 +190,7 @@ type CustomDBClusterParameters struct {
 	// The password for the master database user. This password can contain any
 	// printable ASCII character except "/", """, or "@".
 	//
-	// Constraints: Must contain from 8 to 41 characters.
-	// +optional
+	// Constraints: Must contain from 8 to 41 characters. Required.
 	MasterUserPasswordSecretRef *xpv1.SecretKeySelector `json:"masterUserPasswordSecretRef"`
 
 	// A list of EC2 VPC security groups to associate with this DB cluster.

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -574,7 +574,7 @@ spec:
                     description: "The password for the master database user. This
                       password can contain any printable ASCII character except \"/\",
                       \"\"\", or \"@\". \n Constraints: Must contain from 8 to 41
-                      characters."
+                      characters. Required."
                     properties:
                       key:
                         description: The key to select.
@@ -811,6 +811,7 @@ spec:
                     type: array
                 required:
                 - engine
+                - masterUserPasswordSecretRef
                 - region
                 type: object
               providerConfigRef:


### PR DESCRIPTION
Signed-off-by: Guilherme Souza <101073+guilhermef@users.noreply.github.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When PR #1413 was tested, we noticed that the  `masterUserPasswordSecretRef` was still required since it's used as a reference to the secret that will hold the generated DBCluster password.
This PR will make it required again.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
A new DBCluster was created in our environment with an empty password.
The provider created a random password and stored it on the Secret.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
