### PR TITLE
fix(kinesis): panic when enhanced metrics not defined

### DIFF
--- a/pkg/controller/kinesis/stream/setup.go
+++ b/pkg/controller/kinesis/stream/setup.go
@@ -143,6 +143,12 @@ func (u *updater) isUpToDate(cr *svcapitypes.Stream, obj *svcsdk.DescribeStreamO
 			return false, nil
 		}
 
+		// Prevent an out of range panic when enhanced metrics
+		// arent defined in the spec
+		if len(cr.Spec.ForProvider.EnhancedMetrics) == 0 {
+			cr.Spec.ForProvider.EnhancedMetrics = append(cr.Spec.ForProvider.EnhancedMetrics, &svcapitypes.EnhancedMetrics{})
+		}
+
 		createKey, deleteKey := DifferenceShardLevelMetrics(cr.Spec.ForProvider.EnhancedMetrics[0].ShardLevelMetrics, obj.StreamDescription.EnhancedMonitoring[0].ShardLevelMetrics)
 		if len(createKey) != 0 || len(deleteKey) != 0 {
 			return false, nil
@@ -256,6 +262,12 @@ func (u *updater) update(ctx context.Context, mg resource.Managed) (managed.Exte
 		}
 		// You can't make other updates to the data stream while it is being updated.
 		return managed.ExternalUpdate{}, nil
+	}
+
+	// Prevent an out of range panic when enhanced metrics
+	// arent defined in the spec
+	if len(cr.Spec.ForProvider.EnhancedMetrics) == 0 {
+		cr.Spec.ForProvider.EnhancedMetrics = append(cr.Spec.ForProvider.EnhancedMetrics, &svcapitypes.EnhancedMetrics{})
 	}
 
 	enableMetrics, disableMetrics := DifferenceShardLevelMetrics(cr.Spec.ForProvider.EnhancedMetrics[0].ShardLevelMetrics, obj.StreamDescription.EnhancedMonitoring[0].ShardLevelMetrics)


### PR DESCRIPTION
Signed-off-by: Alex Last <alexrichardlast@gmail.com>

### Description of your changes
Fixes #1246 an index out of range panic in the Kinesis controller, caused when `spec.forProvider.EnhancedMetrics` is not defined:

```
panic: runtime error: index out of range [0] with length 0

goroutine 830 [running]:
github.com/crossplane-contrib/provider-aws/pkg/controller/kinesis/stream.(*updater).isUpToDate(0xc000d613e0?, 0xc000f82900, 0xc00044e3f8)
	github.com/crossplane-contrib/provider-aws/pkg/controller/kinesis/stream/setup.go:146 +0x66d
github.com/crossplane-contrib/provider-aws/pkg/controller/kinesis/stream.(*external).Observe(0xc0007d2070, {0x3d491f0, 0xc000a65260}, {0x3d6a9a0?, 0xc000f82900})
	github.com/crossplane-contrib/provider-aws/pkg/controller/kinesis/stream/zz_controller.go:91 +0x2b0
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0xc0004bbb80, {0x3d49228, 0xc000a7cbd0}, {{{0x0?, 0x0?}, {0xc000ed0826?, 0x9?}}})
	github.com/crossplane/crossplane-runtime@v0.19.0-rc.0.0.20220930073209-84e629b95898/pkg/reconciler/managed/reconciler.go:780 +0x287f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc0004bbc30, {0x3d49228, 0xc000a7cba0}, {{{0x0?, 0x3529d60?}, {0xc000ed0826?, 0xc000dd95d0?}}})
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114 +0x27e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004bbc30, {0x3d49180, 0xc00063a700}, {0x3317a60?, 0xc000971100?})
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311 +0x349
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004bbc30, {0x3d49180, 0xc00063a700})
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:223 +0x31c
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- [x] Build running and testing on local cluster, working as expected


