### PR TITLE
Remove `masterUserPasswordSecretRef` as a required attribute

### DIFF
--- a/apis/rds/v1alpha1/custom_types.go
+++ b/apis/rds/v1alpha1/custom_types.go
@@ -193,8 +193,14 @@ type CustomDBClusterParameters struct {
 	// The password for the master database user. This password can contain any
 	// printable ASCII character except "/", """, or "@".
 	//
-	// Constraints: Must contain from 8 to 41 characters. Required.
-	MasterUserPasswordSecretRef *xpv1.SecretKeySelector `json:"masterUserPasswordSecretRef"`
+	// This parameter will be required in the following scenarios:
+	// - The first cluster for a global Aurora cluster
+	// - Any cluster as long as it doesn't belong to a global Aurora cluster
+	//
+	// This parameter is required for creation of a primary cluster. However, it is not required when attaching a secondary regional cluster to an existing global cluster.
+	//
+	// Constraints: Must contain from 8 to 41 characters.
+	MasterUserPasswordSecretRef *xpv1.SecretKeySelector `json:"masterUserPasswordSecretRef,omitempty"`
 
 	// A list of VPC security groups that the DB cluster will belong to.
 	//

--- a/examples/rds/db-aurora-globalcluster-full.yaml
+++ b/examples/rds/db-aurora-globalcluster-full.yaml
@@ -1,0 +1,165 @@
+# The following manifest will create a Global DB Aurora cluster with two Regional clusters
+# Primary Region: eu-west-2 with 2 nodes
+# Secondary Region: us-west-2 with 1 node
+#
+# It also creates two ClusterParameterGroups (one per region) to enable parallel query
+# and uses it for the cluster configuration.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-cluster-db-password
+type: Opaque
+data:
+  password: your-passwod
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBCluster
+metadata:
+  name: test-cluster-eu-west-2
+spec:
+  writeConnectionSecretToRef:
+    name: "test-cluster-eu-west-2-db-conn"
+  providerConfigRef:
+    name: default
+  forProvider:
+    applyImmediately: true
+    availabilityZones: ["eu-west-2a","eu-west-2b","eu-west-2c"]
+    backupRetentionPeriod: 10
+    dbSubnetGroupName: db-subnet-group-name
+    storageEncrypted: true
+    kmsKeyID: mrk-test-kms-id
+    enablePerformanceInsights: true
+    region: eu-west-2
+    engine: aurora-mysql
+    engineMode: provisioned
+    engineVersion: 8.0.mysql_aurora.3.03.0
+    enableCloudwatchLogsExports: ['audit','error','general','slowquery']
+    globalClusterIdentifier: test-cluster
+    masterUsername: admin
+    masterUserPasswordSecretRef:
+      name: "test-cluster-db-password"
+      key: password
+    skipFinalSnapshot: true
+    dbClusterParameterGroupName: test-cluster-eu-west-2-aurora-pg
+    vpcSecurityGroupIDs:
+      - vpc-sg-id
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBCluster
+metadata:
+  name: test-cluster-us-west-2
+spec:
+  writeConnectionSecretToRef:
+    name: "test-cluster-us-west-2-db-conn"
+  providerConfigRef:
+    name: default
+  forProvider:
+    applyImmediately: true
+    availabilityZones: ["us-west-2a","us-west-2b","us-west-2c"]
+    backupRetentionPeriod: 10
+    dbSubnetGroupName: moneywise_aurora_sg
+    storageEncrypted: true
+    kmsKeyID: mrk-test-kms-id
+    enablePerformanceInsights: true
+    region: us-west-2
+    engine: aurora-mysql
+    engineMode: provisioned
+    engineVersion: 8.0.mysql_aurora.3.03.0
+    enableCloudwatchLogsExports: ['audit','error','general','slowquery']
+    globalClusterIdentifier: test-cluster
+    skipFinalSnapshot: true
+    dbClusterParameterGroupName: test-cluster-us-west-2-aurora-pg
+    vpcSecurityGroupIDs:
+      - sg-081a9633ca227cac3
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBClusterParameterGroup
+metadata:
+  name: test-cluster-eu-west-2-aurora-pg
+spec:
+  forProvider:
+    region: eu-west-2
+    dbParameterGroupFamily: aurora-mysql8.0
+    description: Aurora MySQL 8 with Parallel Query
+    parameters:
+      - parameterName: aurora_parallel_query
+        parameterValue: '1'
+        applyMethod: immediate
+  providerConfigRef:
+    name: default
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBClusterParameterGroup
+metadata:
+  name: test-cluster-us-west-2-aurora-pg
+spec:
+  forProvider:
+    region: us-west-2
+    dbParameterGroupFamily: aurora-mysql8.0
+    description: Aurora MySQL 8 with Parallel Query
+    parameters:
+      - parameterName: aurora_parallel_query
+        parameterValue: '1'
+        applyMethod: immediate
+  providerConfigRef:
+    name: default
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBInstance
+metadata:
+  name: test-cluster-eu-west-2-0
+spec:
+  forProvider:
+    region: eu-west-2
+    dbInstanceClass: db.r5.large
+    engine: aurora-mysql
+    dbClusterIdentifier: test-cluster-eu-west-2
+    publiclyAccessible: true
+    enablePerformanceInsights: true
+  providerConfigRef:
+    name: default
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBInstance
+metadata:
+  name: test-cluster-eu-west-2-1
+spec:
+  forProvider:
+    region: eu-west-2
+    dbInstanceClass: db.r5.large
+    engine: aurora-mysql
+    dbClusterIdentifier: test-cluster-eu-west-2
+    publiclyAccessible: true
+    enablePerformanceInsights: true
+  providerConfigRef:
+    name: default
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: DBInstance
+metadata:
+  name: test-cluster-us-west-2-0
+spec:
+  forProvider:
+    region: us-west-2
+    dbInstanceClass: db.r5.large
+    engine: aurora-mysql
+    dbClusterIdentifier: test-cluster-us-west-2
+    publiclyAccessible: true
+    enablePerformanceInsights: true
+  providerConfigRef:
+    name: default
+---
+apiVersion: rds.aws.crossplane.io/v1alpha1
+kind: GlobalCluster
+metadata:
+  name: test-cluster
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    region: eu-west-2
+    engine: aurora-mysql
+    storageEncrypted: true
+    engineVersion: 8.0.mysql_aurora.3.03.0
+

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -664,8 +664,13 @@ spec:
                   masterUserPasswordSecretRef:
                     description: "The password for the master database user. This
                       password can contain any printable ASCII character except \"/\",
-                      \"\"\", or \"@\". \n Constraints: Must contain from 8 to 41
-                      characters. Required."
+                      \"\"\", or \"@\". \n This parameter will be required in the
+                      following scenarios: - The first cluster for a global Aurora
+                      cluster - Any cluster as long as it doesn't belong to a global
+                      Aurora cluster \n This parameter is required for creation of
+                      a primary cluster. However, it is not required when attaching
+                      a secondary regional cluster to an existing global cluster.
+                      \n Constraints: Must contain from 8 to 41 characters."
                     properties:
                       key:
                         description: The key to select.
@@ -1090,7 +1095,6 @@ spec:
                     type: array
                 required:
                 - engine
-                - masterUserPasswordSecretRef
                 - region
                 type: object
               providerConfigRef:


### PR DESCRIPTION
Fixes #1668

When creating an Aurora Global cluster with more than 2 regional clusters, the password attribute is mandatory for the first one, but not for the second one. Right now, it's impossible to create global cluster with more than 2 regional cluster.

If you avoid setting up the `masterUserPasswordSecretRef`, Crossplane CRD will complain because this field is required and won't let you create the resource.

If you set up the `masterUserPasswordSecretRef`, the AWS API will complain that the cluster can't be created with the following error message

```
create failed: cannot create DBCluster in AWS: InvalidParameterCombination: Cannot specify password for cross region replication cluster
```