### PR TITLE
Fix panic when ng.LaunchTemplate is nil

### DIFF
--- a/pkg/clients/eks/nodegroup.go
+++ b/pkg/clients/eks/nodegroup.go
@@ -284,7 +284,7 @@ func LateInitializeNodeGroup(in *manualv1alpha1.NodeGroupParameters, ng *ekstype
 	if ng.UpdateConfig != nil {
 		in.UpdateConfig.MaxUnavailable = awsclient.LateInitializeInt32Ptr(in.UpdateConfig.MaxUnavailable, ng.UpdateConfig.MaxUnavailable)
 	}
-	if in.LaunchTemplate != nil && ng.LaunchTemplate.Version != nil {
+	if in.LaunchTemplate != nil && ng.LaunchTemplate != nil && ng.LaunchTemplate.Version != nil {
 		in.LaunchTemplate.Version = awsclient.LateInitializeStringPtr(in.LaunchTemplate.Version, ng.LaunchTemplate.Version)
 	}
 	in.ReleaseVersion = awsclient.LateInitializeStringPtr(in.ReleaseVersion, ng.ReleaseVersion)


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When LaunchTemplate is nil at aws, but not nil at resource, this will panic.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x3662412]

goroutine 5134 [running]:
github.com/crossplane-contrib/provider-aws/pkg/clients/eks.LateInitializeNodeGroup(0xc03cb6d2c8, 0xc031b40fc0)
        github.com/crossplane-contrib/provider-aws/pkg/clients/eks/nodegroup.go:287 +0x432
github.com/crossplane-contrib/provider-aws/pkg/controller/eks/nodegroup.(*external).Observe(0xc03da49780, {0x6a47570, 0xc0418b7620}, {0x6a7ce58?, 0xc03cb6d180})
        github.com/crossplane-contrib/provider-aws/pkg/controller/eks/nodegroup/controller.go:114 +0x207
github.com/crossplane/crossplane-runtime/pkg/reconciler/managed.(*Reconciler).Reconcile(0xc000642bb0, {0x6a475a8, 0xc036f3c2d0}, {{{0x0?, 0x5e3ab60?}, {0xc005922740?, 0x30?}}})
        github.com/crossplane/crossplane-runtime@v0.19.0-rc.0.0.20220930073209-84e629b95898/pkg/reconciler/managed/reconciler.go:780 +0x287f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc000642c60, {0x6a475a8, 0xc036f3c210}, {{{0x0?, 0x5e3ab60?}, {0xc005922740?, 0x4041f4?}}})
        sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114 +0x27e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000642c60, {0x6a47500, 0xc000b40080}, {0x5911420?, 0xc005d5a740?})
        sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311 +0x349
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000642c60, {0x6a47500, 0xc000b40080})
        sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266 +0x1d9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:223 +0x31c
```

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
