### PR TITLE
fix(rds/dbinstance): possible nil pointer panic

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -326,10 +326,10 @@ func (e *custom) isUpToDate(cr *svcapitypes.DBInstance, out *svcsdk.DescribeDBIn
 		return false, err
 	}
 
-	wantedVersion := *cr.Spec.ForProvider.EngineVersion
-	currentVersion := *db.EngineVersion
+	wantedVersion := aws.StringValue(cr.Spec.ForProvider.EngineVersion)
+	currentVersion := aws.StringValue(db.EngineVersion)
 
-	versionChanged := wantedVersion != currentVersion
+	versionChanged := wantedVersion != "" && wantedVersion != currentVersion
 
 	if versionChanged && aws.BoolValue(cr.Spec.ForProvider.AutoMinorVersionUpgrade) {
 		wantedMaiorList := strings.Split(wantedVersion, ".")


### PR DESCRIPTION
### Description of your changes
If the field `engineVersion` is not set or unset by the user, the `dbInstance` controller would have a panic runtime error due to nil pointer dereference in `isUpToDate`.

This change should fix this possibly rare occasion. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually with the db_instance.yaml example