### PR TITLE
fix(docdb/dbcluster): remove unwanted dbsubnetgroup isuptodate-check

### DIFF
--- a/pkg/controller/docdb/dbcluster/setup.go
+++ b/pkg/controller/docdb/dbcluster/setup.go
@@ -162,7 +162,6 @@ func (e *hooks) isUpToDate(cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClu
 	switch {
 	case awsclient.Int64Value(cr.Spec.ForProvider.BackupRetentionPeriod) != awsclient.Int64Value(cluster.BackupRetentionPeriod),
 		awsclient.StringValue(cr.Spec.ForProvider.DBClusterParameterGroupName) != awsclient.StringValue(cluster.DBClusterParameterGroup),
-		awsclient.StringValue(cr.Spec.ForProvider.DBSubnetGroupName) != awsclient.StringValue(cluster.DBSubnetGroup),
 		awsclient.BoolValue(cr.Spec.ForProvider.DeletionProtection) != awsclient.BoolValue(cluster.DeletionProtection),
 		!areSameElements(cr.Spec.ForProvider.EnableCloudwatchLogsExports, cluster.EnabledCloudwatchLogsExports),
 		awsclient.Int64Value(cr.Spec.ForProvider.Port) != awsclient.Int64Value(cluster.Port),


### PR DESCRIPTION
### Description of your changes

The controller for docdb/DBCluster checks if the field `DBSubnetGroup` isUpToDate. However it is not updatable. (e.g. see [AWS CLI docdb - modify-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/docdb/modify-db-cluster.html) and [AWS DocDB DBCluster docs](https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-parameters.html))

This change removes that check (+ unnecessary tests).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
only through `make reviewable test`