### PR TITLE
feat: late init engineVersion if DBInstance is running within DBCluster

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -215,12 +215,12 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 		in.StorageEncrypted = aws.LateInitializeBoolPtr(in.StorageEncrypted, db.StorageEncrypted)
 		in.StorageType = aws.LateInitializeStringPtr(in.StorageType, db.StorageType)
 		in.EngineVersion = aws.LateInitializeStringPtr(in.EngineVersion, db.EngineVersion)
-        // When version 5.6 is chosen, AWS creates 5.6.41 and that's totally valid.
-        // But we detect as if we need to update it all the time. Here, we assign
-        // the actual full version to our spec to avoid unnecessary update signals.
-        if strings.HasPrefix(aws.StringValue(db.EngineVersion), aws.StringValue(in.EngineVersion)) {
-            in.EngineVersion = db.EngineVersion
-        }
+		// When version 5.6 is chosen, AWS creates 5.6.41 and that's totally valid.
+		// But we detect as if we need to update it all the time. Here, we assign
+		// the actual full version to our spec to avoid unnecessary update signals.
+		if strings.HasPrefix(aws.StringValue(db.EngineVersion), aws.StringValue(in.EngineVersion)) {
+			in.EngineVersion = db.EngineVersion
+		}
 	}
 	in.AutoMinorVersionUpgrade = aws.LateInitializeBoolPtr(in.AutoMinorVersionUpgrade, db.AutoMinorVersionUpgrade)
 	in.AvailabilityZone = aws.LateInitializeStringPtr(in.AvailabilityZone, db.AvailabilityZone)

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -214,6 +214,13 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 		in.PreferredBackupWindow = aws.LateInitializeStringPtr(in.PreferredBackupWindow, db.PreferredBackupWindow)
 		in.StorageEncrypted = aws.LateInitializeBoolPtr(in.StorageEncrypted, db.StorageEncrypted)
 		in.StorageType = aws.LateInitializeStringPtr(in.StorageType, db.StorageType)
+		in.EngineVersion = aws.LateInitializeStringPtr(in.EngineVersion, db.EngineVersion)
+        // When version 5.6 is chosen, AWS creates 5.6.41 and that's totally valid.
+        // But we detect as if we need to update it all the time. Here, we assign
+        // the actual full version to our spec to avoid unnecessary update signals.
+        if strings.HasPrefix(aws.StringValue(db.EngineVersion), aws.StringValue(in.EngineVersion)) {
+            in.EngineVersion = db.EngineVersion
+        }
 	}
 	in.AutoMinorVersionUpgrade = aws.LateInitializeBoolPtr(in.AutoMinorVersionUpgrade, db.AutoMinorVersionUpgrade)
 	in.AvailabilityZone = aws.LateInitializeStringPtr(in.AvailabilityZone, db.AvailabilityZone)
@@ -269,13 +276,6 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 		for i, val := range db.VpcSecurityGroups {
 			in.VPCSecurityGroupIDs[i] = aws.StringValue(val.VpcSecurityGroupId)
 		}
-	}
-	in.EngineVersion = aws.LateInitializeStringPtr(in.EngineVersion, db.EngineVersion)
-	// When version 5.6 is chosen, AWS creates 5.6.41 and that's totally valid.
-	// But we detect as if we need to update it all the time. Here, we assign
-	// the actual full version to our spec to avoid unnecessary update signals.
-	if strings.HasPrefix(aws.StringValue(db.EngineVersion), aws.StringValue(in.EngineVersion)) {
-		in.EngineVersion = db.EngineVersion
 	}
 	if in.DBParameterGroupName == nil {
 		for i := range db.DBParameterGroups {


### PR DESCRIPTION
Signed-off-by: Lyuben Dimitrov <l.dimitrov@reply.de>


### Description of your changes

Late initialize the engineVersion for db Instance in case it is running within a DB cluster.

I noticed a lot of my managed `dbinstance.rds.aws.crossplane.io` resource were not Syncing. After inspection I got an error message:

```shell
update failed: cannot update DBInstance in AWS: InvalidParameterCombination: 
The specified DB Instance is a member of a cluster. Modify the DB engine version for the DB Cluster using the ModifyDbCluster API 
```

In my setup, I have a DB Clusters with multiple DB Instances and a lot of the parameters can be only updated for the DB Cluster. I believe the engineVersion belongs also here in this check.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
