### PR TITLE
fix: Adjusting returned keyarn to match input value

### DIFF
--- a/apis/rds/v1alpha1/referencers.go
+++ b/apis/rds/v1alpha1/referencers.go
@@ -234,7 +234,7 @@ func (mg *DBInstance) ResolveReferences(ctx context.Context, c client.Reader) er
 		Reference:    mg.Spec.ForProvider.KMSKeyIDRef,
 		Selector:     mg.Spec.ForProvider.KMSKeyIDSelector,
 		To:           reference.To{Managed: &kmsv1alpha1.Key{}, List: &kmsv1alpha1.KeyList{}},
-		Extract:      reference.ExternalName(),
+		Extract:      kmsv1alpha1.KMSKeyARN(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "spec.forProvider.kmsKeyID")

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -417,8 +417,8 @@ func (e *custom) savePasswordSecret(ctx context.Context, cr *svcapitypes.DBInsta
 func handleKmsKey(inKey *string, dbKey *string) *string {
 	if inKey != nil && dbKey != nil && !strings.Contains(*inKey, "/") {
 		lastInd := strings.LastIndex(*dbKey, "/")
-		keyId := (*dbKey)[lastInd+1:]
-		return &keyId
+		keyID := (*dbKey)[lastInd+1:]
+		return &keyID
 	}
 	return dbKey
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The describe endpoint of aws for dbinstance returns the full arn for kmskeyid. If an dbinstance is created with an keyed only, Crossplane tries to update the instance. 

This update uses only the key id part of the returned are, if the user uses only an id for the kmykeyid field.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
#1348 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

We used the following yaml for testing:
```yaml
apiVersion: rds.aws.crossplane.io/v1alpha1
kind: DBInstance
metadata:
  name: example
spec:
  deletionPolicy: Delete
  forProvider:
    region: eu-central-1
    allocatedStorage: 20
    dbInstanceClass: db.t3.medium
    preferredBackupWindow: "02:46-03:16"
    preferredMaintenanceWindow: "Wed:00:12-wed:00:42"
    dbName: prada
    vpcSecurityGroupIDs:
      - sg-88d8e3fc
    dbSubnetGroupName: sample-subnet-group
    backupRetentionPeriod: 30
    engine: postgres
    engineVersion: "14.1"
    masterUsername: adminuser
    masterUserPasswordSecretRef:
      key: password
      name: example-dbinstance
      namespace: crossplane-system
    kmsKeyID: b4c2ddac-7798-4791-871e-54b2aad19922
    storageEncrypted: true
    deletionProtection: true
    autoMinorVersionUpgrade: true
    enableIAMDatabaseAuthentication: true
    applyImmediately: true
    skipFinalSnapshot: false
    finalDBSnapshotIdentifier: example-final-snapshot
    copyTagsToSnapshot: true
  providerConfigRef:
    name: example
```
kubectl get managed:

```bash
NAME                                       READY   SYNCED   EXTERNAL-NAME
dbinstance.rds.aws.crossplane.io/example   True    True     example
```
[contribution process]: https://git.io/fj2m9
