### PR TITLE
feat(servicediscovery): Add Update function for namespaces

### DIFF
--- a/apis/servicediscovery/v1alpha1/custom_types.go
+++ b/apis/servicediscovery/v1alpha1/custom_types.go
@@ -52,9 +52,14 @@ func (in *HTTPNamespace) GetDescription() *string {
 	return in.Spec.ForProvider.Description
 }
 
-// SetDescription sets the description.
-func (in *HTTPNamespace) SetDescription(d *string) {
-	in.Spec.ForProvider.Description = d
+// GetTTL returns the TTL.
+func (in *HTTPNamespace) GetTTL() *int64 {
+	return nil
+}
+
+// GetTags returns the tags.
+func (in *HTTPNamespace) GetTags() []*Tag {
+	return in.Spec.ForProvider.Tags
 }
 
 // GetOperationID returns the last operation id.
@@ -75,9 +80,17 @@ func (in *PrivateDNSNamespace) GetDescription() *string {
 	return in.Spec.ForProvider.Description
 }
 
-// SetDescription sets the description.
-func (in *PrivateDNSNamespace) SetDescription(d *string) {
-	in.Spec.ForProvider.Description = d
+// GetTTL returns the TTL.
+func (in *PrivateDNSNamespace) GetTTL() *int64 {
+	if in.Spec.ForProvider.Properties == nil || in.Spec.ForProvider.Properties.DNSProperties == nil || in.Spec.ForProvider.Properties.DNSProperties.SOA == nil {
+		return nil
+	}
+	return in.Spec.ForProvider.Properties.DNSProperties.SOA.TTL
+}
+
+// GetTags returns the tags.
+func (in *PrivateDNSNamespace) GetTags() []*Tag {
+	return in.Spec.ForProvider.Tags
 }
 
 // GetOperationID returns the last operation id.
@@ -98,7 +111,15 @@ func (in *PublicDNSNamespace) GetDescription() *string {
 	return in.Spec.ForProvider.Description
 }
 
-// SetDescription sets the description.
-func (in *PublicDNSNamespace) SetDescription(d *string) {
-	in.Spec.ForProvider.Description = d
+// GetTTL returns the TTL.
+func (in *PublicDNSNamespace) GetTTL() *int64 {
+	if in.Spec.ForProvider.Properties == nil || in.Spec.ForProvider.Properties.DNSProperties == nil || in.Spec.ForProvider.Properties.DNSProperties.SOA == nil {
+		return nil
+	}
+	return in.Spec.ForProvider.Properties.DNSProperties.SOA.TTL
+}
+
+// GetTags returns the tags.
+func (in *PublicDNSNamespace) GetTags() []*Tag {
+	return in.Spec.ForProvider.Tags
 }

--- a/pkg/clients/servicediscovery/fake/fake.go
+++ b/pkg/clients/servicediscovery/fake/fake.go
@@ -36,6 +36,12 @@ type MockServicediscoveryClient struct {
 	MockCreateHTTPNamespaceRequest func(*svcsdk.CreateHttpNamespaceInput) (*request.Request, *svcsdk.CreateHttpNamespaceOutput)
 	// MockDeleteNamespaceRequest is a function pointer
 	MockDeleteNamespaceRequest func(*svcsdk.DeleteNamespaceInput) (*request.Request, *svcsdk.DeleteNamespaceOutput)
+	// MockListTagsForResource is a function pointer
+	MockListTagsForResource func(*svcsdk.ListTagsForResourceInput) (*svcsdk.ListTagsForResourceOutput, error)
+	// MockUntagResource is a function pointer
+	MockUntagResource func(*svcsdk.UntagResourceInput) (*svcsdk.UntagResourceOutput, error)
+	// MockTagResource is a function pointer
+	MockTagResource func(*svcsdk.TagResourceInput) (*svcsdk.TagResourceOutput, error)
 }
 
 // CreatePrivateDnsNamespace is the interface function to call the mock function pointer
@@ -214,4 +220,28 @@ func (m *MockServicediscoveryClient) DeleteNamespaceRequest(input *svcsdk.Delete
 		return &request.Request{}, nil
 	}
 	return m.MockDeleteNamespaceRequest(input)
+}
+
+// ListTagsForResource is the interface function to call the mock function pointer
+func (m *MockServicediscoveryClient) ListTagsForResource(input *svcsdk.ListTagsForResourceInput) (*svcsdk.ListTagsForResourceOutput, error) { // nolint:golint
+	if m.MockListTagsForResource == nil {
+		return &svcsdk.ListTagsForResourceOutput{}, nil
+	}
+	return m.MockListTagsForResource(input)
+}
+
+// UntagResource is the interface function to call the mock function pointer
+func (m *MockServicediscoveryClient) UntagResource(input *svcsdk.UntagResourceInput) (*svcsdk.UntagResourceOutput, error) { // nolint:golint
+	if m.MockUntagResource == nil {
+		return &svcsdk.UntagResourceOutput{}, nil
+	}
+	return m.MockUntagResource(input)
+}
+
+// TagResource is the interface function to call the mock function pointer
+func (m *MockServicediscoveryClient) TagResource(input *svcsdk.TagResourceInput) (*svcsdk.TagResourceOutput, error) { // nolint:golint
+	if m.MockTagResource == nil {
+		return &svcsdk.TagResourceOutput{}, nil
+	}
+	return m.MockTagResource(input)
 }

--- a/pkg/controller/servicediscovery/commonnamespace/hooks.go
+++ b/pkg/controller/servicediscovery/commonnamespace/hooks.go
@@ -21,15 +21,15 @@ import (
 
 	svcsdk "github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/aws/aws-sdk-go/service/servicediscovery/servicediscoveryiface"
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-aws/apis/servicediscovery/v1alpha1"
 	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
@@ -40,6 +40,10 @@ const (
 	errGetNamespace               = "get-namespace failed"
 	errDeleteNamespace            = "delete-namespace failed"
 	errOperationResponseMalformed = "get-operation result malformed"
+
+	errListTagsForResource = "cannot list tags"
+	errRemoveTags          = "cannot remove tags"
+	errCreateTags          = "cannot create tags"
 )
 
 type namespace interface {
@@ -47,7 +51,8 @@ type namespace interface {
 	GetOperationID() *string
 	SetOperationID(*string)
 	GetDescription() *string
-	SetDescription(*string)
+	GetTTL() *int64
+	GetTags() []*v1alpha1.Tag
 }
 
 // NewHooks returns a new Hooks object.
@@ -94,7 +99,7 @@ func (h *Hooks) Observe(ctx context.Context, mg cpresource.Managed) (managed.Ext
 		}
 		switch awsclient.StringValue(opResp.Operation.Status) {
 		case "PENDING", "SUBMITTED":
-			return managed.ExternalObservation{ResourceExists: true}, nil
+			return managed.ExternalObservation{}, nil
 		case "FAIL":
 			cr.SetConditions(xpv1.Unavailable().WithMessage(awsclient.StringValue(opResp.Operation.ErrorMessage)))
 			return managed.ExternalObservation{}, nil
@@ -125,24 +130,54 @@ func (h *Hooks) Observe(ctx context.Context, mg cpresource.Managed) (managed.Ext
 	}
 	nsReqResp, err := h.client.GetNamespaceWithContext(ctx, nsInput)
 	if err != nil {
+		// Deleting is done
+		if cr.GetCondition(xpv1.TypeReady).Reason == xpv1.ReasonDeleting {
+			return managed.ExternalObservation{}, nil
+		}
 		cr.SetConditions(xpv1.Unavailable())
 		return managed.ExternalObservation{},
 			awsclient.Wrap(cpresource.Ignore(ActualIsNotFound, err), errGetNamespace)
 	}
 
+	// Deleting is still on-going.
+	if cr.GetCondition(xpv1.TypeReady).Reason == xpv1.ReasonDeleting {
+		return managed.ExternalObservation{
+			ResourceExists: true,
+		}, nil
+	}
+
 	cr.SetConditions(xpv1.Available())
 
-	lateInited := false
-	if awsclient.StringValue(cr.GetDescription()) == "" && awsclient.StringValue(nsReqResp.Namespace.Description) != "" {
-		cr.SetDescription(nsReqResp.Namespace.Description)
-		// set READY false
-		lateInited = true
+	upToDate := true
+	tagUpToDate, err := AreTagsUpToDate(h.client, cr.GetTags(), nsReqResp.Namespace.Arn)
+	if err != nil {
+		cr.SetConditions(xpv1.Unavailable())
+		return managed.ExternalObservation{
+				ResourceExists: true,
+			},
+			awsclient.Wrap(cpresource.Ignore(ActualIsNotFound, err), errListTagsForResource)
+	}
+	if !tagUpToDate {
+		// Update Tags
+		upToDate = false
+	}
+
+	if cr.GetDescription() != nil && // Ignore aws value if no description are set
+		awsclient.StringValue(cr.GetDescription()) != awsclient.StringValue(nsReqResp.Namespace.Description) {
+		// Update Description
+		upToDate = false
+	}
+
+	if cr.GetTTL() != nil && // Ignore aws value if no ttl are set
+		(nsReqResp.Namespace == nil || nsReqResp.Namespace.Properties == nil || nsReqResp.Namespace.Properties.DnsProperties == nil ||
+			awsclient.Int64Value(cr.GetTTL()) != awsclient.Int64Value(nsReqResp.Namespace.Properties.DnsProperties.SOA.TTL)) {
+		// Update TTL
+		upToDate = false
 	}
 
 	return managed.ExternalObservation{
-		ResourceExists:          true,
-		ResourceLateInitialized: lateInited,
-		ResourceUpToDate:        true, // Namespaces cannot be updated.
+		ResourceExists:   true,
+		ResourceUpToDate: upToDate,
 	}, nil
 }
 
@@ -182,4 +217,107 @@ func ActualIsNotFound(err error) bool {
 func IsDuplicateRequest(err error) bool {
 	var duplicateRequest *svcsdk.DuplicateRequest
 	return errors.As(err, &duplicateRequest)
+}
+
+// AreTagsUpToDate for spec and resourceName
+func AreTagsUpToDate(client servicediscoveryiface.ServiceDiscoveryAPI, spec []*v1alpha1.Tag, resourceName *string) (bool, error) {
+	current, err := ListTagsForResource(client, resourceName)
+	if err != nil {
+		return false, err
+	}
+
+	add, remove := DiffTags(spec, current)
+
+	return len(add) == 0 && len(remove) == 0, nil
+}
+
+// UpdateTagsForResource with resourceName
+func UpdateTagsForResource(client servicediscoveryiface.ServiceDiscoveryAPI, spec []*v1alpha1.Tag, cr v1.Object) error {
+
+	nsInput := &svcsdk.GetNamespaceInput{
+		Id: awsclient.String(meta.GetExternalName(cr)),
+	}
+
+	nsReqResp, err := client.GetNamespace(nsInput)
+	if err != nil {
+		return err
+	}
+
+	current, err := ListTagsForResource(client, nsReqResp.Namespace.Arn)
+	if err != nil {
+		return err
+	}
+
+	add, remove := DiffTags(spec, current)
+	if len(remove) != 0 {
+		if _, err := client.UntagResource(&svcsdk.UntagResourceInput{
+			ResourceARN: nsReqResp.Namespace.Arn,
+			TagKeys:     remove,
+		}); err != nil {
+			return errors.Wrap(err, errRemoveTags)
+		}
+	}
+	if len(add) != 0 {
+		if _, err := client.TagResource(&svcsdk.TagResourceInput{
+			ResourceARN: nsReqResp.Namespace.Arn,
+			Tags:        add,
+		}); err != nil {
+			return errors.Wrap(err, errCreateTags)
+		}
+	}
+
+	return nil
+}
+
+// ListTagsForResource for the given resource
+func ListTagsForResource(client servicediscoveryiface.ServiceDiscoveryAPI, resourceARN *string) ([]*svcsdk.Tag, error) {
+	req := &svcsdk.ListTagsForResourceInput{
+		ResourceARN: resourceARN,
+	}
+
+	resp, err := client.ListTagsForResource(req)
+	if err != nil {
+		return nil, errors.Wrap(err, errListTagsForResource)
+	}
+
+	return resp.Tags, nil
+}
+
+// DiffTags between spec and current
+func DiffTags(spec []*v1alpha1.Tag, current []*svcsdk.Tag) (addTags []*svcsdk.Tag, removeTags []*string) {
+	currentMap := make(map[string]string, len(current))
+	for _, t := range current {
+		currentMap[awsclient.StringValue(t.Key)] = awsclient.StringValue(t.Value)
+	}
+
+	specMap := make(map[string]string, len(spec))
+	for _, t := range spec {
+		key := awsclient.StringValue(t.Key)
+		val := awsclient.StringValue(t.Value)
+		specMap[key] = awsclient.StringValue(t.Value)
+
+		if currentVal, exists := currentMap[key]; exists {
+			if currentVal != val {
+				removeTags = append(removeTags, t.Key)
+				addTags = append(addTags, &svcsdk.Tag{
+					Key:   awsclient.String(key),
+					Value: awsclient.String(val),
+				})
+			}
+		} else {
+			addTags = append(addTags, &svcsdk.Tag{
+				Key:   awsclient.String(key),
+				Value: awsclient.String(val),
+			})
+		}
+	}
+
+	for _, t := range current {
+		key := awsclient.StringValue(t.Key)
+		if _, exists := specMap[key]; !exists {
+			removeTags = append(removeTags, awsclient.String(key))
+		}
+	}
+
+	return addTags, removeTags
 }


### PR DESCRIPTION
### Description of your changes

Implemented update and observe function to namespace controller for AWS Servicediscovery.
Remove write back option from AWS to “ForProvider" object.

This PR is based on #1433, which seems to be stale.

#### Possible updates:
httpnamespace

 - Description
 - Tags

privatednsnamespace, publicdnsnamespace

 - Description
 - Tags
 - TTL

Fixes #1395 
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Added unit test for tag update. All resources were tested manually (create, update, delete).

[contribution process]: https://git.io/fj2m9
