### PR TITLE
cluster.kafka: Fix cluster creation after AWS change

### DIFF
--- a/apis/kafka/generator-config.yaml
+++ b/apis/kafka/generator-config.yaml
@@ -17,4 +17,4 @@ resources:
     exceptions:
       errors:
         404:
-          code: BadRequestException
+          code: NotFoundException

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -64,7 +64,8 @@ func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 			managed.WithPollInterval(o.PollInterval),
 			managed.WithLogger(o.Logger.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
-			managed.WithConnectionPublishers(cps...)))
+			managed.WithConnectionPublishers(cps...),
+			managed.WithInitializers()))
 }
 
 func preDelete(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.DeleteClusterInput) (bool, error) {
@@ -117,7 +118,7 @@ func postObserve(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.Describ
 }
 
 func preCreate(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.CreateClusterInput) error {
-	obj.ClusterName = awsclients.String(meta.GetExternalName(cr))
+	obj.ClusterName = awsclients.String(cr.GetName())
 	obj.BrokerNodeGroupInfo = &svcsdk.BrokerNodeGroupInfo{
 		ClientSubnets:  cr.Spec.ForProvider.CustomBrokerNodeGroupInfo.ClientSubnets,
 		InstanceType:   cr.Spec.ForProvider.CustomBrokerNodeGroupInfo.InstanceType,

--- a/pkg/controller/kafka/cluster/zz_conversions.go
+++ b/pkg/controller/kafka/cluster/zz_conversions.go
@@ -390,5 +390,5 @@ func GenerateDeleteClusterInput(cr *svcapitypes.Cluster) *svcsdk.DeleteClusterIn
 // IsNotFound returns whether the given error is of type NotFound or not.
 func IsNotFound(err error) bool {
 	awsErr, ok := err.(awserr.Error)
-	return ok && awsErr.Code() == "BadRequestException"
+	return ok && awsErr.Code() == "NotFoundException"
 }


### PR DESCRIPTION
### Description of your changes

AWS has changed DescribeCluster to return AccessDeniedException instead
of BadRequestException on an invalid ARN. This breaks cluster creation.

But we should not initialize external-name with a plain string based on
the kubernetes object name, it simply doesn't make sense as the service
requires an ARN. To avoid this, call managed.WithInitializers() to clear
the external name initializer.

This change was introduced in eu-north-1 within the last couple of
months.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

* Ensure we can create a cluster.
* Delete a cluster in AWS and ensure a new one is created.

[contribution process]: https://git.io/fj2m9
