### PR TITLE
chore: Document field error on S3 Bucket types

### DIFF
--- a/apis/s3/v1beta1/bucket_types.go
+++ b/apis/s3/v1beta1/bucket_types.go
@@ -35,6 +35,9 @@ type BucketParameters struct {
 
 	// LocationConstraint specifies the Region where the bucket will be created.
 	// It is a required field.
+	// Due to AWS API limitations lacking on a proper response, when this field is set to a wrong value,
+	// or to non-existent region on bucket creation, it's impossible forwarding a meaning status message to the user
+	// about the problem, producing some errors related to dial
 	LocationConstraint string `json:"locationConstraint"`
 
 	// Allows grantee the read, write, read ACP, and write ACP permissions on the

--- a/apis/s3/v1beta1/bucket_types.go
+++ b/apis/s3/v1beta1/bucket_types.go
@@ -36,8 +36,8 @@ type BucketParameters struct {
 	// LocationConstraint specifies the Region where the bucket will be created.
 	// It is a required field.
 	// Due to AWS API limitations lacking on a proper response, when this field is set to a wrong value,
-	// or to non-existent region on bucket creation, it's impossible forwarding a meaning status message to the user
-	// about the problem, producing some errors related to dial
+	// or to non-existent region on bucket creation, it's impossible forwarding a meaningful status message to the user
+	// about the problem, producing connection errors instead.
 	LocationConstraint string `json:"locationConstraint"`
 
 	// Allows grantee the read, write, read ACP, and write ACP permissions on the

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -413,7 +413,11 @@ spec:
                     type: object
                   locationConstraint:
                     description: LocationConstraint specifies the Region where the
-                      bucket will be created. It is a required field.
+                      bucket will be created. It is a required field. Due to AWS API
+                      limitations lacking on a proper response, when this field is
+                      set to a wrong value, or to non-existent region on bucket creation,
+                      it's impossible forwarding a meaning status message to the user
+                      about the problem, producing some errors related to dial
                     type: string
                   loggingConfiguration:
                     description: Specifies logging parameters for an Amazon S3 bucket.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Just add a bit of documentation in the field locationConstraint for S3 buckets, to help people to debug some "error dialing" given by AWS and not by the provider

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
