### PR TITLE
Run AWS ACK code-generator with go.mod --aws-sdk-go-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ services: $(GOIMPORTS)
 	@if [ ! -d "$(WORK_DIR)/code-generator" ]; then \
 		cd $(WORK_DIR) && git clone "$(CODE_GENERATOR_REPO)"; \
 	fi
-	@cd $(WORK_DIR)/code-generator && git fetch origin && git checkout $(CODE_GENERATOR_COMMIT)
+	@cd $(WORK_DIR)/code-generator && git fetch origin && git checkout $(CODE_GENERATOR_COMMIT) && go build -tags codegen -o ack-generate cmd/ack-generate/main.go
 	@for svc in $(SERVICES); do \
 		$(INFO) Generating $$svc controllers and CRDs; \
 		PATH="${PATH}:$(TOOLS_HOST_DIR)"; \
-		cd $(WORK_DIR)/code-generator && go run -tags codegen cmd/ack-generate/main.go crossplane $$svc --output ../../ || exit 1; \
+		cd $(WORK_DIR)/code-generator && ./ack-generate crossplane $$svc --output ../../ || exit 1; \
 		$(OK) Generating $$svc controllers and CRDs; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,8 @@ run: go.build
 
 .PHONY: cobertura manifests submodules fallthrough test-integration run crds.clean
 
+AWS_SDK_GO_VERSION ?= $(shell awk '/github.com\/aws\/aws-sdk-go / { print $$2 }' < go.mod)
+
 # NOTE(muvaf): ACK Code Generator is a separate Go module, hence we need to
 # be in its root directory to call "go run" properly.
 services: $(GOIMPORTS)
@@ -144,7 +146,7 @@ services: $(GOIMPORTS)
 	@for svc in $(SERVICES); do \
 		$(INFO) Generating $$svc controllers and CRDs; \
 		PATH="${PATH}:$(TOOLS_HOST_DIR)"; \
-		cd $(WORK_DIR)/code-generator && ./ack-generate crossplane $$svc --output ../../ || exit 1; \
+		cd $(WORK_DIR)/code-generator && ./ack-generate crossplane --aws-sdk-go-version $(AWS_SDK_GO_VERSION) $$svc --output ../../ || exit 1; \
 		$(OK) Generating $$svc controllers and CRDs; \
 	done
 


### PR DESCRIPTION
### Description of your changes

- Compile code-generator to avoid link overhead per service
- Run AWS ACK code-generator with go.mod --aws-sdk-go-version

Fixes #1414
Fixes https://github.com/aws-controllers-k8s/community/issues/1441
    
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* No changes w/ make services.all
* Compiling code (not tested) with `go get github.com/aws/aws-sdk-go@v1.43.43 && go mod tidy`. Testing new SDKs will still be the responsibility of the change bumping the SDK

[contribution process]: https://git.io/fj2m9
