### PR TITLE
fix: same name as examples for ProviderConfig

### DIFF
--- a/CODE_GENERATION.md
+++ b/CODE_GENERATION.md
@@ -466,7 +466,7 @@ data:
 apiVersion: aws.crossplane.io/v1beta1
 kind: ProviderConfig
 metadata:
-  name: default
+  name: example
 spec:
   credentials:
     source: Secret


### PR DESCRIPTION
Signed-off-by: Romain Dauby <romain.dauby@gmail.com>

### Description of your changes

Minor fix on the CODE_GENERATION documentation. 

While contributing to #1482 I encountered non working examples because the provider is not labeled `example`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
