### PR TITLE
resourcerecordset: Should set AliasTarget when check if it is up to date

### DIFF
--- a/pkg/clients/resourcerecordset/resourcerecordset.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset.go
@@ -165,6 +165,12 @@ func LateInitialize(in *v1alpha1.ResourceRecordSetParameters, rrSet *route53type
 	if rrSet == nil || in == nil {
 		return
 	}
+	if rrSet.AliasTarget != nil {
+		in.AliasTarget = &v1alpha1.AliasTarget{}
+		in.AliasTarget.HostedZoneID = awsclients.LateInitializeString(in.AliasTarget.HostedZoneID, rrSet.AliasTarget.HostedZoneId)
+		in.AliasTarget.DNSName = awsclients.LateInitializeString(in.AliasTarget.DNSName, rrSet.AliasTarget.DNSName)
+		in.AliasTarget.EvaluateTargetHealth = rrSet.AliasTarget.EvaluateTargetHealth
+	}
 	rrType := string(rrSet.Type)
 	in.Type = awsclients.LateInitializeString(in.Type, &rrType)
 	in.TTL = awsclients.LateInitializeInt64Ptr(in.TTL, rrSet.TTL)
@@ -193,6 +199,7 @@ func CreatePatch(in *route53types.ResourceRecordSet, target *v1alpha1.ResourceRe
 	if err != nil {
 		return nil, err
 	}
+
 	patch := &v1alpha1.ResourceRecordSetParameters{}
 	if err := json.Unmarshal(jsonPatch, patch); err != nil {
 		return nil, err


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When setting `AliasTarget` in `v1alpha1.ResourceRecordSetParameters`, `IsUpToDate()` will always return false since it does not fill up the field `AliasTarget` then `CreatePatch` will contain the part about `AliasTarget` when comparing with the expected state.

This will make it always try to do a useless update after observing the state.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Add unit test.
Note before fixing it, the first call of `IsUpToDate` in the added test case should be true, but it return false.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
