### PR TITLE
feat(cache): fix version handling for #1617

### DIFF
--- a/examples/cache/cachecluster.yaml
+++ b/examples/cache/cachecluster.yaml
@@ -14,3 +14,22 @@ spec:
     - name: sample-cluster-sg
   providerConfigRef:
     name: example
+---
+apiVersion: cache.aws.crossplane.io/v1alpha1
+kind: CacheCluster
+metadata:
+  name: redis-cache-cluster
+spec:
+  forProvider:
+    region: us-east-1
+    engine: redis
+    engineVersion: "6.2.6"
+    port: 6379
+    cacheNodeType: cache.t2.micro
+    securityGroupIDRefs:
+    - name: sample-cluster-sg
+    cacheSubnetGroupNameRef:
+      name: sample-cache-subnet-group
+    numCacheNodes: 1
+  providerConfigRef:
+    name: example

--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -40,7 +40,10 @@ import (
 	clients "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
-const errCheckUpToDate = "unable to determine if external resource is up to date"
+const (
+	errCheckUpToDate = "unable to determine if external resource is up to date"
+	errVersionInput  = "unable to parse version number"
+)
 
 // A Client handles CRUD operations for ElastiCache resources.
 type Client interface {
@@ -652,7 +655,7 @@ func IsSubnetGroupUpToDate(p cachev1alpha1.CacheSubnetGroupParameters, sg elasti
 }
 
 // GenerateCreateCacheClusterInput returns Cache Cluster creation input
-func GenerateCreateCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id string) *elasticache.CreateCacheClusterInput {
+func GenerateCreateCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id string) (*elasticache.CreateCacheClusterInput, error) {
 	c := &elasticache.CreateCacheClusterInput{
 		AZMode:                     elasticachetypes.AZMode(aws.ToString(p.AZMode)),
 		AuthToken:                  p.AZMode,
@@ -662,7 +665,6 @@ func GenerateCreateCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id 
 		CacheSubnetGroupName:       p.CacheSubnetGroupName,
 		CacheSecurityGroupNames:    p.CacheSecurityGroupNames,
 		Engine:                     p.Engine,
-		EngineVersion:              p.EngineVersion,
 		NotificationTopicArn:       p.NotificationTopicARN,
 		NumCacheNodes:              aws.Int32(p.NumCacheNodes),
 		Port:                       p.Port,
@@ -677,6 +679,16 @@ func GenerateCreateCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id 
 		SnapshotWindow:             p.SnapshotWindow,
 	}
 
+	if p.EngineVersion != nil {
+		version, err := getVersion(p.EngineVersion)
+		if err != nil {
+			return nil, err
+		}
+		c.EngineVersion = version
+	} else {
+		c.EngineVersion = p.EngineVersion
+	}
+
 	if len(p.Tags) != 0 {
 		c.Tags = make([]elasticachetypes.Tag, len(p.Tags))
 		for i, tag := range p.Tags {
@@ -687,13 +699,13 @@ func GenerateCreateCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id 
 		}
 	}
 
-	return c
+	return c, nil
 }
 
 // GenerateModifyCacheClusterInput returns ElastiCache Cache Cluster
 // modification input suitable for use with the AWS API.
-func GenerateModifyCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id string) *elasticache.ModifyCacheClusterInput {
-	return &elasticache.ModifyCacheClusterInput{
+func GenerateModifyCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id string) (*elasticache.ModifyCacheClusterInput, error) {
+	c := &elasticache.ModifyCacheClusterInput{
 		CacheClusterId:             aws.String(id),
 		AZMode:                     elasticachetypes.AZMode(aws.ToString(p.AZMode)),
 		ApplyImmediately:           aws.ToBool(p.ApplyImmediately),
@@ -712,6 +724,18 @@ func GenerateModifyCacheClusterInput(p cachev1alpha1.CacheClusterParameters, id 
 		SnapshotRetentionLimit:     p.SnapshotRetentionLimit,
 		SnapshotWindow:             p.SnapshotWindow,
 	}
+
+	if p.EngineVersion != nil {
+		version, err := getVersion(p.EngineVersion)
+		if err != nil {
+			return nil, err
+		}
+		c.EngineVersion = version
+	} else {
+		c.EngineVersion = p.EngineVersion
+	}
+
+	return c, nil
 }
 
 // GenerateClusterObservation produces a CacheClusterObservation object out of
@@ -816,5 +840,40 @@ func IsClusterUpToDate(name string, in *cachev1alpha1.CacheClusterParameters, ob
 	}
 	GenerateCluster(name, *in, desired)
 
+	if desired.EngineVersion != nil {
+		observedVersion := observed.EngineVersion
+		desiredVersion := desired.EngineVersion
+
+		observedVersionSplit := strings.Split(aws.ToString(observedVersion), ".")
+		desiredVersionSplit := strings.Split(aws.ToString(desiredVersion), ".")
+		if observedVersionSplit[0] != desiredVersionSplit[0] {
+			return false, nil
+		}
+		if len(desiredVersionSplit) > 1 {
+			if observedVersionSplit[1] != desiredVersionSplit[1] {
+				return false, nil
+			}
+		}
+		// to ignore in following equal
+		desired.EngineVersion = observed.EngineVersion
+	}
+
 	return cmp.Equal(desired, observed, cmpopts.EquateEmpty(), cmpopts.IgnoreTypes(document.NoSerde{})), nil
+}
+
+func getVersion(version *string) (*string, error) {
+	versionSplit := strings.Split(aws.ToString(version), ".")
+	version1, err := strconv.Atoi(versionSplit[0])
+	if err != nil {
+		return nil, errors.Wrap(err, errVersionInput)
+	}
+	versionOut := strconv.Itoa(version1)
+	if len(versionSplit) > 1 {
+		version2, err := strconv.Atoi(versionSplit[1])
+		if err != nil {
+			return nil, errors.Wrap(err, errVersionInput)
+		}
+		versionOut += "." + strconv.Itoa(version2)
+	}
+	return &versionOut, nil
 }

--- a/pkg/clients/elasticache/elasticcachecluster_test.go
+++ b/pkg/clients/elasticache/elasticcachecluster_test.go
@@ -158,7 +158,7 @@ func TestGenerateCreateCacheClusterInput(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := GenerateCreateCacheClusterInput(tc.in, clusterID)
+			r, _ := GenerateCreateCacheClusterInput(tc.in, clusterID)
 			if diff := cmp.Diff(r, &tc.out, cmpopts.IgnoreTypes(document.NoSerde{})); diff != "" {
 				t.Errorf("GenerateNetworkObservation(...): -want, +got:\n%s", diff)
 			}
@@ -186,7 +186,7 @@ func TestGenerateModifyCacheClusterInput(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := GenerateModifyCacheClusterInput(tc.in, clusterID)
+			r, _ := GenerateModifyCacheClusterInput(tc.in, clusterID)
 			if diff := cmp.Diff(r, &tc.out, cmpopts.IgnoreTypes(document.NoSerde{})); diff != "" {
 				t.Errorf("GenerateNetworkObservation(...): -want, +got:\n%s", diff)
 			}

--- a/pkg/controller/cache/cluster/controller.go
+++ b/pkg/controller/cache/cluster/controller.go
@@ -148,7 +148,10 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.Status.SetConditions(xpv1.Creating())
 
-	_, err := e.client.CreateCacheCluster(ctx, elasticache.GenerateCreateCacheClusterInput(cr.Spec.ForProvider, meta.GetExternalName(cr)))
+	input, err := elasticache.GenerateCreateCacheClusterInput(cr.Spec.ForProvider, meta.GetExternalName(cr))
+	if err == nil {
+		_, err = e.client.CreateCacheCluster(ctx, input)
+	}
 
 	return managed.ExternalCreation{}, awsclient.Wrap(err, errCreateCacheCluster)
 }
@@ -164,7 +167,11 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, nil
 	}
 
-	_, err := e.client.ModifyCacheCluster(ctx, elasticache.GenerateModifyCacheClusterInput(cr.Spec.ForProvider, meta.GetExternalName(cr)))
+	clusterInput, err := elasticache.GenerateModifyCacheClusterInput(cr.Spec.ForProvider, meta.GetExternalName(cr))
+	if err == nil {
+		_, err = e.client.ModifyCacheCluster(ctx, clusterInput)
+	}
+
 	return managed.ExternalUpdate{}, awsclient.Wrap(err, errModifyCacheCluster)
 }
 


### PR DESCRIPTION
Signed-off-by: Christopher Paul Haar <christopherpaul.haar@dkb.de>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
changed version handling for cache cluster

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1617

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
added new example

```
kubectl get managed
NAME                                                          STATUS      READY   SYNCED   AGE
cachecluster.cache.aws.crossplane.io/aws-memcached-standard   available   True    True     19m
cachecluster.cache.aws.crossplane.io/redis-cache-cluster      available   True    True     19m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
