### PR TITLE
fix(cache/endpoint): populate cache status with endpoint

### DIFF
--- a/apis/cache/v1beta1/replication_group_types.go
+++ b/apis/cache/v1beta1/replication_group_types.go
@@ -84,7 +84,7 @@ type NodeGroup struct {
 	// (cluster mode disabled) replication group contains only 1 node group;
 	// therefore, the node group ID is 0001. A Redis (cluster mode enabled)
 	// replication group contains 1 to 15 node groups numbered 0001 to 0015.
-	NodeGroupID string `json:"port,omitempty"`
+	NodeGroupID string `json:"nodeGroupID,omitempty"`
 
 	// NodeGroupMembers is a list containing information about individual nodes
 	// within the node group (shard).

--- a/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/package/crds/cache.aws.crossplane.io_replicationgroups.yaml
@@ -931,6 +931,13 @@ spec:
                         read/write primary node. All the other nodes are read-only
                         Replica nodes. Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticache-2015-02-02/NodeGroup
                       properties:
+                        nodeGroupID:
+                          description: NodeGroupID is the identifier for the node
+                            group (shard). A Redis (cluster mode disabled) replication
+                            group contains only 1 node group; therefore, the node
+                            group ID is 0001. A Redis (cluster mode enabled) replication
+                            group contains 1 to 15 node groups numbered 0001 to 0015.
+                          type: string
                         nodeGroupMembers:
                           description: NodeGroupMembers is a list containing information
                             about individual nodes within the node group (shard).
@@ -974,13 +981,6 @@ spec:
                                 type: object
                             type: object
                           type: array
-                        port:
-                          description: NodeGroupID is the identifier for the node
-                            group (shard). A Redis (cluster mode disabled) replication
-                            group contains only 1 node group; therefore, the node
-                            group ID is 0001. A Redis (cluster mode enabled) replication
-                            group contains 1 to 15 node groups numbered 0001 to 0015.
-                          type: string
                         primaryEndpoint:
                           description: PrimaryEndpoint is the endpoint of the primary
                             node in this node group (shard).

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -640,6 +640,75 @@ func TestGenerateObservation(t *testing.T) {
 				Status:                status,
 			},
 		},
+		{
+			name: "cluster-mode-no-endpoint",
+			rg: elasticachetypes.ReplicationGroup{
+				AutomaticFailover:     automaticFailover,
+				ClusterEnabled:        &clusterEnabled,
+				ConfigurationEndpoint: nil,
+				MemberClusters:        memberClusters,
+				Status:                &status,
+				NodeGroups:            nodeGroups,
+				PendingModifiedValues: &rgpmdv,
+			},
+			want: v1beta1.ReplicationGroupObservation{
+				AutomaticFailover:     string(automaticFailover),
+				ClusterEnabled:        clusterEnabled,
+				ConfigurationEndpoint: v1beta1.Endpoint{},
+				MemberClusters:        memberClusters,
+				NodeGroups: []v1beta1.NodeGroup{
+					generateNodeGroup(nodeGroups[0]),
+				},
+				PendingModifiedValues: generateReplicationGroupPendingModifiedValues(rgpmdv),
+				Status:                status,
+			},
+		},
+		{
+			name: "non-cluster-mode",
+			rg: elasticachetypes.ReplicationGroup{
+				AutomaticFailover:     automaticFailover,
+				ClusterEnabled:        aws.Bool(false),
+				ConfigurationEndpoint: configurationEndpoint,
+				MemberClusters:        memberClusters,
+				Status:                &status,
+				NodeGroups:            nodeGroups,
+				PendingModifiedValues: &rgpmdv,
+			},
+			want: v1beta1.ReplicationGroupObservation{
+				AutomaticFailover: string(automaticFailover),
+				ClusterEnabled:    false,
+				ConfigurationEndpoint: v1beta1.Endpoint{
+					Address: *nodeGroups[0].PrimaryEndpoint.Address,
+					Port:    int(nodeGroups[0].PrimaryEndpoint.Port),
+				},
+				MemberClusters: memberClusters,
+				NodeGroups: []v1beta1.NodeGroup{
+					generateNodeGroup(nodeGroups[0]),
+				},
+				PendingModifiedValues: generateReplicationGroupPendingModifiedValues(rgpmdv),
+				Status:                status,
+			},
+		},
+		{
+			name: "non-cluster-mode-no-nodes",
+			rg: elasticachetypes.ReplicationGroup{
+				AutomaticFailover:     automaticFailover,
+				ClusterEnabled:        aws.Bool(false),
+				ConfigurationEndpoint: configurationEndpoint,
+				MemberClusters:        memberClusters,
+				Status:                &status,
+				PendingModifiedValues: &rgpmdv,
+			},
+			want: v1beta1.ReplicationGroupObservation{
+				AutomaticFailover:     string(automaticFailover),
+				ClusterEnabled:        false,
+				ConfigurationEndpoint: v1beta1.Endpoint{},
+				MemberClusters:        memberClusters,
+				NodeGroups:            nil,
+				PendingModifiedValues: generateReplicationGroupPendingModifiedValues(rgpmdv),
+				Status:                status,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Populate cache status with endpoint correctly, and correct json tag for node group. 

fixes: #1358 

This should probably move to elasticache in the future like Christopher mentioned in the issue.



Signed-off-by: Manabu McCloskey <manabu.mccloskey@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested against my cluster. 
Before:

```yaml
status:
  atProvider:
    automaticFailoverStatus: enabled
    configurationEndpoint: {}
```

After:

```yaml
status:
  atProvider:
    automaticFailoverStatus: enabled
    configurationEndpoint:
      address: master.sgonly-w92q6-mjsjl.pqeclz.usw2.cache.amazonaws.com
      port: 6380
```