### PR TITLE
Updates link to the latest version of Crossplane docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ control plane and adds the following new functionality:
 ## Getting Started and Documentation
 
 For getting started guides, installation, deployment, and administration, see
-our [Documentation](https://crossplane.io/docs/latest).
+our [Documentation](https://crossplane.io/docs).
 
 ## Contributing
 


### PR DESCRIPTION
Signed-off-by: Pete Lumbis <pete@upbound.io>
The Crossplane docs were recently restructured and the link to the `latest` version changed. This updates the readme to point to the correct URL