### PR TITLE
Fixes an issue with S3 notifications

### DIFF
--- a/apis/s3/v1beta1/notificationConfiguration_types.go
+++ b/apis/s3/v1beta1/notificationConfiguration_types.go
@@ -175,8 +175,8 @@ type TopicConfiguration struct {
 	// publishes a message when it detects events of the specified type.
 	// At least one of topicArn, topicArnRef or topicSelector is required.
 	// +optional
-	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-aws/apis/notification/v1alpha1.SNSTopic
-	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-aws/apis/notification/v1alpha1.SNSTopicARN()
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-aws/apis/sns/v1beta1.Topic
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-aws/apis/sns/v1beta1.SNSTopicARN()
 	TopicArn *string `json:"topicArn,omitempty"`
 
 	// TopicArnRef references an SNS Topic to retrieve its Arn

--- a/apis/s3/v1beta1/zz_generated.resolvers.go
+++ b/apis/s3/v1beta1/zz_generated.resolvers.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	v1beta1 "github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1"
 	v1alpha1 "github.com/crossplane-contrib/provider-aws/apis/kms/v1alpha1"
-	v1alpha11 "github.com/crossplane-contrib/provider-aws/apis/notification/v1alpha1"
+	v1beta12 "github.com/crossplane-contrib/provider-aws/apis/sns/v1beta1"
 	v1beta11 "github.com/crossplane-contrib/provider-aws/apis/sqs/v1beta1"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
@@ -158,12 +158,12 @@ func (mg *Bucket) ResolveReferences(ctx context.Context, c client.Reader) error 
 		for i4 := 0; i4 < len(mg.Spec.ForProvider.NotificationConfiguration.TopicConfigurations); i4++ {
 			rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 				CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NotificationConfiguration.TopicConfigurations[i4].TopicArn),
-				Extract:      v1alpha11.SNSTopicARN(),
+				Extract:      v1beta12.SNSTopicARN(),
 				Reference:    mg.Spec.ForProvider.NotificationConfiguration.TopicConfigurations[i4].TopicArnRef,
 				Selector:     mg.Spec.ForProvider.NotificationConfiguration.TopicConfigurations[i4].TopicArnSelector,
 				To: reference.To{
-					List:    &v1alpha11.SNSTopicList{},
-					Managed: &v1alpha11.SNSTopic{},
+					List:    &v1beta12.TopicList{},
+					Managed: &v1beta12.Topic{},
 				},
 			})
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Michael Duffy <mike@stunthamster.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR fixes an issue where SNS notifications cannot be added to S3 buckets using topicRef names. Currently, the topicRef attempts to find a SNSTopic object from the deprecated notification.aws.crossplane.io API group. This PR changes it to use the correct SNS API group. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [ x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
N/A
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
