### PR TITLE
Add docs for SecurityGroupRule to fix #1516

### DIFF
--- a/apis/ec2/manualv1alpha1/securitygrouprule_types.go
+++ b/apis/ec2/manualv1alpha1/securitygrouprule_types.go
@@ -58,6 +58,9 @@ type SecurityGroupRuleParameters struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region"`
 
+	// If using a SecurityGroup managed by crossplane as reference,
+	// enable ignoreIngress or ignoreEgress on the sg to prevent the
+	// rules to be constantly created and deleted
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +kubebuilder:validation:Optional
 	// +immutable

--- a/apis/ec2/manualv1alpha1/securitygrouprule_types.go
+++ b/apis/ec2/manualv1alpha1/securitygrouprule_types.go
@@ -63,9 +63,9 @@ type SecurityGroupRuleParameters struct {
 	// +immutable
 	SecurityGroupID *string `json:"securityGroupId,omitempty"`
 
-	// If using a SecurittyGroup managed by crossplane as reference,
+	// If using a SecurityGroup managed by crossplane as reference,
 	// enable ignoreIngress or ignoreEgress on the sg to prevent the
-	// roules to be constantly created and deleted
+	// rules to be constantly created and deleted
 	// +kubebuilder:validation:Optional
 	// +immutable
 	SecurityGroupIDRef *xpv1.Reference `json:"securityGroupIdRef,omitempty"`

--- a/apis/ec2/v1beta1/securitygroup_types.go
+++ b/apis/ec2/v1beta1/securitygroup_types.go
@@ -69,10 +69,10 @@ type SecurityGroupParameters struct {
 	VPCIDSelector *xpv1.Selector `json:"vpcIdSelector,omitempty"`
 
 	// Dont manage the ingress settings for the created resource
-	IgnorIngress *bool `json:"ignoreIngress,omitempty"`
+	IgnoreIngress *bool `json:"ignoreIngress,omitempty"`
 
 	// Dont manage the egress settings for the created resource
-	IgnorEgress *bool `json:"ignoreEgress,omitempty"`
+	IgnoreEgress *bool `json:"ignoreEgress,omitempty"`
 }
 
 // IPRange describes an IPv4 range.

--- a/apis/ec2/v1beta1/zz_generated.deepcopy.go
+++ b/apis/ec2/v1beta1/zz_generated.deepcopy.go
@@ -1086,13 +1086,13 @@ func (in *SecurityGroupParameters) DeepCopyInto(out *SecurityGroupParameters) {
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.IgnorIngress != nil {
-		in, out := &in.IgnorIngress, &out.IgnorIngress
+	if in.IgnoreIngress != nil {
+		in, out := &in.IgnoreIngress, &out.IgnoreIngress
 		*out = new(bool)
 		**out = **in
 	}
-	if in.IgnorEgress != nil {
-		in, out := &in.IgnorEgress, &out.IgnorEgress
+	if in.IgnoreEgress != nil {
+		in, out := &in.IgnoreEgress, &out.IgnoreEgress
 		*out = new(bool)
 		**out = **in
 	}

--- a/package/crds/ec2.aws.crossplane.io_securitygrouprules.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygrouprules.yaml
@@ -84,6 +84,9 @@ spec:
                       be created in.
                     type: string
                   securityGroupId:
+                    description: If using a SecurityGroup managed by crossplane as
+                      reference, enable ignoreIngress or ignoreEgress on the sg to
+                      prevent the rules to be constantly created and deleted
                     type: string
                   securityGroupIdRef:
                     description: If using a SecurityGroup managed by crossplane as

--- a/package/crds/ec2.aws.crossplane.io_securitygrouprules.yaml
+++ b/package/crds/ec2.aws.crossplane.io_securitygrouprules.yaml
@@ -86,9 +86,9 @@ spec:
                   securityGroupId:
                     type: string
                   securityGroupIdRef:
-                    description: If using a SecurittyGroup managed by crossplane as
+                    description: If using a SecurityGroup managed by crossplane as
                       reference, enable ignoreIngress or ignoreEgress on the sg to
-                      prevent the roules to be constantly created and deleted
+                      prevent the rules to be constantly created and deleted
                     properties:
                       name:
                         description: Name of the referenced object.

--- a/pkg/clients/ec2/securitygroup.go
+++ b/pkg/clients/ec2/securitygroup.go
@@ -130,13 +130,13 @@ func IsSGUpToDate(sg v1beta1.SecurityGroupParameters, observed ec2types.Security
 		return false
 	}
 
-	if !awsclients.BoolValue(sg.IgnorIngress) {
+	if !awsclients.BoolValue(sg.IgnoreIngress) {
 		add, remove := DiffPermissions(GenerateEC2Permissions(sg.Ingress), observed.IpPermissions)
 		if len(add) > 0 || len(remove) > 0 {
 			return false
 		}
 	}
-	if !awsclients.BoolValue(sg.IgnorEgress) {
+	if !awsclients.BoolValue(sg.IgnoreEgress) {
 		add, remove := DiffPermissions(GenerateEC2Permissions(sg.Egress), observed.IpPermissionsEgress)
 		if len(add) > 0 || len(remove) > 0 {
 			return false

--- a/pkg/controller/ec2/securitygroup/controller.go
+++ b/pkg/controller/ec2/securitygroup/controller.go
@@ -241,7 +241,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	if !awsclient.BoolValue(cr.Spec.ForProvider.IgnorIngress) {
+	if !awsclient.BoolValue(cr.Spec.ForProvider.IgnoreIngress) {
 		add, remove := ec2.DiffPermissions(ec2.GenerateEC2Permissions(cr.Spec.ForProvider.Ingress), response.SecurityGroups[0].IpPermissions)
 		if len(remove) > 0 {
 			if _, err := e.sg.RevokeSecurityGroupIngress(ctx, &awsec2.RevokeSecurityGroupIngressInput{
@@ -261,7 +261,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	if !awsclient.BoolValue(cr.Spec.ForProvider.IgnorEgress) {
+	if !awsclient.BoolValue(cr.Spec.ForProvider.IgnoreEgress) {
 		add, remove := ec2.DiffPermissions(ec2.GenerateEC2Permissions(cr.Spec.ForProvider.Egress), response.SecurityGroups[0].IpPermissionsEgress)
 		if len(remove) > 0 {
 			if _, err = e.sg.RevokeSecurityGroupEgress(ctx, &awsec2.RevokeSecurityGroupEgressInput{


### PR DESCRIPTION
### Description of your changes

This PR increases the documentation for SecurityGroupRules by adding an important hint to securityGroupId.
Without it users might miss that they need to set the option ignoreIngress and/or ignoreEgress and it will lead to repeated recreation of SecurityGroupRules.

Fixes #1516

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Will be tested by running locally with `make run`

[contribution process]: https://git.io/fj2m9
