### PR TITLE
fix(crawler): RoleRef should extract ARN

### DIFF
--- a/apis/glue/v1alpha1/custom_types.go
+++ b/apis/glue/v1alpha1/custom_types.go
@@ -354,6 +354,7 @@ type CustomCrawlerParameters struct {
 	// AWS API seems to give just name of the role back (not ARN)
 	// +immutable
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1.Role
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1.RoleARN()
 	// +crossplane:generate:reference:refFieldName=RoleRef
 	// +crossplane:generate:reference:selectorFieldName=RoleSelector
 	Role string `json:"role,omitempty"`

--- a/apis/glue/v1alpha1/zz_generated.resolvers.go
+++ b/apis/glue/v1alpha1/zz_generated.resolvers.go
@@ -139,7 +139,7 @@ func (mg *Crawler) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: mg.Spec.ForProvider.CustomCrawlerParameters.Role,
-		Extract:      reference.ExternalName(),
+		Extract:      v1beta11.RoleARN(),
 		Reference:    mg.Spec.ForProvider.CustomCrawlerParameters.RoleRef,
 		Selector:     mg.Spec.ForProvider.CustomCrawlerParameters.RoleSelector,
 		To: reference.To{


### PR DESCRIPTION
### Description of your changes

Adds line to extract ARN from Role to be used for `Crawler`

I miss of my part, when I enhanced the Glue service here.

Role reference for the resource `Crawler` should use the ARN:
1. for consistency -> same as the Glue resource `Job`
2. with ARN through refs, users don't have to think about possible path, if other fields only take ARN

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually with the relating example.