### PR TITLE
fix(eks/identityproviderconfig): Reset status field to retry create

### DIFF
--- a/pkg/controller/eks/identityproviderconfig/controller_test.go
+++ b/pkg/controller/eks/identityproviderconfig/controller_test.go
@@ -171,6 +171,23 @@ func TestObserve(t *testing.T) {
 				cr: identityProviderConfig(),
 			},
 		},
+		"NotFoundResetStatus": {
+			args: args{
+				eks: &fake.MockClient{
+					MockDescribeIdentityProviderConfig: func(ctx context.Context, input *awseks.DescribeIdentityProviderConfigInput, opts []func(*awseks.Options)) (*awseks.DescribeIdentityProviderConfigOutput, error) {
+						return nil, &awsekstypes.ResourceNotFoundException{}
+					},
+				},
+				cr: identityProviderConfig(
+					withStatus(manualv1alpha1.IdentityProviderConfigStatusCreateFailed),
+				),
+			},
+			want: want{
+				cr: identityProviderConfig(
+					withStatus(""),
+				),
+			},
+		},
 		"LateInitSuccess": {
 			args: args{
 				kube: &test.MockClient{


### PR DESCRIPTION
### Description of your changes

Fixes #1422

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit testing