### PR TITLE
fix(kafka): add clusterName because of api-changes

### DIFF
--- a/apis/kafka/generator-config.yaml
+++ b/apis/kafka/generator-config.yaml
@@ -3,7 +3,6 @@ ignore:
     - ClusterV2
   field_paths:
     - CreateClusterInput.BrokerNodeGroupInfo
-    - CreateClusterInput.ClusterName
     - CreateClusterInput.ConfigurationInfo
     - CreateConfigurationInput.Name
     - CreateConfigurationInput.ServerProperties

--- a/apis/kafka/v1alpha1/zz_cluster.go
+++ b/apis/kafka/v1alpha1/zz_cluster.go
@@ -31,6 +31,9 @@ type ClusterParameters struct {
 	Region string `json:"region"`
 	// Includes all client authentication related information.
 	ClientAuthentication *ClientAuthentication `json:"clientAuthentication,omitempty"`
+	// The name of the cluster.
+	// +kubebuilder:validation:Required
+	ClusterName *string `json:"clusterName"`
 	// Includes all encryption-related information.
 	EncryptionInfo *EncryptionInfo `json:"encryptionInfo,omitempty"`
 	// Specifies the level of monitoring for the MSK cluster. The possible values
@@ -61,8 +64,6 @@ type ClusterSpec struct {
 type ClusterObservation struct {
 	// The Amazon Resource Name (ARN) of the cluster.
 	ClusterARN *string `json:"clusterARN,omitempty"`
-	// The name of the MSK cluster.
-	ClusterName *string `json:"clusterName,omitempty"`
 	// The state of the cluster. The possible states are ACTIVE, CREATING, DELETING,
 	// FAILED, HEALING, MAINTENANCE, REBOOTING_BROKER, and UPDATING.
 	State *string `json:"state,omitempty"`

--- a/apis/kafka/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/kafka/v1alpha1/zz_generated.deepcopy.go
@@ -455,11 +455,6 @@ func (in *ClusterObservation) DeepCopyInto(out *ClusterObservation) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.ClusterName != nil {
-		in, out := &in.ClusterName, &out.ClusterName
-		*out = new(string)
-		**out = **in
-	}
 	if in.State != nil {
 		in, out := &in.State, &out.State
 		*out = new(string)
@@ -572,6 +567,11 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		in, out := &in.ClientAuthentication, &out.ClientAuthentication
 		*out = new(ClientAuthentication)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.ClusterName != nil {
+		in, out := &in.ClusterName, &out.ClusterName
+		*out = new(string)
+		**out = **in
 	}
 	if in.EncryptionInfo != nil {
 		in, out := &in.EncryptionInfo, &out.EncryptionInfo

--- a/examples/kafka/cluster.yaml
+++ b/examples/kafka/cluster.yaml
@@ -5,6 +5,7 @@ metadata:
   name: example
 spec:
   forProvider:
+    clusterName: example
     region: us-east-1
     brokerNodeGroupInfo:
       clientSubnetRefs:

--- a/package/crds/kafka.aws.crossplane.io_clusters.yaml
+++ b/package/crds/kafka.aws.crossplane.io_clusters.yaml
@@ -293,6 +293,9 @@ spec:
                             type: boolean
                         type: object
                     type: object
+                  clusterName:
+                    description: The name of the cluster.
+                    type: string
                   configurationInfo:
                     description: Represents the configuration that you want MSK to
                       use for the cluster.
@@ -479,6 +482,7 @@ spec:
                     description: Create tags when creating the cluster.
                     type: object
                 required:
+                - clusterName
                 - kafkaVersion
                 - numberOfBrokerNodes
                 - region
@@ -662,9 +666,6 @@ spec:
                 properties:
                   clusterARN:
                     description: The Amazon Resource Name (ARN) of the cluster.
-                    type: string
-                  clusterName:
-                    description: The name of the MSK cluster.
                     type: string
                   state:
                     description: The state of the cluster. The possible states are

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -39,7 +39,6 @@ func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ClusterGroupKind)
 	opts := []option{
 		func(e *external) {
-			e.preObserve = preObserve
 			e.postObserve = postObserve
 			e.preDelete = preDelete
 			e.postDelete = postDelete
@@ -84,11 +83,6 @@ func postDelete(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.DeleteCl
 	return err
 }
 
-func preObserve(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.DescribeClusterInput) error {
-	obj.ClusterArn = awsclients.String(meta.GetExternalName(cr))
-	return nil
-}
-
 func postObserve(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.DescribeClusterOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
 	if err != nil {
 		return managed.ExternalObservation{}, err
@@ -118,7 +112,6 @@ func postObserve(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.Describ
 }
 
 func preCreate(_ context.Context, cr *svcapitypes.Cluster, obj *svcsdk.CreateClusterInput) error {
-	obj.ClusterName = awsclients.String(meta.GetExternalName(cr))
 	obj.BrokerNodeGroupInfo = &svcsdk.BrokerNodeGroupInfo{
 		ClientSubnets:  cr.Spec.ForProvider.CustomBrokerNodeGroupInfo.ClientSubnets,
 		InstanceType:   cr.Spec.ForProvider.CustomBrokerNodeGroupInfo.InstanceType,

--- a/pkg/controller/kafka/cluster/zz_controller.go
+++ b/pkg/controller/kafka/cluster/zz_controller.go
@@ -120,9 +120,9 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 		cr.Status.AtProvider.ClusterARN = nil
 	}
 	if resp.ClusterName != nil {
-		cr.Status.AtProvider.ClusterName = resp.ClusterName
+		cr.Spec.ForProvider.ClusterName = resp.ClusterName
 	} else {
-		cr.Status.AtProvider.ClusterName = nil
+		cr.Spec.ForProvider.ClusterName = nil
 	}
 	if resp.State != nil {
 		cr.Status.AtProvider.State = resp.State

--- a/pkg/controller/kafka/cluster/zz_conversions.go
+++ b/pkg/controller/kafka/cluster/zz_conversions.go
@@ -97,9 +97,9 @@ func GenerateCluster(resp *svcsdk.DescribeClusterOutput) *svcapitypes.Cluster {
 		cr.Status.AtProvider.ClusterARN = nil
 	}
 	if resp.ClusterInfo.ClusterName != nil {
-		cr.Status.AtProvider.ClusterName = resp.ClusterInfo.ClusterName
+		cr.Spec.ForProvider.ClusterName = resp.ClusterInfo.ClusterName
 	} else {
-		cr.Status.AtProvider.ClusterName = nil
+		cr.Spec.ForProvider.ClusterName = nil
 	}
 	if resp.ClusterInfo.EncryptionInfo != nil {
 		f8 := &svcapitypes.EncryptionInfo{}
@@ -270,26 +270,29 @@ func GenerateCreateClusterInput(cr *svcapitypes.Cluster) *svcsdk.CreateClusterIn
 		}
 		res.SetClientAuthentication(f0)
 	}
+	if cr.Spec.ForProvider.ClusterName != nil {
+		res.SetClusterName(*cr.Spec.ForProvider.ClusterName)
+	}
 	if cr.Spec.ForProvider.EncryptionInfo != nil {
-		f1 := &svcsdk.EncryptionInfo{}
+		f2 := &svcsdk.EncryptionInfo{}
 		if cr.Spec.ForProvider.EncryptionInfo.EncryptionAtRest != nil {
-			f1f0 := &svcsdk.EncryptionAtRest{}
+			f2f0 := &svcsdk.EncryptionAtRest{}
 			if cr.Spec.ForProvider.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyID != nil {
-				f1f0.SetDataVolumeKMSKeyId(*cr.Spec.ForProvider.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyID)
+				f2f0.SetDataVolumeKMSKeyId(*cr.Spec.ForProvider.EncryptionInfo.EncryptionAtRest.DataVolumeKMSKeyID)
 			}
-			f1.SetEncryptionAtRest(f1f0)
+			f2.SetEncryptionAtRest(f2f0)
 		}
 		if cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit != nil {
-			f1f1 := &svcsdk.EncryptionInTransit{}
+			f2f1 := &svcsdk.EncryptionInTransit{}
 			if cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit.ClientBroker != nil {
-				f1f1.SetClientBroker(*cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit.ClientBroker)
+				f2f1.SetClientBroker(*cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit.ClientBroker)
 			}
 			if cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit.InCluster != nil {
-				f1f1.SetInCluster(*cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit.InCluster)
+				f2f1.SetInCluster(*cr.Spec.ForProvider.EncryptionInfo.EncryptionInTransit.InCluster)
 			}
-			f1.SetEncryptionInTransit(f1f1)
+			f2.SetEncryptionInTransit(f2f1)
 		}
-		res.SetEncryptionInfo(f1)
+		res.SetEncryptionInfo(f2)
 	}
 	if cr.Spec.ForProvider.EnhancedMonitoring != nil {
 		res.SetEnhancedMonitoring(*cr.Spec.ForProvider.EnhancedMonitoring)
@@ -298,79 +301,79 @@ func GenerateCreateClusterInput(cr *svcapitypes.Cluster) *svcsdk.CreateClusterIn
 		res.SetKafkaVersion(*cr.Spec.ForProvider.KafkaVersion)
 	}
 	if cr.Spec.ForProvider.LoggingInfo != nil {
-		f4 := &svcsdk.LoggingInfo{}
+		f5 := &svcsdk.LoggingInfo{}
 		if cr.Spec.ForProvider.LoggingInfo.BrokerLogs != nil {
-			f4f0 := &svcsdk.BrokerLogs{}
+			f5f0 := &svcsdk.BrokerLogs{}
 			if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs != nil {
-				f4f0f0 := &svcsdk.CloudWatchLogs{}
+				f5f0f0 := &svcsdk.CloudWatchLogs{}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs.Enabled != nil {
-					f4f0f0.SetEnabled(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs.Enabled)
+					f5f0f0.SetEnabled(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs.Enabled)
 				}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs.LogGroup != nil {
-					f4f0f0.SetLogGroup(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs.LogGroup)
+					f5f0f0.SetLogGroup(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.CloudWatchLogs.LogGroup)
 				}
-				f4f0.SetCloudWatchLogs(f4f0f0)
+				f5f0.SetCloudWatchLogs(f5f0f0)
 			}
 			if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose != nil {
-				f4f0f1 := &svcsdk.Firehose{}
+				f5f0f1 := &svcsdk.Firehose{}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose.DeliveryStream != nil {
-					f4f0f1.SetDeliveryStream(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose.DeliveryStream)
+					f5f0f1.SetDeliveryStream(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose.DeliveryStream)
 				}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose.Enabled != nil {
-					f4f0f1.SetEnabled(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose.Enabled)
+					f5f0f1.SetEnabled(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.Firehose.Enabled)
 				}
-				f4f0.SetFirehose(f4f0f1)
+				f5f0.SetFirehose(f5f0f1)
 			}
 			if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3 != nil {
-				f4f0f2 := &svcsdk.S3{}
+				f5f0f2 := &svcsdk.S3{}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Bucket != nil {
-					f4f0f2.SetBucket(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Bucket)
+					f5f0f2.SetBucket(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Bucket)
 				}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Enabled != nil {
-					f4f0f2.SetEnabled(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Enabled)
+					f5f0f2.SetEnabled(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Enabled)
 				}
 				if cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Prefix != nil {
-					f4f0f2.SetPrefix(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Prefix)
+					f5f0f2.SetPrefix(*cr.Spec.ForProvider.LoggingInfo.BrokerLogs.S3.Prefix)
 				}
-				f4f0.SetS3(f4f0f2)
+				f5f0.SetS3(f5f0f2)
 			}
-			f4.SetBrokerLogs(f4f0)
+			f5.SetBrokerLogs(f5f0)
 		}
-		res.SetLoggingInfo(f4)
+		res.SetLoggingInfo(f5)
 	}
 	if cr.Spec.ForProvider.NumberOfBrokerNodes != nil {
 		res.SetNumberOfBrokerNodes(*cr.Spec.ForProvider.NumberOfBrokerNodes)
 	}
 	if cr.Spec.ForProvider.OpenMonitoring != nil {
-		f6 := &svcsdk.OpenMonitoringInfo{}
+		f7 := &svcsdk.OpenMonitoringInfo{}
 		if cr.Spec.ForProvider.OpenMonitoring.Prometheus != nil {
-			f6f0 := &svcsdk.PrometheusInfo{}
+			f7f0 := &svcsdk.PrometheusInfo{}
 			if cr.Spec.ForProvider.OpenMonitoring.Prometheus.JmxExporter != nil {
-				f6f0f0 := &svcsdk.JmxExporterInfo{}
+				f7f0f0 := &svcsdk.JmxExporterInfo{}
 				if cr.Spec.ForProvider.OpenMonitoring.Prometheus.JmxExporter.EnabledInBroker != nil {
-					f6f0f0.SetEnabledInBroker(*cr.Spec.ForProvider.OpenMonitoring.Prometheus.JmxExporter.EnabledInBroker)
+					f7f0f0.SetEnabledInBroker(*cr.Spec.ForProvider.OpenMonitoring.Prometheus.JmxExporter.EnabledInBroker)
 				}
-				f6f0.SetJmxExporter(f6f0f0)
+				f7f0.SetJmxExporter(f7f0f0)
 			}
 			if cr.Spec.ForProvider.OpenMonitoring.Prometheus.NodeExporter != nil {
-				f6f0f1 := &svcsdk.NodeExporterInfo{}
+				f7f0f1 := &svcsdk.NodeExporterInfo{}
 				if cr.Spec.ForProvider.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker != nil {
-					f6f0f1.SetEnabledInBroker(*cr.Spec.ForProvider.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker)
+					f7f0f1.SetEnabledInBroker(*cr.Spec.ForProvider.OpenMonitoring.Prometheus.NodeExporter.EnabledInBroker)
 				}
-				f6f0.SetNodeExporter(f6f0f1)
+				f7f0.SetNodeExporter(f7f0f1)
 			}
-			f6.SetPrometheus(f6f0)
+			f7.SetPrometheus(f7f0)
 		}
-		res.SetOpenMonitoring(f6)
+		res.SetOpenMonitoring(f7)
 	}
 	if cr.Spec.ForProvider.Tags != nil {
-		f7 := map[string]*string{}
-		for f7key, f7valiter := range cr.Spec.ForProvider.Tags {
-			var f7val string
-			f7val = *f7valiter
-			f7[f7key] = &f7val
+		f8 := map[string]*string{}
+		for f8key, f8valiter := range cr.Spec.ForProvider.Tags {
+			var f8val string
+			f8val = *f8valiter
+			f8[f8key] = &f8val
 		}
-		res.SetTags(f7)
+		res.SetTags(f8)
 	}
 
 	return res


### PR DESCRIPTION
Signed-off-by: Christopher Paul Haar <christopherpaul.haar@dkb.de>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
fix(kafka): add clusterName because of api-changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1612
replace: #1620

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```
kubectl get managed

NAME                                      READY   SYNCED   EXTERNAL-NAME
cluster.kafka.aws.crossplane.io/example   True   True     arn:aws:kafka:us-east-1:12345678910:cluster/example/cef294f9-8e22-4342-9bfd-9635fcaeaebb-9

NAME                                                          READY   SYNCED   EXTERNAL-NAME
configuration.kafka.aws.crossplane.io/example-configuration   True    True     arn:aws:kafka:us-east-1:12345678910:configuration/example-configuration/73a88bf4-8aee-485e-b004-a788735643d4-9
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
