### PR TITLE
fix(eks): Add checks for custom AMIs to enable updates

### DIFF
--- a/pkg/clients/eks/nodegroup_test.go
+++ b/pkg/clients/eks/nodegroup_test.go
@@ -234,8 +234,10 @@ func TestGenerateUpdateNodeGroupVersionInput(t *testing.T) {
 				},
 			},
 			wantUpdate: false,
-			wantInput:  nil,
-		},
+			wantInput: &eks.UpdateNodegroupVersionInput{
+				ClusterName:   &clusterName,
+				NodegroupName: &ngName,
+			}},
 		"VersionChanged": {
 			args: args{
 				name: ngName,

--- a/pkg/controller/eks/nodegroup/controller.go
+++ b/pkg/controller/eks/nodegroup/controller.go
@@ -112,6 +112,10 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	current := cr.Spec.ForProvider.DeepCopy()
 	eks.LateInitializeNodeGroup(&cr.Spec.ForProvider, rsp.Nodegroup)
+	if current.AMIType != nil && *current.AMIType == "CUSTOM" {
+		cr.Spec.ForProvider.ReleaseVersion = rsp.Nodegroup.ReleaseVersion
+		cr.Spec.ForProvider.Version = rsp.Nodegroup.Version
+	}
 	if !reflect.DeepEqual(current, &cr.Spec.ForProvider) {
 		if err := e.kube.Update(ctx, cr); err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, errKubeUpdateFailed)


### PR DESCRIPTION
Signed-off-by: Adam Johnson <adamjohnson01@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This change enables updates to EKS NodeGroups that use custom AMIs. 

According to the [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html) on using `LaunchTemplates` with managed nodegroups

The following fields can't be set in the API if you specify an AMI ID:
- amiType
- releaseVersion
- version

I have updated the code to ignore releaseVersion and version when amiType is `CUSTOM` and  update the `NodeGroup` object in k8s with updated values when running `Observe`.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1632

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I have run the code in my local cluster and confirmed that it is now possible to update NodeGroups that use custom AMIs

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
