### PR TITLE
doc: removed comment about updating GENERATED_SERVICES manually

### DIFF
--- a/CODE_GENERATION.md
+++ b/CODE_GENERATION.md
@@ -63,8 +63,6 @@ When you re-run the generation with this configuration, existing files won't be
 deleted. So you may want to delete everything in `apis/<serviceid>/v1alpha1`and
 then re-run the command.
 
-If `apis/<serviceid>` is created from scratch, please add the new service name to the list called GENERATED_SERVICES in [Makefile](https://github.com/crossplane/provider-aws/blob/master/Makefile#L10).
-
 ### Crossplane Code Generation
 
 After ACK generation process completes, we need to run Crossplane generation procedure


### PR DESCRIPTION

### Description of your changes

The GENERATED_SERVICES variable is automatically set in Makefile
(https://github.com/crossplane-contrib/provider-aws/blob/master/Makefile#L11).
So there is no need to manually update it whenever we create a new
service, as the documentation suggests.

Fixes: #1456

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
No testing required, it's a doc fix.

