### PR TITLE
fix(bucket): Remove policy resource autofill

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.1
 	sigs.k8s.io/controller-tools v0.11.1
 	sigs.k8s.io/yaml v1.3.0
@@ -154,6 +153,7 @@ require (
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/pkg/controller/s3/bucket/policy.go
+++ b/pkg/controller/s3/bucket/policy.go
@@ -23,7 +23,6 @@ import (
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"k8s.io/utils/strings/slices"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
@@ -128,19 +127,6 @@ func (e *PolicyClient) LateInitialize(ctx context.Context, cr *v1beta1.Bucket) e
 	//       inconsistencies between remote and local structures.
 	//       A manual converter needs to be written, pretty much the inverse of
 	//       s3.SerializeBucketPolicyStatement.
-
-	// The only thing that can be done easily is setting the resource field to
-	// the bucket ARN automaitcally since resource policies only apply to the
-	// object they are attached to.
-	bucketARN := cr.Status.AtProvider.ARN
-	if cr.Spec.ForProvider.Policy != nil && bucketARN != "" {
-		for i, statement := range cr.Spec.ForProvider.Policy.Statements {
-			if !slices.Contains(statement.Resource, bucketARN) {
-				statement.Resource = []string{bucketARN}
-				cr.Spec.ForProvider.Policy.Statements[i] = statement
-			}
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
### Description of your changes

Remove the policy autofill since it requires the ARN and is not available during bucket creation. Also the user might require to enter a string other than the bucket ARN.

Require the user to set the ARN himself.

Fixes #1716

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Sample resource

[contribution process]: https://git.io/fj2m9
