### PR TITLE
feat(logger): changed logger to ISO8601TimeEncoder

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/crossplane-contrib/provider-aws/apis"
 	"github.com/crossplane-contrib/provider-aws/apis/v1alpha1"
@@ -56,7 +57,7 @@ func main() {
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	zl := zap.New(zap.UseDevMode(*debug))
+	zl := zap.New(zap.UseDevMode(*debug), UseISO8601())
 	log := logging.NewLogrLogger(zl.WithName("provider-aws"))
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is
@@ -119,4 +120,11 @@ func main() {
 	kingpin.FatalIfError(controller.Setup(mgr, o), "Cannot setup AWS controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 
+}
+
+// UseISO8601 sets the logger to use ISO8601 timestamp format
+func UseISO8601() zap.Opts {
+	return func(o *zap.Options) {
+		o.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/onsi/gomega v1.17.0
 	github.com/pkg/errors v0.9.1
+	go.uber.org/zap v1.19.1
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.23.0
@@ -124,7 +125,6 @@ require (
 	github.com/stretchr/testify v1.8.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
 	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect


### PR DESCRIPTION
Signed-off-by: Christopher Paul Haar <christopherpaul.haar@dkb.de>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
changed logger to ISO8601TimeEncoder

old:

```
1.6656692709539523e+09     DEBUG   provider-aws    External resource is up to date {"controller": "managed/subnet.ec2.aws.crossplane.io", "request": "/sample-subnet2", "uid": "99db324c-c44b-4395-b626-b1cbd543255e", "version": "1317437", "external-name": "subnet-0111adcde1b842c07", "requeue-after": "1.6656692755539544e+09 "}
```

new:

```
2023-01-10T09:43:02.292+0100    DEBUG   provider-aws    External resource is up to date {"controller": "managed/subnet.ec2.aws.crossplane.io", "request": "/sample-subnet2", "uid": "99db324c-c44b-4395-b626-b1cbd543255e", "version": "1317437", "external-name": "subnet-0111adcde1b842c07", "requeue-after": "2023-01-10T09:44:02.292+0100"}
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
