### PR TITLE
Fix kafka input clusterName

### DIFF
--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -118,7 +118,7 @@ func postObserve(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.Describ
 }
 
 func preCreate(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.CreateClusterInput) error {
-	obj.ClusterName = awsclients.String(meta.GetExternalName(cr))
+	obj.ClusterName = awsclients.String(cr.GetName())
 	obj.BrokerNodeGroupInfo = &svcsdk.BrokerNodeGroupInfo{
 		ClientSubnets:  cr.Spec.ForProvider.CustomBrokerNodeGroupInfo.ClientSubnets,
 		InstanceType:   cr.Spec.ForProvider.CustomBrokerNodeGroupInfo.InstanceType,


### PR DESCRIPTION
Signed-off-by: shaoyue.chen <shaoyue.chen@zilliz.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

A follow-up of #1612 

The external-name should be the uniq id of the resource. Usually we use the `Arn` of the resource provided by AWS.
The ClusterName is the user defined name. Which is currently not offered in parameters. It's reasonable to use the name of CR as the ClusterName.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1611

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
