### PR TITLE
fix(docs): Update the location of the aws provider 

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -88,7 +88,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: crossplane/provider-aws:v${VERSION}
+  package: crossplanecontrib/provider-aws:v${VERSION}
   controllerConfigRef:
     name: aws-config
 EOF


### PR DESCRIPTION
### Description of your changes
The location of the AWS Provider was old in the Authentication read me. Updating to be the correct location.

With the location incorrect Crossplane would not accept the Provider and therefor wouldn't create a Kubernetes ServiceAccount.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
No code changed.

