### PR TITLE
Fix NodeGroup LaunchTemplate Updates

### DIFF
--- a/pkg/clients/eks/fake/fake.go
+++ b/pkg/clients/eks/fake/fake.go
@@ -20,9 +20,20 @@ import (
 	"context"
 
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
+
+// MockEc2Client is a fake implementation of ec2Client.
+type MockEc2Client struct {
+	MockDescribeLaunchTemplateVersions func(ctx context.Context, params *ec2.DescribeLaunchTemplateVersionsInput, opts []func(*ec2.Options)) (*ec2.DescribeLaunchTemplateVersionsOutput, error)
+}
+
+// DescribeLaunchTemplateVersions calls the underlying MockDescribeLaunchTemplateVersions method.
+func (c *MockEc2Client) DescribeLaunchTemplateVersions(ctx context.Context, input *ec2.DescribeLaunchTemplateVersionsInput, opts ...func(*ec2.Options)) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+	return c.MockDescribeLaunchTemplateVersions(ctx, input, opts)
+}
 
 // MockClient is a fake implementation of eks.Client.
 type MockClient struct {

--- a/pkg/clients/eks/nodegroup.go
+++ b/pkg/clients/eks/nodegroup.go
@@ -239,6 +239,11 @@ func IsNodeGroupUpToDate(p *manualv1alpha1.NodeGroupParameters, ng *ekstypes.Nod
 	if !cmp.Equal(p.Labels, ng.Labels, cmpopts.EquateEmpty()) {
 		return false
 	}
+	if p.LaunchTemplate != nil && ng.LaunchTemplate != nil {
+		if *p.LaunchTemplate.Version != *ng.LaunchTemplate.Version {
+			return false
+		}
+	}
 	if p.ScalingConfig == nil && ng.ScalingConfig == nil {
 		return true
 	}

--- a/pkg/clients/eks/nodegroup_test.go
+++ b/pkg/clients/eks/nodegroup_test.go
@@ -33,13 +33,14 @@ import (
 )
 
 var (
-	ngName      = "my-cool-ng"
-	amiType     = "cool-ami"
-	diskSize    = int32(20)
-	size        = int32(2)
-	currentSize = int32(5)
-	maxSize     = int32(8)
-	nodeRole    = "cool-role"
+	ngName                = "my-cool-ng"
+	amiType               = "cool-ami"
+	diskSize              = int32(20)
+	size                  = int32(2)
+	currentSize           = int32(5)
+	maxSize               = int32(8)
+	nodeRole              = "cool-role"
+	launchtemplateversion = "1"
 )
 
 func TestGenerateCreateNodeGroupInput(t *testing.T) {
@@ -573,6 +574,7 @@ func TestLateInitializeNodeGroup(t *testing.T) {
 func TestIsNodeGroupUpToDate(t *testing.T) {
 	otherVersion := "1.17"
 	otherSize := int32(100)
+	otherLaunchtemplateVersion := "3"
 
 	type args struct {
 		p *manualv1alpha1.NodeGroupParameters
@@ -655,6 +657,36 @@ func TestIsNodeGroupUpToDate(t *testing.T) {
 					ReleaseVersion: &version,
 					Version:        &version,
 					Tags:           map[string]string{"cool": "tag"},
+				},
+			},
+			want: false,
+		},
+		"UpdateLaunchTemplateVersion": {
+			args: args{
+				p: &manualv1alpha1.NodeGroupParameters{
+					Tags:   map[string]string{"cool": "tag"},
+					Labels: map[string]string{"cool": "label"},
+					ScalingConfig: &manualv1alpha1.NodeGroupScalingConfig{
+						DesiredSize: &size,
+						MaxSize:     &size,
+						MinSize:     &size,
+					},
+					LaunchTemplate: &manualv1alpha1.LaunchTemplateSpecification{
+						Version: &otherLaunchtemplateVersion,
+					},
+				},
+				n: &ekstypes.Nodegroup{
+					Labels: map[string]string{"cool": "label"},
+					ScalingConfig: &ekstypes.NodegroupScalingConfig{
+						DesiredSize: &size,
+						MaxSize:     &size,
+						MinSize:     &size,
+					},
+					ReleaseVersion: &version,
+					LaunchTemplate: &ekstypes.LaunchTemplateSpecification{
+						Version: &launchtemplateversion,
+					},
+					Tags: map[string]string{"cool": "tag"},
 				},
 			},
 			want: false,

--- a/pkg/controller/eks/nodegroup/controller.go
+++ b/pkg/controller/eks/nodegroup/controller.go
@@ -19,9 +19,13 @@ package nodegroup
 import (
 	"context"
 	"reflect"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +57,14 @@ const (
 	errDescribeFailed      = "cannot describe EKS node group"
 )
 
+type ec2Client interface {
+	DescribeLaunchTemplateVersions(ctx context.Context, params *awsec2.DescribeLaunchTemplateVersionsInput, optFns ...func(*awsec2.Options)) (*awsec2.DescribeLaunchTemplateVersionsOutput, error)
+}
+
+func newEc2Client(config aws.Config) ec2Client {
+	return awsec2.NewFromConfig(config)
+}
+
 // SetupNodeGroup adds a controller that reconciles NodeGroups.
 func SetupNodeGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(manualv1alpha1.NodeGroupKind)
@@ -68,7 +80,7 @@ func SetupNodeGroup(mgr ctrl.Manager, o controller.Options) error {
 		For(&manualv1alpha1.NodeGroup{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(manualv1alpha1.NodeGroupGroupVersionKind),
-			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newEKSClientFn: eks.NewEKSClient}),
+			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newEKSClientFn: eks.NewEKSClient, newEc2ClientFn: newEc2Client}),
 			managed.WithInitializers(managed.NewDefaultProviderConfig(mgr.GetClient()), managed.NewNameAsExternalName(mgr.GetClient()), &tagger{kube: mgr.GetClient()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithPollInterval(o.PollInterval),
@@ -80,6 +92,7 @@ func SetupNodeGroup(mgr ctrl.Manager, o controller.Options) error {
 type connector struct {
 	kube           client.Client
 	newEKSClientFn func(config aws.Config) eks.Client
+	newEc2ClientFn func(config aws.Config) ec2Client
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -91,12 +104,13 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	return &external{client: c.newEKSClientFn(*cfg), kube: c.kube}, nil
+	return &external{client: c.newEKSClientFn(*cfg), ec2Client: c.newEc2ClientFn(*cfg), kube: c.kube}, nil
 }
 
 type external struct {
-	client eks.Client
-	kube   client.Client
+	client    eks.Client
+	ec2Client ec2Client
+	kube      client.Client
 }
 
 func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -167,22 +181,18 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil || rsp.Nodegroup == nil {
 		return managed.ExternalUpdate{}, awsclient.Wrap(err, errDescribeFailed)
 	}
-	add, remove := awsclient.DiffTags(cr.Spec.ForProvider.Tags, rsp.Nodegroup.Tags)
-	if len(remove) != 0 {
-		if _, err := e.client.UntagResource(ctx, &awseks.UntagResourceInput{ResourceArn: rsp.Nodegroup.NodegroupArn, TagKeys: remove}); err != nil {
-			return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errAddTagsFailed)
-		}
+
+	err = manageTags(ctx, e, cr, rsp)
+	if err != nil {
+		return managed.ExternalUpdate{}, err
 	}
-	if len(add) != 0 {
-		if _, err := e.client.TagResource(ctx, &awseks.TagResourceInput{ResourceArn: rsp.Nodegroup.NodegroupArn, Tags: add}); err != nil {
-			return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errAddTagsFailed)
+
+	if versionHasChanged(cr, rsp) {
+		input, err := generateInput(ctx, e, cr, rsp)
+		if err != nil {
+			return managed.ExternalUpdate{}, err
 		}
-	}
-	if !reflect.DeepEqual(rsp.Nodegroup.Version, cr.Spec.ForProvider.Version) {
-		_, err := e.client.UpdateNodegroupVersion(ctx, &awseks.UpdateNodegroupVersionInput{
-			ClusterName:   &cr.Spec.ForProvider.ClusterName,
-			NodegroupName: awsclient.String(meta.GetExternalName(cr)),
-			Version:       cr.Spec.ForProvider.Version})
+		_, err = e.client.UpdateNodegroupVersion(ctx, input)
 		return managed.ExternalUpdate{}, awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errUpdateVersionFailed)
 	}
 	_, err = e.client.UpdateNodegroupConfig(ctx, eks.GenerateUpdateNodeGroupConfigInput(meta.GetExternalName(cr), &cr.Spec.ForProvider, rsp.Nodegroup))
@@ -218,4 +228,71 @@ func (t *tagger) Initialize(ctx context.Context, mg resource.Managed) error {
 		cr.Spec.ForProvider.Tags[k] = v
 	}
 	return errors.Wrap(t.kube.Update(ctx, cr), errKubeUpdateFailed)
+}
+
+func versionHasChanged(cr *manualv1alpha1.NodeGroup, ng *awseks.DescribeNodegroupOutput) bool {
+	if ng.Nodegroup.LaunchTemplate != nil && cr.Spec.ForProvider.LaunchTemplate != nil {
+		if !reflect.DeepEqual(ng.Nodegroup.LaunchTemplate.Version, cr.Spec.ForProvider.LaunchTemplate.Version) {
+			return true
+		}
+	}
+	return !reflect.DeepEqual(ng.Nodegroup.Version, cr.Spec.ForProvider.Version)
+}
+
+func generateInput(ctx context.Context, e *external, cr *manualv1alpha1.NodeGroup, ng *awseks.DescribeNodegroupOutput) (*awseks.UpdateNodegroupVersionInput, error) {
+	input := &awseks.UpdateNodegroupVersionInput{
+		ClusterName:   &cr.Spec.ForProvider.ClusterName,
+		NodegroupName: awsclient.String(meta.GetExternalName(cr)),
+	}
+
+	var customAMI bool
+	if ng.Nodegroup.LaunchTemplate != nil {
+		crVersion, err := strconv.ParseInt(*cr.Spec.ForProvider.LaunchTemplate.Version, 10, 64)
+		if err != nil {
+			return &awseks.UpdateNodegroupVersionInput{}, awsclient.Wrap(err, "cannot convert template version")
+		}
+		describeInput := &awsec2.DescribeLaunchTemplateVersionsInput{
+			LaunchTemplateName: cr.Spec.ForProvider.LaunchTemplate.Name,
+			Versions:           []string{*cr.Spec.ForProvider.LaunchTemplate.Version},
+		}
+		ltp, err := e.ec2Client.DescribeLaunchTemplateVersions(ctx, describeInput)
+		if err != nil {
+			return &awseks.UpdateNodegroupVersionInput{}, awsclient.Wrap(err, "cannot describe launchtemplate version")
+		}
+		for _, v := range ltp.LaunchTemplateVersions {
+			if *v.VersionNumber == crVersion {
+				if v.LaunchTemplateData.ImageId != nil {
+					customAMI = true
+				}
+				break
+			}
+		}
+		input.LaunchTemplate = &types.LaunchTemplateSpecification{
+			Id:      cr.Spec.ForProvider.LaunchTemplate.ID,
+			Name:    cr.Spec.ForProvider.LaunchTemplate.Name,
+			Version: cr.Spec.ForProvider.LaunchTemplate.Version,
+		}
+	}
+
+	if !customAMI {
+		input.Version = cr.Spec.ForProvider.Version
+	}
+
+	return input, nil
+
+}
+
+func manageTags(ctx context.Context, e *external, cr *manualv1alpha1.NodeGroup, ng *awseks.DescribeNodegroupOutput) error {
+	add, remove := awsclient.DiffTags(cr.Spec.ForProvider.Tags, ng.Nodegroup.Tags)
+	if len(remove) != 0 {
+		if _, err := e.client.UntagResource(ctx, &awseks.UntagResourceInput{ResourceArn: ng.Nodegroup.NodegroupArn, TagKeys: remove}); err != nil {
+			return awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errAddTagsFailed)
+		}
+	}
+	if len(add) != 0 {
+		if _, err := e.client.TagResource(ctx, &awseks.TagResourceInput{ResourceArn: ng.Nodegroup.NodegroupArn, Tags: add}); err != nil {
+			return awsclient.Wrap(resource.Ignore(eks.IsErrorInUse, err), errAddTagsFailed)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Changes to the `NodeGroup.LaunchTemplate.Version` were not being actioned by the controller. This is because there was no check in place for any changes. I have added a check and also modified the `Update` method to enable updating `NodeGroups` using `LaunchTemplates`. I also had to add a check for AMIs declared in the `LaunchTemplate` as configuring both `Version` and `LaunchTemplate` when the `LaunchTemplate` contains an AMI will cause the process to fail.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1455

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have tested this by the following process
- Create `NodeGroup` with `LaunchTemplate`
- Create a new `LaunchTemplateVersion`
- Change the `NodeGroup` to use the new version
- Check that the `NodeGroup` is reconciled to use new version and that all nodes are recreated

[contribution process]: https://git.io/fj2m9
