### PR TITLE
fix(cognitoidentity): Update broken AWS API function call for GroupUserMembership

### DIFF
--- a/pkg/controller/cognitoidentityprovider/groupusermembership/controller.go
+++ b/pkg/controller/cognitoidentityprovider/groupusermembership/controller.go
@@ -151,7 +151,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		return managed.ExternalObservation{}, errors.Wrap(err, errUnmarshal)
 	}
 
-	attachedGroupObject, err := FindAttachedGroupObject(ctx, e, externalAnnotation.Username, externalAnnotation.UserPoolID, externalAnnotation.Groupname)
+	attachedGroupObject, err := FindAttachedGroupObject(ctx, e, externalAnnotation.UserPoolID, externalAnnotation.Username, externalAnnotation.Groupname)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errGet)
 	}

--- a/pkg/controller/cognitoidentityprovider/groupusermembership/controller_test.go
+++ b/pkg/controller/cognitoidentityprovider/groupusermembership/controller_test.go
@@ -19,6 +19,7 @@ package groupusermembership
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/crossplane-contrib/provider-aws/apis/cognitoidentityprovider/manualv1alpha1"
@@ -111,14 +112,17 @@ func TestObserve(t *testing.T) {
 			args: args{
 				cognitoidentityprovider: &fake.MockGroupUserMembershipClient{
 					MockAdminListGroupsForUser: func(ctx context.Context, input *awscognitoidentityprovider.AdminListGroupsForUserInput, opts []func(*awscognitoidentityprovider.Options)) (*awscognitoidentityprovider.AdminListGroupsForUserOutput, error) {
-						return &awscognitoidentityprovider.AdminListGroupsForUserOutput{
-							Groups: []awscognitoidentityprovidertypes.GroupType{
-								{
-									GroupName:  &groupName,
-									UserPoolId: &userPoolID,
+						if strings.Compare(*input.UserPoolId, userPoolID) == 0 && strings.Compare(*input.Username, Username) == 0 {
+							return &awscognitoidentityprovider.AdminListGroupsForUserOutput{
+								Groups: []awscognitoidentityprovidertypes.GroupType{
+									{
+										GroupName:  &groupName,
+										UserPoolId: &userPoolID,
+									},
 								},
-							},
-						}, nil
+							}, nil
+						}
+						return nil, &awscognitoidentityprovidertypes.ResourceNotFoundException{}
 					},
 				},
 				cr: userGroup(withExternalName(groupName, Username, userPoolID)),


### PR DESCRIPTION
Signed-off-by: abacus3 <57175410+abacus3@users.noreply.github.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

- Fixed incorrect `FindAttachedGroupObject` function call in https://github.com/crossplane-contrib/provider-aws/blob/095bdea17800049a200d7dbfbcc95f57870c3ada/pkg/controller/cognitoidentityprovider/groupusermembership/controller.go#L154 by swapping username and userPoolId invokation parameter
- Extended automatic test case: in https://github.com/crossplane-contrib/provider-aws/blob/02b4ddc8c5cadddbff93b86e37924321f6166732/pkg/controller/cognitoidentityprovider/groupusermembership/controller_test.go#L110-L136

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1586

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Exsiting automated test cases have been extended.
Manual testing of the valid test case has been performed.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
