### PR TITLE
Add autogen-password support to docdb

### DIFF
--- a/apis/docdb/v1alpha1/custom_types.go
+++ b/apis/docdb/v1alpha1/custom_types.go
@@ -92,6 +92,15 @@ type CustomDBClusterParameters struct {
 	// +optional
 	ApplyImmediately *bool `json:"applyImmediately,omitempty"`
 
+	// AutogeneratePassword indicates whether the controller should generate
+	// a random password for the master user if one is not provided via
+	// MasterUserPasswordSecretRef.
+	//
+	// If a password is generated, it will
+	// be stored as a secret at the location specified by MasterUserPasswordSecretRef.
+	// +optional
+	AutogeneratePassword bool `json:"autogeneratePassword,omitempty"`
+
 	// Determines whether a final cluster snapshot is created before the cluster
 	// is deleted. If true is specified, no cluster snapshot is created. If false
 	// is specified, a cluster snapshot is created before the DB cluster is deleted.

--- a/examples/docdb/cluster-autogenPassword.yaml
+++ b/examples/docdb/cluster-autogenPassword.yaml
@@ -1,0 +1,50 @@
+apiVersion: docdb.aws.crossplane.io/v1alpha1
+kind: DBCluster
+metadata:
+  name: example-cluster-autogen-password
+spec:
+  forProvider:
+    region: us-east-1
+    availabilityZones:
+      - us-east-1b
+      - us-east-1c
+    dbClusterParameterGroupName: example-parameter-group
+    dbSubnetGroupName: example-subnet-group
+    engine: docdb
+    skipFinalSnapshot: true
+    masterUsername: master
+    autogeneratePassword: true
+    masterUserPasswordSecretRef:
+      namespace: crossplane-system
+      name: my-docdb-creds
+      key: password
+    vpcSecurityGroupIDsRefs:
+      - name: sample-cluster-sg
+    tags:
+      - key: cluster
+        value: "my-cluster"
+  providerConfigRef:
+    name: example
+---
+apiVersion: docdb.aws.crossplane.io/v1alpha1
+kind: DBInstance
+metadata:
+  name: example-instance-autogen-password
+spec:
+  forProvider:
+    region: us-east-1
+    dbClusterIdentifier: example-cluster-autogen-password
+    dbInstanceClass: db.t3.medium
+    engine: docdb
+    tags:
+      - key: cluster
+        value: "my-cluster"
+  providerConfigRef:
+    name: example
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-docdb-creds
+  namespace: crossplane-system
+type: Opaque

--- a/package/crds/docdb.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/docdb.aws.crossplane.io_dbclusters.yaml
@@ -74,6 +74,13 @@ spec:
                       changes are applied immediately, regardless of the value of
                       the ApplyImmediately parameter. \n Default: false"
                     type: boolean
+                  autogeneratePassword:
+                    description: "AutogeneratePassword indicates whether the controller
+                      should generate a random password for the master user if one
+                      is not provided via MasterUserPasswordSecretRef. \n If a password
+                      is generated, it will be stored as a secret at the location
+                      specified by MasterUserPasswordSecretRef."
+                    type: boolean
                   availabilityZones:
                     description: A list of Amazon EC2 Availability Zones that instances
                       in the cluster can be created in.

--- a/pkg/controller/docdb/dbcluster/setup_test.go
+++ b/pkg/controller/docdb/dbcluster/setup_test.go
@@ -306,13 +306,17 @@ func mergeTags(lists ...[]*svcapitypes.Tag) []*svcapitypes.Tag {
 }
 
 func generateConnectionDetails(username, password, readerEndpoint, endpoint string, port int) managed.ConnectionDetails {
-	return managed.ConnectionDetails{
+
+	mcd := managed.ConnectionDetails{
 		xpv1.ResourceCredentialsSecretEndpointKey: []byte(endpoint),
 		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(port)),
 		xpv1.ResourceCredentialsSecretUserKey:     []byte(username),
-		xpv1.ResourceCredentialsSecretPasswordKey: []byte(password),
 		"readerEndpoint":                          []byte(readerEndpoint),
 	}
+	if password != "" {
+		mcd[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(password)
+	}
+	return mcd
 }
 
 func TestObserve(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Steven Borrelli <steve@borrelli.org>


### Description of your changes

Add `autogenPassword` functionality (similar to RDS) to docdb clusters.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested using an EC2 instance mongo client with the generated password:

```console
mongosh --tls --host example-cluster-autogen-password.cluster-czjq0bppekwt.us-east-1.docdb.amazonaws.com:27017 --tlsCAFile rds-combined-ca-bundle.pem --username master --password $PW
Current Mongosh Log ID:	63b8ab77e42f14df6bca2c7a
Connecting to:		mongodb://<credentials>@example-cluster-autogen-password.cluster-czjq0bppekwt.us-east-1.docdb.amazonaws.com:27017/?directConnection=true&tls=true&tlsCAFile=rds-combined-ca-bundle.pem&appName=mongosh+1.6.1
Using MongoDB:		4.0.0
Using Mongosh:		1.6.1


rs0 [direct: primary] test> 

```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
