### PR TITLE
fix(rds): include caCertificateIdentifier in lateInitialize for dbinstance

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -285,6 +285,7 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 	}
 	in.AutoMinorVersionUpgrade = aws.LateInitializeBoolPtr(in.AutoMinorVersionUpgrade, db.AutoMinorVersionUpgrade)
 	in.AvailabilityZone = aws.LateInitializeStringPtr(in.AvailabilityZone, db.AvailabilityZone)
+	in.CACertificateIdentifier = aws.LateInitializeStringPtr(in.CACertificateIdentifier, db.CACertificateIdentifier)
 	in.CharacterSetName = aws.LateInitializeStringPtr(in.CharacterSetName, db.CharacterSetName)
 	in.DBName = aws.LateInitializeStringPtr(in.DBName, db.DBName)
 	in.EnablePerformanceInsights = aws.LateInitializeBoolPtr(in.EnablePerformanceInsights, db.PerformanceInsightsEnabled)


### PR DESCRIPTION
### Description of your changes

When setting the new `caCertificateIdentifier` parameter for `DBInstances` the resource is continually updated with the following:

```
Normal  UpdatedExternalResource  16m (x66 over 81m)   managed/dbinstance.rds.aws.crossplane.io  Successfully requested update of external resource
```

This ensures that `caCertificateIdentifier` is handled correctly in the `lateInitialize()` function.

I have:

- [x] Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- [x] Build running locally ensuring the parameter can be set as expected and updates of the external resource are not continually requested when there are no changes.
