### PR TITLE
Bug - ELB updates every reconcile when running multiple listeners 

### DIFF
--- a/pkg/clients/elasticloadbalancing/elb/elb.go
+++ b/pkg/clients/elasticloadbalancing/elb/elb.go
@@ -170,6 +170,15 @@ func CreatePatch(in elbtypes.LoadBalancerDescription, target v1alpha1.ELBParamet
 		targetCopy.Listeners[i].Protocol = strings.ToUpper(v.Protocol)
 		targetCopy.Listeners[i].InstanceProtocol = aws.String(strings.ToUpper(aws.ToString(v.InstanceProtocol)))
 	}
+	
+	// Make sure the listeners are sorted by port number for both currentParams and target.
+	sort.Slice(currentParams.Listeners, func(i, j int) bool {
+		return currentParams.Listeners[i].LoadBalancerPort < currentParams.Listeners[j].LoadBalancerPort
+	})
+
+	sort.Slice(targetCopy.Listeners, func(i, j int) bool {
+		return targetCopy.Listeners[i].LoadBalancerPort < targetCopy.Listeners[j].LoadBalancerPort
+	})
 
 	jsonPatch, err := clients.CreateJSONPatch(currentParams, targetCopy)
 	if err != nil {


### PR DESCRIPTION
### Description of your changes
If multiple listeners are added to an ELB, the controller compares the current state with the desired state, but the listeners' list is not sorted, causing endless updates.
Each time the controller updates, the listeners are removed and added again, causing the AWS API rate limit to be exceeded.


Fixes #
I have added a sort function for the current state and the desired state and tested it using my local Kind cluster.

I have:

- [V] Read and followed Crossplane's [contribution process].
- [V] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
This code has been tested using Kind cluster.


[contribution process]: https://git.io/fj2m9
![Screen Shot 2022-12-07 at 17 41 38](https://user-images.githubusercontent.com/105583031/206965743-dae8612c-ae9e-41c9-adaf-d1f701ed9d7c.jpg)
