### PR TITLE
Fix documentation links in AUTHENTICATION.md

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -19,7 +19,7 @@ AWS API. This can be done in one of the following ways:
 
 - Using a base64-encoded static credentials in a Kubernetes
   `Secret`. This is described in detail
-  [here](https://crossplane.io/docs/v1.6/getting-started/install-configure.html#get-aws-account-keyfile).
+  [here](https://crossplane.io/docs/v1.10/getting-started/install-configure.html#get-aws-account-keyfile).
 - Using IAM Roles for Kubernetes `ServiceAccounts`. This
   functionality is only available when running Crossplane on EKS, and the
   feature has been
@@ -67,7 +67,7 @@ $ helm repo add crossplane-stable https://charts.crossplane.io/stable
 $ helm install crossplane --create-namespace --namespace crossplane-system crossplane-stable/crossplane
 ```
 
-`provider-aws` can be installed with the [Crossplane CLI](https://crossplane.io/docs/v1.6/getting-started/install-configure.html#install-crossplane-cli),
+`provider-aws` can be installed with the [Crossplane CLI](https://crossplane.io/docs/v1.10/getting-started/install-configure.html#install-crossplane-cli),
 but we will do so manually so that we can also create and reference a
 `ControllerConfig`:
 


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Updated links in the AUTHENTICATION.md file to point at Crossplane v1.10 docs instead of v1.6.

It would be better to point at a "latest" link rather than a specific release, but that will require updates in Crossplane docs.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Verified that the links are correct

[contribution process]: https://git.io/fj2m9
