### PR TITLE
feat(rds): instance + cluster allowMajorVersionUpgrade

### DIFF
--- a/apis/rds/generator-config.yaml
+++ b/apis/rds/generator-config.yaml
@@ -7,6 +7,18 @@ operations:
     operation_type: Delete
 
 resources:
+  DBInstance:
+    fields:
+      AllowMajorVersionUpgrade:
+        from:
+          operation: ModifyDBInstance
+          path: AllowMajorVersionUpgrade
+  DBCluster:
+    fields:
+      AllowMajorVersionUpgrade:
+        from:
+          operation: ModifyDBCluster
+          path: AllowMajorVersionUpgrade
   DBInstanceRoleAssociation:
     exceptions:
       errors:

--- a/apis/rds/v1alpha1/custom_types.go
+++ b/apis/rds/v1alpha1/custom_types.go
@@ -196,7 +196,9 @@ type CustomDBClusterParameters struct {
 	// Constraints: Must contain from 8 to 41 characters. Required.
 	MasterUserPasswordSecretRef *xpv1.SecretKeySelector `json:"masterUserPasswordSecretRef"`
 
-	// A list of EC2 VPC security groups to associate with this DB cluster.
+	// A list of VPC security groups that the DB cluster will belong to.
+	//
+	// Valid for: Aurora DB clusters and Multi-AZ DB clusters
 	VPCSecurityGroupIDs []string `json:"vpcSecurityGroupIDs,omitempty"`
 
 	// VPCSecurityGroupIDRefs are references to VPCSecurityGroups used to set
@@ -539,7 +541,17 @@ type CustomDBInstanceParameters struct {
 	// +optional
 	SkipFinalSnapshot bool `json:"skipFinalSnapshot,omitempty"`
 
-	// A list of EC2 VPC security groups to associate with this DB instance.
+	// A list of Amazon EC2 VPC security groups to authorize on this DB instance.
+	// This change is asynchronously applied as soon as possible.
+	//
+	// This setting doesn't apply to RDS Custom.
+	//
+	// Amazon Aurora
+	// Not applicable. The associated list of EC2 VPC security groups is managed
+	// by the DB cluster. For more information, see ModifyDBCluster.
+	//
+	// Constraints:
+	//    * If supplied, must match existing VpcSecurityGroupIds.
 	VPCSecurityGroupIDs []string `json:"vpcSecurityGroupIDs,omitempty"`
 
 	// VPCSecurityGroupIDRefs are references to VPCSecurityGroups used to set

--- a/apis/rds/v1alpha1/zz_db_cluster.go
+++ b/apis/rds/v1alpha1/zz_db_cluster.go
@@ -36,6 +36,14 @@ type DBClusterParameters struct {
 	//
 	// Valid for: Multi-AZ DB clusters only
 	AllocatedStorage *int64 `json:"allocatedStorage,omitempty"`
+	// A value that indicates whether major version upgrades are allowed.
+	//
+	// Constraints: You must allow major version upgrades when specifying a value
+	// for the EngineVersion parameter that is a different major version than the
+	// DB cluster's current version.
+	//
+	// Valid for: Aurora DB clusters only
+	AllowMajorVersionUpgrade *bool `json:"allowMajorVersionUpgrade,omitempty"`
 	// A value that indicates whether minor engine upgrades are applied automatically
 	// to the DB cluster during the maintenance window. By default, minor engine
 	// upgrades are applied automatically.

--- a/apis/rds/v1alpha1/zz_db_instance.go
+++ b/apis/rds/v1alpha1/zz_db_instance.go
@@ -105,6 +105,16 @@ type DBInstanceParameters struct {
 	//    be an integer from 20 to 1024. Web and Express editions: Must be an integer
 	//    from 20 to 1024.
 	AllocatedStorage *int64 `json:"allocatedStorage,omitempty"`
+	// A value that indicates whether major version upgrades are allowed. Changing
+	// this parameter doesn't result in an outage and the change is asynchronously
+	// applied as soon as possible.
+	//
+	// This setting doesn't apply to RDS Custom.
+	//
+	// Constraints: Major version upgrades must be allowed when specifying a value
+	// for the EngineVersion parameter that is a different major version than the
+	// DB instance's current version.
+	AllowMajorVersionUpgrade *bool `json:"allowMajorVersionUpgrade,omitempty"`
 	// A value that indicates whether minor engine upgrades are applied automatically
 	// to the DB instance during the maintenance window. By default, minor engine
 	// upgrades are applied automatically.

--- a/apis/rds/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/rds/v1alpha1/zz_generated.deepcopy.go
@@ -1328,6 +1328,11 @@ func (in *DBClusterParameters) DeepCopyInto(out *DBClusterParameters) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.AllowMajorVersionUpgrade != nil {
+		in, out := &in.AllowMajorVersionUpgrade, &out.AllowMajorVersionUpgrade
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AutoMinorVersionUpgrade != nil {
 		in, out := &in.AutoMinorVersionUpgrade, &out.AutoMinorVersionUpgrade
 		*out = new(bool)
@@ -2868,6 +2873,11 @@ func (in *DBInstanceParameters) DeepCopyInto(out *DBInstanceParameters) {
 	if in.AllocatedStorage != nil {
 		in, out := &in.AllocatedStorage, &out.AllocatedStorage
 		*out = new(int64)
+		**out = **in
+	}
+	if in.AllowMajorVersionUpgrade != nil {
+		in, out := &in.AllowMajorVersionUpgrade, &out.AllowMajorVersionUpgrade
+		*out = new(bool)
 		**out = **in
 	}
 	if in.AutoMinorVersionUpgrade != nil {

--- a/examples/rds/db-aurora-cluster.yaml
+++ b/examples/rds/db-aurora-cluster.yaml
@@ -6,7 +6,9 @@ spec:
   forProvider:
     region: us-east-1
     engine: aurora-mysql
-    masterUsername: admin
+    allowMajorVersionUpgrade: true # unset per default (Note: dbClusterParameterGroup with correct dbParameterClusterGroupFamily may needed, before majorVersion upgrade possible)
+    # for majorVersion upgrade via Cluster - depending on the setup - instances may need adjustments: before (e.g. supported instanceClass) or after (e.g. matching dbParameterGroup) the upgrade
+    masterUsername: adminuser
     masterUserPasswordSecretRef:
       name: example-aurora-mysql-cluster
       namespace: crossplane-system

--- a/examples/rds/db-instance.yaml
+++ b/examples/rds/db-instance.yaml
@@ -9,10 +9,11 @@ spec:
     autoMinorVersionUpgrade: true
     autogeneratePassword: true
     backupRetentionPeriod: 14
-    dbInstanceClass: db.t2.micro
+    dbInstanceClass: db.t3.micro # needs to support engine and -version (see AWS Docs: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.Support)
     dbName: example
     engine: postgres
     engineVersion: "12.9"
+    allowMajorVersionUpgrade: true # unset per default (Note: supported dbInstanceClass and dbParameterGroup with correct dbParameterGroupFamily needed, before majorVersion upgrade possible; applyImmediately matters)
     masterUsername: adminuser
     masterUserPasswordSecretRef:
       key: password

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -68,6 +68,13 @@ spec:
                       DB clusters only"
                     format: int64
                     type: integer
+                  allowMajorVersionUpgrade:
+                    description: "A value that indicates whether major version upgrades
+                      are allowed. \n Constraints: You must allow major version upgrades
+                      when specifying a value for the EngineVersion parameter that
+                      is a different major version than the DB cluster's current version.
+                      \n Valid for: Aurora DB clusters only"
+                    type: boolean
                   applyImmediately:
                     description: "A value that indicates whether the modifications
                       in this request and any pending modifications are asynchronously
@@ -1075,8 +1082,9 @@ spec:
                         type: object
                     type: object
                   vpcSecurityGroupIDs:
-                    description: A list of EC2 VPC security groups to associate with
-                      this DB cluster.
+                    description: "A list of VPC security groups that the DB cluster
+                      will belong to. \n Valid for: Aurora DB clusters and Multi-AZ
+                      DB clusters"
                     items:
                       type: string
                     type: array

--- a/package/crds/rds.aws.crossplane.io_dbinstances.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbinstances.yaml
@@ -105,6 +105,15 @@ spec:
                       and Express editions: Must be an integer from 20 to 1024."
                     format: int64
                     type: integer
+                  allowMajorVersionUpgrade:
+                    description: "A value that indicates whether major version upgrades
+                      are allowed. Changing this parameter doesn't result in an outage
+                      and the change is asynchronously applied as soon as possible.
+                      \n This setting doesn't apply to RDS Custom. \n Constraints:
+                      Major version upgrades must be allowed when specifying a value
+                      for the EngineVersion parameter that is a different major version
+                      than the DB instance's current version."
+                    type: boolean
                   applyImmediately:
                     description: "A value that indicates whether the modifications
                       in this request and any pending modifications are asynchronously
@@ -1284,8 +1293,13 @@ spec:
                         type: object
                     type: object
                   vpcSecurityGroupIDs:
-                    description: A list of EC2 VPC security groups to associate with
-                      this DB instance.
+                    description: "A list of Amazon EC2 VPC security groups to authorize
+                      on this DB instance. This change is asynchronously applied as
+                      soon as possible. \n This setting doesn't apply to RDS Custom.
+                      \n Amazon Aurora Not applicable. The associated list of EC2
+                      VPC security groups is managed by the DB cluster. For more information,
+                      see ModifyDBCluster. \n Constraints: * If supplied, must match
+                      existing VpcSecurityGroupIds."
                     items:
                       type: string
                     type: array

--- a/pkg/controller/rds/dbcluster/setup_test.go
+++ b/pkg/controller/rds/dbcluster/setup_test.go
@@ -61,7 +61,7 @@ func TestIsVPCSecurityGroupIDsUpToDate(t *testing.T) {
 				isUpToDate: false,
 			},
 		},
-		"DesiredEmpty": {
+		"DesiredBeingManged": { // AWS default or managed by DBCluster
 			args: args{
 				cr: &svcapitypes.DBCluster{
 					Spec: svcapitypes.DBClusterSpec{
@@ -88,7 +88,7 @@ func TestIsVPCSecurityGroupIDsUpToDate(t *testing.T) {
 				},
 			},
 			want: want{
-				isUpToDate: false,
+				isUpToDate: true,
 			},
 		},
 		"ActualEmpty": {
@@ -178,7 +178,7 @@ func TestIsVPCSecurityGroupIDsUpToDate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			isUpToDate := isVPCSecurityGroupIDsUpToDate(tc.args.cr, tc.args.out)
+			isUpToDate := areVPCSecurityGroupIDsUpToDate(tc.args.cr, tc.args.out)
 
 			if diff := cmp.Diff(tc.want.isUpToDate, isUpToDate); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)

--- a/pkg/controller/rds/dbcluster/zz_conversions.go
+++ b/pkg/controller/rds/dbcluster/zz_conversions.go
@@ -715,6 +715,9 @@ func GenerateModifyDBClusterInput(cr *svcapitypes.DBCluster) *svcsdk.ModifyDBClu
 	if cr.Spec.ForProvider.AllocatedStorage != nil {
 		res.SetAllocatedStorage(*cr.Spec.ForProvider.AllocatedStorage)
 	}
+	if cr.Spec.ForProvider.AllowMajorVersionUpgrade != nil {
+		res.SetAllowMajorVersionUpgrade(*cr.Spec.ForProvider.AllowMajorVersionUpgrade)
+	}
 	if cr.Spec.ForProvider.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*cr.Spec.ForProvider.AutoMinorVersionUpgrade)
 	}

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -484,13 +484,13 @@ func areVPCSecurityGroupIDsUpToDate(cr *svcapitypes.DBInstance, out *svcsdk.DBIn
 	// if user is fine with default SG or lets DBCluster manage it
 	// (removing all SGs is not possible, AWS will keep last set SGs)
 	if len(desiredIDs) == 0 {
-		return false
+		return true
 	}
 
 	actualGroups := out.VpcSecurityGroups
 
 	if len(desiredIDs) != len(actualGroups) {
-		return true
+		return false
 	}
 
 	actualIDs := make([]string, 0, len(actualGroups))

--- a/pkg/controller/rds/dbinstance/zz_conversions.go
+++ b/pkg/controller/rds/dbinstance/zz_conversions.go
@@ -897,6 +897,9 @@ func GenerateModifyDBInstanceInput(cr *svcapitypes.DBInstance) *svcsdk.ModifyDBI
 	if cr.Spec.ForProvider.AllocatedStorage != nil {
 		res.SetAllocatedStorage(*cr.Spec.ForProvider.AllocatedStorage)
 	}
+	if cr.Spec.ForProvider.AllowMajorVersionUpgrade != nil {
+		res.SetAllowMajorVersionUpgrade(*cr.Spec.ForProvider.AllowMajorVersionUpgrade)
+	}
 	if cr.Spec.ForProvider.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*cr.Spec.ForProvider.AutoMinorVersionUpgrade)
 	}


### PR DESCRIPTION


### Description of your changes

to both DBInstance and DBCluster
- add field/flag `allowMajorVersionUpgrade` (+ special update handling needed for DBCluster)
- make condition.status partly include AWS resource status (willing to revert parts here, if considered too redundant)
- implement controllers updating `VPCSecurityGroupIDs` and `DBParameterGroupName`/`DBClusterParameterGroupName`


Fixes #1330

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manual tests (DBInstance; DBCluster with DBInstance)
