### PR TITLE
fix(eks/cluster): outpost status fields optional

### DIFF
--- a/apis/eks/v1beta1/types.go
+++ b/apis/eks/v1beta1/types.go
@@ -341,13 +341,13 @@ type OutpostConfigResponse struct {
 	// the same for all control plane instances.
 	//
 	// This member is required.
-	ControlPlaneInstanceType string `json:"controlPlaneInstanceType"`
+	ControlPlaneInstanceType string `json:"controlPlaneInstanceType,omitempty"`
 
 	// The ARN of the Outpost that you specified for use with your local Amazon EKS
 	// cluster on Outposts.
 	//
 	// This member is required.
-	OutpostArns []string `json:"outpostArns"`
+	OutpostArns []string `json:"outpostArns,omitempty"`
 	// contains filtered or unexported fields
 }
 

--- a/examples/eks/cluster.yaml
+++ b/examples/eks/cluster.yaml
@@ -20,7 +20,7 @@ spec:
         - name: sample-subnet2
       securityGroupIdRefs:
         - name: sample-cluster-sg
-    version: "1.16"
+    version: "1.21"
   writeConnectionSecretToRef:
     name: cluster-conn
     namespace: default

--- a/package/crds/eks.aws.crossplane.io_clusters.yaml
+++ b/package/crds/eks.aws.crossplane.io_clusters.yaml
@@ -715,9 +715,6 @@ spec:
                         items:
                           type: string
                         type: array
-                    required:
-                    - controlPlaneInstanceType
-                    - outpostArns
                     type: object
                   platformVersion:
                     description: The platform version of your Amazon EKS cluster.


### PR DESCRIPTION
### Description of your changes

> 1.6686110160807893e+09    ERROR    controller.managed/cluster.eks.aws.crossplane.io    Reconciler error    {"reconciler group": "eks.aws.crossplane.io", "reconciler kind": "Cluster", "name": "baum-dev-cluster-76fz7", "namespace": "", "error": "cannot update managed resource status: Cluster.eks.aws.crossplane.io \"baum-dev-cluster-76fz7\" is invalid: status.atProvider.outpostConfig.outpostArns: Required value"}

This change fixes the above error, which resulted in no `status` of the resource being delivered.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually with the example
