### PR TITLE
feat: add posibility for filtering controllers for applied crds

### DIFF
--- a/CODE_GENERATION.md
+++ b/CODE_GENERATION.md
@@ -98,6 +98,46 @@ The generated controller needs to be registered with the main controller manager
 of the provider. Create a file called `pkg/controller/<serviceid>/<managedResource>/setup.go` and
 add the setup function like the following:
 ```golang
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
 // SetupStage adds a controller that reconciles Stage.
 func SetupStage(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.StageGroupKind)
@@ -217,6 +257,11 @@ in generation and then inject the value of our annotation in its place in the SD
 Likely, we need to do this injection before every SDK call. The following is an
 example for hook functions injected:
 ```golang
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
 // SetupStage adds a controller that reconciles Stage.
 func SetupStage(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.StageGroupKind)

--- a/examples/ec2/securitygroup.yaml
+++ b/examples/ec2/securitygroup.yaml
@@ -19,28 +19,28 @@ spec:
           - cidrIp: 10.0.0.0/8
   providerConfigRef:
     name: example
----
-apiVersion: ec2.aws.crossplane.io/v1beta1
-kind: SecurityGroup
-metadata:
-  name: db-security-group
-spec:
-  forProvider:
-    region: us-east-1
-    vpcIdRef:
-      name: sample-vpc
-    groupName: db-sg
-    description: Enable rds access
-    egress:
-      # AWS will treat it as all ports any protocol
-      - ipProtocol: '-1'
-        ipRanges:
-          - cidrIp: 0.0.0.0/0
-    ingress:
-      - fromPort: 5432
-        ipProtocol: tcp
-        ipRanges:
-          - cidrIp: 10.0.0.0/8
-        toPort: 5432
-  providerConfigRef:
-    name: example
+# ---
+# apiVersion: ec2.aws.crossplane.io/v1beta1
+# kind: SecurityGroup
+# metadata:
+#   name: db-security-group
+# spec:
+#   forProvider:
+#     region: us-east-1
+#     vpcIdRef:
+#       name: sample-vpc
+#     groupName: db-sg
+#     description: Enable rds access
+#     egress:
+#       # AWS will treat it as all ports any protocol
+#       - ipProtocol: '-1'
+#         ipRanges:
+#           - cidrIp: 0.0.0.0/0
+#     ingress:
+#       - fromPort: 5432
+#         ipProtocol: tcp
+#         ipRanges:
+#           - cidrIp: 10.0.0.0/8
+#         toPort: 5432
+#   providerConfigRef:
+#     name: example

--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -57,6 +57,11 @@ const (
 	errRemoveTagsFailed = "failed to remove tags for Certificate"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.CertificateGroupKind
+}
+
 // SetupCertificate adds a controller that reconciles Certificates.
 func SetupCertificate(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.CertificateGroupKind)

--- a/pkg/controller/acmpca/certificateauthority/controller.go
+++ b/pkg/controller/acmpca/certificateauthority/controller.go
@@ -57,6 +57,11 @@ const (
 	errCertificateAuthority = "failed to update the ACMPCA resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.CertificateAuthorityGroupKind
+}
+
 // SetupCertificateAuthority adds a controller that reconciles ACMPCA.
 func SetupCertificateAuthority(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.CertificateAuthorityGroupKind)

--- a/pkg/controller/acmpca/certificateauthoritypermission/controller.go
+++ b/pkg/controller/acmpca/certificateauthoritypermission/controller.go
@@ -49,6 +49,11 @@ const (
 	errDelete           = "failed to delete the ACMPCA resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.CertificateAuthorityPermissionGroupKind
+}
+
 // SetupCertificateAuthorityPermission adds a controller that reconciles ACMPCA.
 func SetupCertificateAuthorityPermission(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.CertificateAuthorityPermissionGroupKind)

--- a/pkg/controller/apigateway/method/setup.go
+++ b/pkg/controller/apigateway/method/setup.go
@@ -20,6 +20,11 @@ import (
 	apigwclient "github.com/crossplane-contrib/provider-aws/pkg/clients/apigateway"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.MethodGroupKind
+}
+
 // SetupMethod adds a controller that reconciles Method.
 func SetupMethod(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.MethodGroupKind)

--- a/pkg/controller/apigateway/resource/setup.go
+++ b/pkg/controller/apigateway/resource/setup.go
@@ -37,6 +37,11 @@ import (
 	apigwclient "github.com/crossplane-contrib/provider-aws/pkg/clients/apigateway"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ResourceGroupKind
+}
+
 // SetupResource adds a controller that reconciles Resource.
 func SetupResource(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ResourceGroupKind)

--- a/pkg/controller/apigateway/restapi/setup.go
+++ b/pkg/controller/apigateway/restapi/setup.go
@@ -37,6 +37,11 @@ import (
 	apigwclient "github.com/crossplane-contrib/provider-aws/pkg/clients/apigateway"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RestAPIGroupKind
+}
+
 // SetupRestAPI adds a controller that reconciles RestAPI.
 func SetupRestAPI(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RestAPIGroupKind)

--- a/pkg/controller/apigatewayv2/api/setup.go
+++ b/pkg/controller/apigatewayv2/api/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.APIGroupKind
+}
+
 // SetupAPI adds a controller that reconciles API.
 func SetupAPI(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.APIGroupKind)

--- a/pkg/controller/apigatewayv2/apimapping/setup.go
+++ b/pkg/controller/apigatewayv2/apimapping/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.APIMappingGroupKind
+}
+
 // SetupAPIMapping adds a controller that reconciles APIMapping.
 func SetupAPIMapping(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.APIMappingGroupKind)

--- a/pkg/controller/apigatewayv2/authorizer/setup.go
+++ b/pkg/controller/apigatewayv2/authorizer/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.AuthorizerGroupKind
+}
+
 // SetupAuthorizer adds a controller that reconciles Authorizer.
 func SetupAuthorizer(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.AuthorizerGroupKind)

--- a/pkg/controller/apigatewayv2/deployment/setup.go
+++ b/pkg/controller/apigatewayv2/deployment/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DeploymentGroupKind
+}
+
 // SetupDeployment adds a controller that reconciles Deployment.
 func SetupDeployment(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DeploymentGroupKind)

--- a/pkg/controller/apigatewayv2/domainname/setup.go
+++ b/pkg/controller/apigatewayv2/domainname/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DomainNameGroupKind
+}
+
 // SetupDomainName adds a controller that reconciles DomainName.
 func SetupDomainName(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DomainNameGroupKind)

--- a/pkg/controller/apigatewayv2/integration/setup.go
+++ b/pkg/controller/apigatewayv2/integration/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.IntegrationGroupKind
+}
+
 // SetupIntegration adds a controller that reconciles Integration.
 func SetupIntegration(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.IntegrationGroupKind)

--- a/pkg/controller/apigatewayv2/integrationresponse/setup.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.IntegrationResponseGroupKind
+}
+
 // SetupIntegrationResponse adds a controller that reconciles IntegrationResponse.
 func SetupIntegrationResponse(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.IntegrationResponseGroupKind)

--- a/pkg/controller/apigatewayv2/model/setup.go
+++ b/pkg/controller/apigatewayv2/model/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ModelGroupKind
+}
+
 // SetupModel adds a controller that reconciles Model.
 func SetupModel(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ModelGroupKind)

--- a/pkg/controller/apigatewayv2/route/setup.go
+++ b/pkg/controller/apigatewayv2/route/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RouteGroupKind
+}
+
 // SetupRoute adds a controller that reconciles Route.
 func SetupRoute(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RouteGroupKind)

--- a/pkg/controller/apigatewayv2/routeresponse/setup.go
+++ b/pkg/controller/apigatewayv2/routeresponse/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RouteResponseGroupKind
+}
+
 // SetupRouteResponse adds a controller that reconciles RouteResponse.
 func SetupRouteResponse(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RouteResponseGroupKind)

--- a/pkg/controller/apigatewayv2/stage/setup.go
+++ b/pkg/controller/apigatewayv2/stage/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StageGroupKind
+}
+
 // SetupStage adds a controller that reconciles Stage.
 func SetupStage(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.StageGroupKind)

--- a/pkg/controller/apigatewayv2/vpclink/setup.go
+++ b/pkg/controller/apigatewayv2/vpclink/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.VPCLinkGroupKind
+}
+
 // SetupVPCLink adds a controller that reconciles VPCLink.
 func SetupVPCLink(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VPCLinkGroupKind)

--- a/pkg/controller/athena/workgroup/setup.go
+++ b/pkg/controller/athena/workgroup/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.WorkGroupGroupKind
+}
+
 // SetupWorkGroup adds a controller that reconciles WorkGroup.
 func SetupWorkGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.WorkGroupGroupKind)

--- a/pkg/controller/autoscaling/autoscalinggroup/setup.go
+++ b/pkg/controller/autoscaling/autoscalinggroup/setup.go
@@ -23,6 +23,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.AutoScalingGroupGroupKind
+}
+
 // SetupAutoScalingGroup adds a controller that reconciles AutoScalingGroup.
 func SetupAutoScalingGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.AutoScalingGroupGroupKind)

--- a/pkg/controller/batch/computeenvironment/setup.go
+++ b/pkg/controller/batch/computeenvironment/setup.go
@@ -35,6 +35,11 @@ import (
 	svcutils "github.com/crossplane-contrib/provider-aws/pkg/controller/batch"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ComputeEnvironmentGroupKind
+}
+
 // SetupComputeEnvironment adds a controller that reconciles a ComputeEnvironment.
 func SetupComputeEnvironment(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ComputeEnvironmentGroupKind)

--- a/pkg/controller/batch/job/controller.go
+++ b/pkg/controller/batch/job/controller.go
@@ -52,9 +52,14 @@ const (
 	errDescribeJob   = "cannot describe Batch Job"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.JobGroupKind
+}
+
 // SetupJob adds a controller that reconciles Jobs.
 func SetupJob(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.JobKind)
+	name := managed.ControllerName(svcapitypes.JobGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/batch/jobdefinition/controller.go
+++ b/pkg/controller/batch/jobdefinition/controller.go
@@ -53,9 +53,14 @@ const (
 	errDescribeJobDefinition   = "cannot describe Batch JobDefinition"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.JobDefinitionGroupKind
+}
+
 // SetupJobDefinition adds a controller that reconciles JobDefinitions.
 func SetupJobDefinition(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.JobDefinitionKind)
+	name := managed.ControllerName(svcapitypes.JobDefinitionGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/batch/jobqueue/setup.go
+++ b/pkg/controller/batch/jobqueue/setup.go
@@ -41,6 +41,11 @@ const (
 	errComputeEnvironmentARN = "missing or incorrect ARN for ComputeEnvironment"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.JobQueueGroupKind
+}
+
 // SetupJobQueue adds a controller that reconciles a JobQueue.
 func SetupJobQueue(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.JobQueueGroupKind)

--- a/pkg/controller/cache/cachesubnetgroup/controller.go
+++ b/pkg/controller/cache/cachesubnetgroup/controller.go
@@ -49,6 +49,11 @@ const (
 	errDeleteSubnetGroup   = "cannot delete Subnet Group"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return cachev1alpha1.CacheSubnetGroupGroupKind
+}
+
 // SetupCacheSubnetGroup adds a controller that reconciles SubnetGroups.
 func SetupCacheSubnetGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(cachev1alpha1.CacheSubnetGroupGroupKind)

--- a/pkg/controller/cache/cluster/controller.go
+++ b/pkg/controller/cache/cluster/controller.go
@@ -51,6 +51,11 @@ const (
 	errDeleteCacheCluster   = "cannot delete Cache Cluster"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return cachev1alpha1.CacheClusterGroupKind
+}
+
 // SetupCacheCluster adds a controller that reconciles CacheCluster.
 func SetupCacheCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(cachev1alpha1.CacheClusterGroupKind)

--- a/pkg/controller/cache/managed.go
+++ b/pkg/controller/cache/managed.go
@@ -62,6 +62,11 @@ const (
 	errReplicationGroupCacheClusterMaximum = "maximum of 5 replicas are allowed"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.ReplicationGroupGroupKind
+}
+
 // SetupReplicationGroup adds a controller that reconciles ReplicationGroups.
 func SetupReplicationGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.ReplicationGroupGroupKind)

--- a/pkg/controller/cloudfront/cachepolicy/setup.go
+++ b/pkg/controller/cloudfront/cachepolicy/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.CachePolicyGroupKind
+}
+
 // SetupCachePolicy adds a controller that reconciles CachePolicy.
 func SetupCachePolicy(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.CachePolicyGroupKind)

--- a/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/setup.go
+++ b/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.CloudFrontOriginAccessIdentityGroupKind
+}
+
 // SetupCloudFrontOriginAccessIdentity adds a controller that reconciles CloudFrontOriginAccessIdentity .
 func SetupCloudFrontOriginAccessIdentity(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.CloudFrontOriginAccessIdentityGroupKind)

--- a/pkg/controller/cloudfront/distribution/setup.go
+++ b/pkg/controller/cloudfront/distribution/setup.go
@@ -46,6 +46,11 @@ const (
 	stateDeployed = "Deployed"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DistributionGroupKind
+}
+
 // SetupDistribution adds a controller that reconciles Distribution.
 func SetupDistribution(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DistributionGroupKind)

--- a/pkg/controller/cloudfront/responseheaderspolicy/setup.go
+++ b/pkg/controller/cloudfront/responseheaderspolicy/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ResponseHeadersPolicyGroupKind
+}
+
 // SetupResponseHeadersPolicy adds a controller that reconciles ResponseHeadersPolicy.
 func SetupResponseHeadersPolicy(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ResponseHeadersPolicyGroupKind)

--- a/pkg/controller/cloudsearch/domain/setup.go
+++ b/pkg/controller/cloudsearch/domain/setup.go
@@ -47,6 +47,11 @@ const (
 	infoConditionProcessing = "currently processing"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DomainGroupKind
+}
+
 // SetupDomain adds a controller that reconciles CloudSearch domains.
 func SetupDomain(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DomainGroupKind)

--- a/pkg/controller/cloudwatchlogs/loggroup/setup.go
+++ b/pkg/controller/cloudwatchlogs/loggroup/setup.go
@@ -42,6 +42,11 @@ const (
 	errUntagResource = "cannot untag resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.LogGroupGroupKind
+}
+
 // SetupLogGroup adds a controller that reconciles LogGroup.
 func SetupLogGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.LogGroupGroupKind)

--- a/pkg/controller/cognitoidentity/identitypool/setup.go
+++ b/pkg/controller/cognitoidentity/identitypool/setup.go
@@ -34,6 +34,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.IdentityPoolGroupKind
+}
+
 // SetupIdentityPool adds a controller that reconciles IdentityPool.
 func SetupIdentityPool(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.IdentityPoolGroupKind)

--- a/pkg/controller/cognitoidentityprovider/group/setup.go
+++ b/pkg/controller/cognitoidentityprovider/group/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.GroupGroupKind
+}
+
 // SetupGroup adds a controller that reconciles Group.
 func SetupGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.GroupGroupKind)

--- a/pkg/controller/cognitoidentityprovider/groupusermembership/controller.go
+++ b/pkg/controller/cognitoidentityprovider/groupusermembership/controller.go
@@ -52,6 +52,11 @@ const (
 	errRemove    = "failed to remove the user to group"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.GroupUserMembershipGroupKind
+}
+
 // SetupGroupUserMembership adds a controller that reconciles
 // GroupUserMemberships.
 func SetupGroupUserMembership(mgr ctrl.Manager, o controller.Options) error {

--- a/pkg/controller/cognitoidentityprovider/identityprovider/setup.go
+++ b/pkg/controller/cognitoidentityprovider/identityprovider/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.IdentityProviderGroupKind
+}
+
 // SetupIdentityProvider adds a controller that reconciles IdentityProvider.
 func SetupIdentityProvider(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.IdentityProviderGroupKind)

--- a/pkg/controller/cognitoidentityprovider/resourceserver/setup.go
+++ b/pkg/controller/cognitoidentityprovider/resourceserver/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ResourceServerGroupKind
+}
+
 // SetupResourceServer adds a controller that reconciles Stage.
 func SetupResourceServer(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ResourceServerGroupKind)

--- a/pkg/controller/cognitoidentityprovider/userpool/setup.go
+++ b/pkg/controller/cognitoidentityprovider/userpool/setup.go
@@ -43,6 +43,11 @@ const (
 	errConflictingFields   = "fields conflicting! Please only use one of them or both with the same value"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.UserPoolGroupKind
+}
+
 // SetupUserPool adds a controller that reconciles UserPool.
 func SetupUserPool(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.UserPoolGroupKind)

--- a/pkg/controller/cognitoidentityprovider/userpoolclient/setup.go
+++ b/pkg/controller/cognitoidentityprovider/userpoolclient/setup.go
@@ -34,6 +34,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.UserPoolClientGroupKind
+}
+
 // SetupUserPoolClient adds a controller that reconciles UserPoolClient.
 func SetupUserPoolClient(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.UserPoolClientGroupKind)

--- a/pkg/controller/cognitoidentityprovider/userpooldomain/setup.go
+++ b/pkg/controller/cognitoidentityprovider/userpooldomain/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.UserPoolDomainGroupKind
+}
+
 // SetupUserPoolDomain adds a controller that reconciles User.
 func SetupUserPoolDomain(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.UserPoolDomainGroupKind)

--- a/pkg/controller/database/dbsubnetgroup/controller.go
+++ b/pkg/controller/database/dbsubnetgroup/controller.go
@@ -56,6 +56,11 @@ const (
 	errNotOne           = "expected exactly one DBSubnetGroup"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.DBSubnetGroupGroupKind
+}
+
 // SetupDBSubnetGroup adds a controller that reconciles DBSubnetGroups.
 func SetupDBSubnetGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.DBSubnetGroupGroupKind)

--- a/pkg/controller/database/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance.go
@@ -62,6 +62,11 @@ const (
 	errGetPasswordSecretFailed            = "cannot get password secret"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.RDSInstanceGroupKind
+}
+
 // SetupRDSInstance adds a controller that reconciles RDSInstances.
 func SetupRDSInstance(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.RDSInstanceGroupKind)

--- a/pkg/controller/dax/cluster/setup.go
+++ b/pkg/controller/dax/cluster/setup.go
@@ -18,6 +18,11 @@ import (
 	awsclients "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ClusterGroupKind
+}
+
 // SetupCluster adds a controller that reconciles Cluster.
 func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ClusterGroupKind)

--- a/pkg/controller/dax/parametergroup/setup.go
+++ b/pkg/controller/dax/parametergroup/setup.go
@@ -20,6 +20,11 @@ import (
 	awsclients "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ParameterGroupGroupKind
+}
+
 // SetupParameterGroup adds a controller that reconciles ParameterGroup.
 func SetupParameterGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ParameterGroupGroupKind)

--- a/pkg/controller/dax/subnetgroup/setup.go
+++ b/pkg/controller/dax/subnetgroup/setup.go
@@ -17,6 +17,11 @@ import (
 	awsclients "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.SubnetGroupGroupKind
+}
+
 // SetupSubnetGroup adds a controller that reconciles SubnetGroup.
 func SetupSubnetGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.SubnetGroupGroupKind)

--- a/pkg/controller/docdb/dbcluster/setup.go
+++ b/pkg/controller/docdb/dbcluster/setup.go
@@ -54,9 +54,14 @@ const (
 	errSaveSecretFailed        = "failed to save generated password to Kubernetes secret"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBClusterGroupKind
+}
+
 // SetupDBCluster adds a controller that reconciles a DBCluster.
 func SetupDBCluster(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.DBClusterKind)
+	name := managed.ControllerName(svcapitypes.DBClusterGroupKind)
 	opts := []option{setupExternal}
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}

--- a/pkg/controller/docdb/dbclusterparametergroup/setup.go
+++ b/pkg/controller/docdb/dbclusterparametergroup/setup.go
@@ -49,9 +49,14 @@ const (
 	errDescribeParameters         = "cannot describe parameters for DBClusterParameterGroup"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBClusterParameterGroupGroupKind
+}
+
 // SetupDBClusterParameterGroup adds a controller that reconciles a DBClusterParameterGroup.
 func SetupDBClusterParameterGroup(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.DBClusterParameterGroupKind)
+	name := managed.ControllerName(svcapitypes.DBClusterParameterGroupGroupKind)
 	opts := []option{setupExternal}
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}

--- a/pkg/controller/docdb/dbinstance/setup.go
+++ b/pkg/controller/docdb/dbinstance/setup.go
@@ -46,6 +46,11 @@ const (
 	errKubeUpdateFailed = "cannot update DocDB instance custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBInstanceGroupKind
+}
+
 // SetupDBInstance adds a controller that reconciles a DBInstance.
 func SetupDBInstance(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DBInstanceGroupKind)

--- a/pkg/controller/docdb/dbsubnetgroup/setup.go
+++ b/pkg/controller/docdb/dbsubnetgroup/setup.go
@@ -45,9 +45,14 @@ const (
 	errKubeUpdateFailed = "cannot update DocDBSubnetGroup custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBSubnetGroupGroupKind
+}
+
 // SetupDBSubnetGroup adds a controller that reconciles a DBSubnetGroup.
 func SetupDBSubnetGroup(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.DBSubnetGroupKind)
+	name := managed.ControllerName(svcapitypes.DBSubnetGroupGroupKind)
 	opts := []option{setupExternal}
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}

--- a/pkg/controller/dynamodb/backup/hooks.go
+++ b/pkg/controller/dynamodb/backup/hooks.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.BackupGroupKind
+}
+
 // SetupBackup adds a controller that reconciles Backup.
 func SetupBackup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.BackupGroupKind)

--- a/pkg/controller/dynamodb/globaltable/hooks.go
+++ b/pkg/controller/dynamodb/globaltable/hooks.go
@@ -40,6 +40,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.GlobalTableGroupKind
+}
+
 // SetupGlobalTable adds a controller that reconciles GlobalTable.
 func SetupGlobalTable(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.GlobalTableGroupKind)

--- a/pkg/controller/dynamodb/table/hooks.go
+++ b/pkg/controller/dynamodb/table/hooks.go
@@ -43,6 +43,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.TableGroupKind
+}
+
 // SetupTable adds a controller that reconciles Table.
 func SetupTable(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.TableGroupKind)

--- a/pkg/controller/ec2/address/controller.go
+++ b/pkg/controller/ec2/address/controller.go
@@ -56,6 +56,11 @@ const (
 	errStatusUpdate  = "cannot update status of Address custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.AddressGroupKind
+}
+
 // SetupAddress adds a controller that reconciles Address.
 func SetupAddress(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.AddressGroupKind)

--- a/pkg/controller/ec2/flowlog/setup.go
+++ b/pkg/controller/ec2/flowlog/setup.go
@@ -46,6 +46,11 @@ type deleter struct {
 	client ec2iface.EC2API
 }
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.FlowLogGroupKind
+}
+
 // SetupFlowLog adds a controller that reconciles FlowLog
 func SetupFlowLog(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.FlowLogGroupKind)

--- a/pkg/controller/ec2/instance/controller.go
+++ b/pkg/controller/ec2/instance/controller.go
@@ -56,6 +56,11 @@ const (
 	errDelete                   = "failed to delete the Instance resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.InstanceGroupKind
+}
+
 // SetupInstance adds a controller that reconciles Instances.
 func SetupInstance(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.InstanceGroupKind)

--- a/pkg/controller/ec2/internetgateway/controller.go
+++ b/pkg/controller/ec2/internetgateway/controller.go
@@ -55,6 +55,11 @@ const (
 	errCreateTags          = "failed to create tags for the InternetGateway resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.InternetGatewayGroupKind
+}
+
 // SetupInternetGateway adds a controller that reconciles InternetGateways.
 func SetupInternetGateway(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.InternetGatewayGroupKind)

--- a/pkg/controller/ec2/launchtemplate/setup.go
+++ b/pkg/controller/ec2/launchtemplate/setup.go
@@ -23,6 +23,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.LaunchTemplateGroupKind
+}
+
 // SetupLaunchTemplate adds a controller that reconciles LaunchTemplate.
 func SetupLaunchTemplate(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.LaunchTemplateGroupKind)

--- a/pkg/controller/ec2/launchtemplateversion/setup.go
+++ b/pkg/controller/ec2/launchtemplateversion/setup.go
@@ -21,6 +21,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.LaunchTemplateVersionGroupKind
+}
+
 // SetupLaunchTemplateVersion adds a controller that reconciles LaunchTemplateVersion.
 func SetupLaunchTemplateVersion(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.LaunchTemplateVersionGroupKind)

--- a/pkg/controller/ec2/natgateway/controller.go
+++ b/pkg/controller/ec2/natgateway/controller.go
@@ -36,6 +36,11 @@ const (
 	errDeleteTags       = "failed to delete tags for NATGateway resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.NATGatewayGroupKind
+}
+
 // SetupNatGateway adds a controller that reconciles NatGateways.
 func SetupNatGateway(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.NATGatewayGroupKind)

--- a/pkg/controller/ec2/route/setup.go
+++ b/pkg/controller/ec2/route/setup.go
@@ -26,6 +26,11 @@ const (
 	errMultipleItems = "retrieved multiple RouteTables for the given routeTableId"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RouteGroupKind
+}
+
 // SetupRoute adds a controller that reconciles Route.
 func SetupRoute(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RouteGroupKind)

--- a/pkg/controller/ec2/routetable/controller.go
+++ b/pkg/controller/ec2/routetable/controller.go
@@ -61,6 +61,11 @@ const (
 	errDeleteTags         = "failed to delete tags for the RouteTable resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.RouteTableGroupKind
+}
+
 // SetupRouteTable adds a controller that reconciles RouteTables.
 func SetupRouteTable(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.RouteTableGroupKind)

--- a/pkg/controller/ec2/securitygroup/controller.go
+++ b/pkg/controller/ec2/securitygroup/controller.go
@@ -63,6 +63,11 @@ const (
 	errDeleteTags       = "failed to delete tags for the Security Group resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.SecurityGroupGroupKind
+}
+
 // SetupSecurityGroup adds a controller that reconciles SecurityGroups.
 func SetupSecurityGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.SecurityGroupGroupKind)

--- a/pkg/controller/ec2/securitygrouprule/controller.go
+++ b/pkg/controller/ec2/securitygrouprule/controller.go
@@ -33,9 +33,14 @@ const (
 	egressType          = "egress"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return manualv1alpha1.SecurityGroupRuleGroupKind
+}
+
 // SetupSecurityGroupRule adds a controller that reconciles SecurityGroupRules.
 func SetupSecurityGroupRule(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(manualv1alpha1.SecurityGroupRuleKind)
+	name := managed.ControllerName(manualv1alpha1.SecurityGroupRuleGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/ec2/subnet/controller.go
+++ b/pkg/controller/ec2/subnet/controller.go
@@ -57,6 +57,11 @@ const (
 	errDeleteTags    = "failed to delete tags for the Subnet resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.SubnetGroupKind
+}
+
 // SetupSubnet adds a controller that reconciles Subnets.
 func SetupSubnet(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.SubnetGroupKind)

--- a/pkg/controller/ec2/transitgateway/setup.go
+++ b/pkg/controller/ec2/transitgateway/setup.go
@@ -28,6 +28,11 @@ const (
 	errKubeUpdateFailed = "cannot update TransitGateway"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.TransitGatewayGroupKind
+}
+
 // SetupTransitGateway adds a controller that reconciles TransitGateway.
 func SetupTransitGateway(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.TransitGatewayGroupKind)

--- a/pkg/controller/ec2/transitgatewayroute/setup.go
+++ b/pkg/controller/ec2/transitgatewayroute/setup.go
@@ -25,6 +25,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RouteGroupKind
+}
+
 // SetupTransitGatewayRoute adds a controller that reconciles TransitGatewayRoutes.
 func SetupTransitGatewayRoute(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RouteGroupKind)

--- a/pkg/controller/ec2/transitgatewayroutetable/setup.go
+++ b/pkg/controller/ec2/transitgatewayroutetable/setup.go
@@ -29,6 +29,11 @@ const (
 	errKubeUpdateFailed = "cannot update TransitGateway"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RouteGroupKind
+}
+
 // SetupTransitGatewayRouteTable adds a controller that reconciles TransitGatewayRouteTable.
 func SetupTransitGatewayRouteTable(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RouteGroupKind)

--- a/pkg/controller/ec2/transitgatewayvpcattachment/setup.go
+++ b/pkg/controller/ec2/transitgatewayvpcattachment/setup.go
@@ -29,6 +29,11 @@ const (
 	errKubeUpdateFailed = "cannot update TransitGatewayAttachment"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.TransitGatewayVPCAttachmentGroupKind
+}
+
 // SetupTransitGatewayVPCAttachment adds a controller that reconciles TransitGatewayVPCAttachment.
 func SetupTransitGatewayVPCAttachment(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.TransitGatewayVPCAttachmentGroupKind)

--- a/pkg/controller/ec2/volume/setup.go
+++ b/pkg/controller/ec2/volume/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.VolumeGroupKind
+}
+
 // SetupVolume adds a controller that reconciles Volume.
 func SetupVolume(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VolumeGroupKind)

--- a/pkg/controller/ec2/vpc/controller.go
+++ b/pkg/controller/ec2/vpc/controller.go
@@ -58,6 +58,11 @@ const (
 	errDelete              = "failed to delete the VPC resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.VPCGroupKind
+}
+
 // SetupVPC adds a controller that reconciles VPCs.
 func SetupVPC(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.VPCGroupKind)

--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -51,6 +51,11 @@ const (
 	errDisassociate     = "failed to disassociate the VPCCIDRBlock resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.VPCCIDRBlockGroupKind
+}
+
 // SetupVPCCIDRBlock adds a controller that reconciles VPCCIDRBlocks.
 func SetupVPCCIDRBlock(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.VPCCIDRBlockGroupKind)

--- a/pkg/controller/ec2/vpcendpoint/setup.go
+++ b/pkg/controller/ec2/vpcendpoint/setup.go
@@ -27,6 +27,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.VPCEndpointGroupKind
+}
+
 // SetupVPCEndpoint adds a controller that reconciles VPCEndpoint.
 func SetupVPCEndpoint(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VPCEndpointGroupKind)

--- a/pkg/controller/ec2/vpcendpointserviceconfiguration/setup.go
+++ b/pkg/controller/ec2/vpcendpointserviceconfiguration/setup.go
@@ -30,6 +30,11 @@ const (
 	errKubeUpdateFailed = "cannot update VPCEndpointServiceConfiguration"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.VPCEndpointServiceConfigurationGroupKind
+}
+
 // SetupVPCEndpointServiceConfiguration adds a controller that reconciles VPCEndpointServiceConfiguration.
 func SetupVPCEndpointServiceConfiguration(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VPCEndpointServiceConfigurationGroupKind)

--- a/pkg/controller/ec2/vpcpeeringconnection/setup.go
+++ b/pkg/controller/ec2/vpcpeeringconnection/setup.go
@@ -31,6 +31,11 @@ const (
 	errKubeUpdateFailed = "cannot update VPCPeeringConnection"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.VPCPeeringConnectionGroupKind
+}
+
 // SetupVPCPeeringConnection adds a controller that reconciles VPCPeeringConnection.
 func SetupVPCPeeringConnection(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VPCPeeringConnectionGroupKind)

--- a/pkg/controller/ecr/lifecyclepolicy/setup.go
+++ b/pkg/controller/ecr/lifecyclepolicy/setup.go
@@ -19,6 +19,11 @@ import (
 	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.LifecyclePolicyGroupKind
+}
+
 // SetupLifecyclePolicy adds a controller that reconciles LifecyclePolicy.
 func SetupLifecyclePolicy(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.LifecyclePolicyGroupKind)

--- a/pkg/controller/ecr/repository/controller.go
+++ b/pkg/controller/ecr/repository/controller.go
@@ -60,6 +60,11 @@ const (
 	errPatchCreationFailed = "cannot create a patch object"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.RepositoryGroupKind
+}
+
 // SetupRepository adds a controller that reconciles ECR.
 func SetupRepository(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.RepositoryGroupKind)

--- a/pkg/controller/ecr/repositorypolicy/controller.go
+++ b/pkg/controller/ecr/repositorypolicy/controller.go
@@ -48,6 +48,11 @@ const (
 	errDelete = "failed to delete the repository resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.RepositoryPolicyGroupKind
+}
+
 // SetupRepositoryPolicy adds a controller that reconciles ECR.
 func SetupRepositoryPolicy(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.RepositoryPolicyGroupKind)

--- a/pkg/controller/ecs/cluster/setup.go
+++ b/pkg/controller/ecs/cluster/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ClusterGroupKind
+}
+
 // SetupCluster adds a controller that reconciles Cluster.
 func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ClusterGroupKind)

--- a/pkg/controller/ecs/service/setup.go
+++ b/pkg/controller/ecs/service/setup.go
@@ -21,6 +21,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ServiceGroupKind
+}
+
 // SetupService adds a controller that reconciles Service.
 func SetupService(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ServiceGroupKind)

--- a/pkg/controller/ecs/taskdefinition/setup.go
+++ b/pkg/controller/ecs/taskdefinition/setup.go
@@ -21,6 +21,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.TaskDefinitionGroupKind
+}
+
 // SetupTaskDefinition adds a controller that reconciles TaskDefinition.
 func SetupTaskDefinition(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.TaskDefinitionGroupKind)

--- a/pkg/controller/efs/accesspoint/setup.go
+++ b/pkg/controller/efs/accesspoint/setup.go
@@ -17,6 +17,11 @@ import (
 	awsclients "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.AccessPointGroupKind
+}
+
 // SetupAccessPoint adds a controller that reconciles AccessPoint.
 func SetupAccessPoint(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.AccessPointGroupKind)

--- a/pkg/controller/efs/filesystem/setup.go
+++ b/pkg/controller/efs/filesystem/setup.go
@@ -21,6 +21,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.FileSystemGroupKind
+}
+
 // SetupFileSystem adds a controller that reconciles FileSystem.
 func SetupFileSystem(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.FileSystemGroupKind)

--- a/pkg/controller/efs/mounttarget/setup.go
+++ b/pkg/controller/efs/mounttarget/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.MountTargetGroupKind
+}
+
 // SetupMountTarget adds a controller that reconciles MountTarget.
 func SetupMountTarget(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.MountTargetGroupKind)

--- a/pkg/controller/eks/addon/setup.go
+++ b/pkg/controller/eks/addon/setup.go
@@ -46,6 +46,11 @@ const (
 	errUntagResource    = "cannot untag resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return eksv1alpha1.AddonGroupKind
+}
+
 // SetupAddon adds a controller that reconciles Clusters.
 func SetupAddon(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(eksv1alpha1.AddonGroupKind)

--- a/pkg/controller/eks/cluster.go
+++ b/pkg/controller/eks/cluster.go
@@ -55,6 +55,11 @@ const (
 	errUpToDateFailed      = "cannot check whether object is up-to-date"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.ClusterGroupKind
+}
+
 // SetupCluster adds a controller that reconciles Clusters.
 func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.ClusterGroupKind)

--- a/pkg/controller/eks/fargateprofile/controller.go
+++ b/pkg/controller/eks/fargateprofile/controller.go
@@ -50,9 +50,14 @@ const (
 	errDescribeFailed       = "cannot describe EKS fargate profile"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.FargateProfileGroupKind
+}
+
 // SetupFargateProfile adds a controller that reconciles FargateProfiles.
 func SetupFargateProfile(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(v1beta1.FargateProfileKind)
+	name := managed.ControllerName(v1beta1.FargateProfileGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/eks/identityproviderconfig/controller.go
+++ b/pkg/controller/eks/identityproviderconfig/controller.go
@@ -52,9 +52,14 @@ const (
 	errAddTagsFailed  = "cannot add tags to EKS identity provider config"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return manualv1alpha1.IdentityProviderConfigGroupKind
+}
+
 // SetupIdentityProviderConfig adds a controller that reconciles IdentityProviderConfigs.
 func SetupIdentityProviderConfig(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(manualv1alpha1.IdentityProviderConfigKind)
+	name := managed.ControllerName(manualv1alpha1.IdentityProviderConfigGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/eks/nodegroup/controller.go
+++ b/pkg/controller/eks/nodegroup/controller.go
@@ -53,9 +53,14 @@ const (
 	errDescribeFailed      = "cannot describe EKS node group"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return manualv1alpha1.NodeGroupGroupKind
+}
+
 // SetupNodeGroup adds a controller that reconciles NodeGroups.
 func SetupNodeGroup(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(manualv1alpha1.NodeGroupKind)
+	name := managed.ControllerName(manualv1alpha1.NodeGroupGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/elasticache/cacheparametergroup/setup.go
+++ b/pkg/controller/elasticache/cacheparametergroup/setup.go
@@ -40,9 +40,14 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.CacheParameterGroupGroupKind
+}
+
 // SetupCacheParameterGroup adds a controller that reconciles a CacheParameterGroup.
 func SetupCacheParameterGroup(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.CacheParameterGroupKind)
+	name := managed.ControllerName(svcapitypes.CacheParameterGroupGroupKind)
 	opts := []option{setupExternal}
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}

--- a/pkg/controller/elasticloadbalancing/elb/controller.go
+++ b/pkg/controller/elasticloadbalancing/elb/controller.go
@@ -55,6 +55,11 @@ const (
 	errUpToDate      = "cannot check if the resource is up to date"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return elasticloadbalancingv1alpha1.ELBGroupKind
+}
+
 // SetupELB adds a controller that reconciles ELBs.
 func SetupELB(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(elasticloadbalancingv1alpha1.ELBGroupKind)

--- a/pkg/controller/elasticloadbalancing/elbattachment/controller.go
+++ b/pkg/controller/elasticloadbalancing/elbattachment/controller.go
@@ -50,6 +50,11 @@ const (
 	errDelete        = "failed to deregister instance from the ELB"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return elasticloadbalancingv1alpha1.ELBAttachmentGroupKind
+}
+
 // SetupELBAttachment adds a controller that reconciles ELBAttachmets.
 func SetupELBAttachment(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(elasticloadbalancingv1alpha1.ELBAttachmentGroupKind)

--- a/pkg/controller/elbv2/listener/setup.go
+++ b/pkg/controller/elbv2/listener/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ListenerGroupKind
+}
+
 // SetupListener adds a controller that reconciles Listener.
 func SetupListener(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ListenerGroupKind)

--- a/pkg/controller/elbv2/loadbalancer/setup.go
+++ b/pkg/controller/elbv2/loadbalancer/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.LoadBalancerGroupKind
+}
+
 // SetupLoadBalancer adds a controller that reconciles LoadBalancer.
 func SetupLoadBalancer(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.LoadBalancerGroupKind)

--- a/pkg/controller/elbv2/target/controller.go
+++ b/pkg/controller/elbv2/target/controller.go
@@ -47,9 +47,14 @@ const (
 	errDescribeTargetHealthFailed      = "failed to describe target health"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return manualv1alpha1.TargetGroupKind
+}
+
 // SetupTarget adds a controller that reconciles Targets.
 func SetupTarget(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(manualv1alpha1.TargetKind)
+	name := managed.ControllerName(manualv1alpha1.TargetGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/elbv2/targetgroup/setup.go
+++ b/pkg/controller/elbv2/targetgroup/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.TargetGroupGroupKind
+}
+
 // SetupTargetGroup adds a controller that reconciles TargetGroup.
 func SetupTargetGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.TargetGroupGroupKind)

--- a/pkg/controller/emrcontainers/jobrun/setup.go
+++ b/pkg/controller/emrcontainers/jobrun/setup.go
@@ -25,9 +25,14 @@ const (
 	firstObserveJobRunID = "0000000000000000000"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.JobRunGroupKind
+}
+
 // SetupJobRun adds a controller that reconciles JobRun.
 func SetupJobRun(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.JobRunKind)
+	name := managed.ControllerName(svcapitypes.JobRunGroupKind)
 	opts := []option{
 		func(e *external) {
 			e.preCreate = preCreate

--- a/pkg/controller/emrcontainers/virtualcluster/setup.go
+++ b/pkg/controller/emrcontainers/virtualcluster/setup.go
@@ -31,6 +31,11 @@ const (
 	errTag            = "cannot add tags"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.VirtualClusterGroupKind
+}
+
 // SetupVirtualCluster adds a controller that reconciles VirtualCluster.
 func SetupVirtualCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VirtualClusterGroupKind)

--- a/pkg/controller/glue/classifier/setup.go
+++ b/pkg/controller/glue/classifier/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ClassifierGroupKind
+}
+
 // SetupClassifier adds a controller that reconciles Classifier.
 func SetupClassifier(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ClassifierGroupKind)

--- a/pkg/controller/glue/connection/setup.go
+++ b/pkg/controller/glue/connection/setup.go
@@ -50,6 +50,11 @@ const (
 	annotationARN     = "crossplane.io/external-aws-glue-connection-arn"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ConnectionGroupKind
+}
+
 // SetupConnection adds a controller that reconciles Connection.
 func SetupConnection(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ConnectionGroupKind)

--- a/pkg/controller/glue/crawler/setup.go
+++ b/pkg/controller/glue/crawler/setup.go
@@ -51,6 +51,11 @@ const (
 	annotationARN     = "crossplane.io/external-aws-glue-crawler-arn"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.CrawlerGroupKind
+}
+
 // SetupCrawler adds a controller that reconciles Crawler.
 func SetupCrawler(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.CrawlerGroupKind)

--- a/pkg/controller/glue/database/setup.go
+++ b/pkg/controller/glue/database/setup.go
@@ -44,6 +44,11 @@ const (
 	errCreateSameIdentifier = "cannot create Glue Database. Combine permissions for same principals under one createTableDefaultPermissions entry"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DatabaseGroupKind
+}
+
 // SetupDatabase adds a controller that reconciles Database.
 func SetupDatabase(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DatabaseGroupKind)

--- a/pkg/controller/glue/job/setup.go
+++ b/pkg/controller/glue/job/setup.go
@@ -50,6 +50,11 @@ const (
 	annotationARN     = "crossplane.io/external-aws-glue-job-arn"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.JobGroupKind
+}
+
 // SetupJob adds a controller that reconciles Job.
 func SetupJob(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.JobGroupKind)

--- a/pkg/controller/glue/securityconfiguration/setup.go
+++ b/pkg/controller/glue/securityconfiguration/setup.go
@@ -35,6 +35,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.SecurityConfigurationGroupKind
+}
+
 // SetupSecurityConfiguration adds a controller that reconciles SecurityConfiguration.
 func SetupSecurityConfiguration(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.SecurityConfigurationGroupKind)

--- a/pkg/controller/iam/accesskey/controller.go
+++ b/pkg/controller/iam/accesskey/controller.go
@@ -49,6 +49,11 @@ const (
 	errUpdate           = "failed to update the AccessKey resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.AccessKeyGroupKind
+}
+
 // SetupAccessKey adds a controller that reconciles AccessKeys.
 func SetupAccessKey(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.AccessKeyGroupKind)

--- a/pkg/controller/iam/group/controller.go
+++ b/pkg/controller/iam/group/controller.go
@@ -51,6 +51,11 @@ const (
 	errKubeUpdateFailed = "cannot late initialize IAM Group"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.GroupGroupKind
+}
+
 // SetupGroup adds a controller that reconciles Groups.
 func SetupGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.GroupGroupKind)

--- a/pkg/controller/iam/grouppolicyattachment/controller.go
+++ b/pkg/controller/iam/grouppolicyattachment/controller.go
@@ -50,6 +50,11 @@ const (
 	errDetach = "failed to detach the policy to group"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.GroupPolicyAttachmentGroupKind
+}
+
 // SetupGroupPolicyAttachment adds a controller that reconciles
 // GroupPolicyAttachments.
 func SetupGroupPolicyAttachment(mgr ctrl.Manager, o controller.Options) error {

--- a/pkg/controller/iam/groupusermembership/controller.go
+++ b/pkg/controller/iam/groupusermembership/controller.go
@@ -50,6 +50,11 @@ const (
 	errRemove = "failed to remove the user to group"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.GroupUserMembershipGroupKind
+}
+
 // SetupGroupUserMembership adds a controller that reconciles
 // GroupUserMemberships.
 func SetupGroupUserMembership(mgr ctrl.Manager, o controller.Options) error {

--- a/pkg/controller/iam/instanceprofile/setup.go
+++ b/pkg/controller/iam/instanceprofile/setup.go
@@ -37,6 +37,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.InstanceProfileGroupKind
+}
+
 // SetupInstanceProfile adds a controller that reconciles InstanceProfile.
 func SetupInstanceProfile(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.InstanceProfileGroupKind)

--- a/pkg/controller/iam/openidconnectprovider/controller.go
+++ b/pkg/controller/iam/openidconnectprovider/controller.go
@@ -61,6 +61,11 @@ const (
 	errKubeUpdateFailed = "cannot update OpenIDConnectProvider instance custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.OpenIDConnectProviderGroupKind
+}
+
 // SetupOpenIDConnectProvider adds a controller that reconciles OpenIDConnectProvider.
 func SetupOpenIDConnectProvider(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.OpenIDConnectProviderGroupKind)

--- a/pkg/controller/iam/policy/controller.go
+++ b/pkg/controller/iam/policy/controller.go
@@ -59,6 +59,11 @@ const (
 	errUntag            = "cannot untag policy"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.PolicyGroupKind
+}
+
 // SetupPolicy adds a controller that reconciles IAM Policy.
 func SetupPolicy(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.PolicyGroupKind)

--- a/pkg/controller/iam/role/controller.go
+++ b/pkg/controller/iam/role/controller.go
@@ -54,6 +54,11 @@ const (
 	errUpToDateFailed   = "cannot check whether object is up-to-date"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.RoleGroupKind
+}
+
 // SetupRole adds a controller that reconciles Roles.
 func SetupRole(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.RoleGroupKind)

--- a/pkg/controller/iam/rolepolicyattachment/controller.go
+++ b/pkg/controller/iam/rolepolicyattachment/controller.go
@@ -47,6 +47,11 @@ const (
 	errDetach           = "failed to detach the policy to role"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.RolePolicyAttachmentGroupKind
+}
+
 // SetupRolePolicyAttachment adds a controller that reconciles
 // RolePolicyAttachments.
 func SetupRolePolicyAttachment(mgr ctrl.Manager, o controller.Options) error {

--- a/pkg/controller/iam/user/controller.go
+++ b/pkg/controller/iam/user/controller.go
@@ -56,6 +56,11 @@ const (
 	errKubeUpdateFailed = "cannot late initialize IAM User"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.UserGroupKind
+}
+
 // SetupUser adds a controller that reconciles Users.
 func SetupUser(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.UserGroupKind)

--- a/pkg/controller/iam/userpolicyattachment/controller.go
+++ b/pkg/controller/iam/userpolicyattachment/controller.go
@@ -48,6 +48,11 @@ const (
 	errDetach = "failed to detach the policy to user"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.UserPolicyAttachmentGroupKind
+}
+
 // SetupUserPolicyAttachment adds a controller that reconciles
 // UserPolicyAttachments.
 func SetupUserPolicyAttachment(mgr ctrl.Manager, o controller.Options) error {

--- a/pkg/controller/iot/policy/setup.go
+++ b/pkg/controller/iot/policy/setup.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.PolicyGroupKind
+}
+
 // SetupPolicy adds a controller that reconciles Policy.
 func SetupPolicy(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.PolicyGroupKind)

--- a/pkg/controller/iot/thing/setup.go
+++ b/pkg/controller/iot/thing/setup.go
@@ -40,6 +40,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return iottypes.ThingGroupKind
+}
+
 // SetupThing adds a controller that reconciles Thing.
 func SetupThing(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(iottypes.ThingGroupKind)

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -34,6 +34,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ClusterGroupKind
+}
+
 // SetupCluster adds a controller that reconciles Cluster.
 func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ClusterGroupKind)

--- a/pkg/controller/kafka/configuration/setup.go
+++ b/pkg/controller/kafka/configuration/setup.go
@@ -34,6 +34,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ConfigurationGroupKind
+}
+
 // SetupConfiguration adds a controller that reconciles Configuration.
 func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ConfigurationGroupKind)

--- a/pkg/controller/kinesis/stream/setup.go
+++ b/pkg/controller/kinesis/stream/setup.go
@@ -35,6 +35,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StreamGroupKind
+}
+
 // SetupStream adds a controller that reconciles Stream.
 func SetupStream(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.StreamGroupKind)

--- a/pkg/controller/kms/alias/setup.go
+++ b/pkg/controller/kms/alias/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.AliasGroupKind
+}
+
 // SetupAlias adds a controller that reconciles Alias.
 func SetupAlias(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.AliasGroupKind)

--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -22,6 +22,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.KeyGroupKind
+}
+
 // SetupKey adds a controller that reconciles Key.
 func SetupKey(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.KeyGroupKind)

--- a/pkg/controller/lambda/function/setup.go
+++ b/pkg/controller/lambda/function/setup.go
@@ -37,6 +37,11 @@ const (
 	repositoryTypeS3  = "S3"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.FunctionGroupKind
+}
+
 // SetupFunction adds a controller that reconciles Function.
 func SetupFunction(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.FunctionGroupKind)

--- a/pkg/controller/lambda/functionurlconfig/setup.go
+++ b/pkg/controller/lambda/functionurlconfig/setup.go
@@ -23,6 +23,11 @@ import (
 	aws "github.com/crossplane-contrib/provider-aws/pkg/clients"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.FunctionURLConfigGroupKind
+}
+
 // SetupFunctionURL adds a controller that reconciles FunctionURLConfig.
 func SetupFunctionURL(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.FunctionURLConfigGroupKind)

--- a/pkg/controller/lambda/permission/controller.go
+++ b/pkg/controller/lambda/permission/controller.go
@@ -52,9 +52,14 @@ const (
 	errParsePolicy           = "cannot parse policy"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.PermissionGroupKind
+}
+
 // SetupPermission adds a controller that reconciles Permissions.
 func SetupPermission(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.PermissionKind)
+	name := managed.ControllerName(svcapitypes.PermissionGroupKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {

--- a/pkg/controller/mq/broker/setup.go
+++ b/pkg/controller/mq/broker/setup.go
@@ -26,6 +26,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.BrokerGroupKind
+}
+
 // SetupBroker adds a controller that reconciles Broker.
 func SetupBroker(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.BrokerGroupKind)

--- a/pkg/controller/mq/user/setup.go
+++ b/pkg/controller/mq/user/setup.go
@@ -25,6 +25,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.UserGroupKind
+}
+
 // SetupUser adds a controller that reconciles User.
 func SetupUser(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.UserGroupKind)

--- a/pkg/controller/mwaa/environment/setup.go
+++ b/pkg/controller/mwaa/environment/setup.go
@@ -32,6 +32,11 @@ const (
 	errUntagResource    = "cannot untag resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.EnvironmentGroupKind
+}
+
 // SetupEnvironment adds a controller that reconciles Environment.
 func SetupEnvironment(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.EnvironmentGroupKind)

--- a/pkg/controller/neptune/dbcluster/setup.go
+++ b/pkg/controller/neptune/dbcluster/setup.go
@@ -45,9 +45,14 @@ const (
 	statusUpdating  dbClusterStatus = "updating"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBClusterGroupKind
+}
+
 // SetupDBCluster adds a controller that reconciles DB Cluster.
 func SetupDBCluster(mgr ctrl.Manager, o controller.Options) error {
-	name := managed.ControllerName(svcapitypes.DBClusterKind)
+	name := managed.ControllerName(svcapitypes.DBClusterGroupKind)
 	opts := []option{
 		func(e *external) {
 			e.lateInitialize = lateInitialize

--- a/pkg/controller/opensearchservice/domain/setup.go
+++ b/pkg/controller/opensearchservice/domain/setup.go
@@ -24,6 +24,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DomainGroupKind
+}
+
 // SetupDomain adds a controller that reconciles Domain.
 func SetupDomain(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DomainGroupKind)

--- a/pkg/controller/prometheusservice/alertmanagerdefinition/setup.go
+++ b/pkg/controller/prometheusservice/alertmanagerdefinition/setup.go
@@ -24,6 +24,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.AlertManagerDefinitionGroupKind
+}
+
 // SetupAlertManagerDefinition adds a controller that reconciles AlertManagerDefinition.
 func SetupAlertManagerDefinition(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.AlertManagerDefinitionGroupKind)

--- a/pkg/controller/prometheusservice/rulegroupsnamespace/setup.go
+++ b/pkg/controller/prometheusservice/rulegroupsnamespace/setup.go
@@ -31,6 +31,11 @@ const (
 	errKubeUpdateFailed       = "cannot update RuleGroupsNamespace custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.RuleGroupsNamespaceGroupKind
+}
+
 // SetupRuleGroupsNamespace adds a controller that reconciles RuleGroupsNamespace.
 func SetupRuleGroupsNamespace(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.RuleGroupsNamespaceGroupKind)

--- a/pkg/controller/prometheusservice/workspace/setup.go
+++ b/pkg/controller/prometheusservice/workspace/setup.go
@@ -29,6 +29,11 @@ const (
 	errKubeUpdateFailed = "cannot update Workspace custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.WorkspaceGroupKind
+}
+
 // SetupWorkspace adds a controller that reconciles Workspace for PrometheusService.
 func SetupWorkspace(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.WorkspaceGroupKind)

--- a/pkg/controller/ram/resourceshare/setup.go
+++ b/pkg/controller/ram/resourceshare/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ResourceShareGroupKind
+}
+
 // SetupResourceShare adds a controller that reconciles ResourceShare.
 func SetupResourceShare(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ResourceShareGroupKind)

--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -45,6 +45,11 @@ type updater struct {
 	client svcsdkapi.RDSAPI
 }
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBClusterGroupKind
+}
+
 // SetupDBCluster adds a controller that reconciles DbCluster.
 func SetupDBCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DBClusterGroupKind)

--- a/pkg/controller/rds/dbclusterparametergroup/setup.go
+++ b/pkg/controller/rds/dbclusterparametergroup/setup.go
@@ -35,6 +35,11 @@ const (
 	errNoDBEngineVersions                        = "no DB engine versions returned by AWS"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBClusterParameterGroupGroupKind
+}
+
 // SetupDBClusterParameterGroup adds a controller that reconciles DBClusterParameterGroup.
 func SetupDBClusterParameterGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DBClusterParameterGroupGroupKind)

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -51,6 +51,11 @@ const (
 	statusDeleting              = "deleting"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBInstanceGroupKind
+}
+
 // SetupDBInstance adds a controller that reconciles DBInstance
 func SetupDBInstance(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DBInstanceGroupKind)

--- a/pkg/controller/rds/dbinstanceroleassociation/setup.go
+++ b/pkg/controller/rds/dbinstanceroleassociation/setup.go
@@ -25,6 +25,11 @@ const (
 	errDescribeAssoc = "failed to describe DBInstance for DBInstanceRoleAssociation"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBInstanceRoleAssociationGroupKind
+}
+
 // SetupDBInstanceRoleAssociation adds a controller that reconciles DBInstanceRoleAssociation.
 func SetupDBInstanceRoleAssociation(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DBInstanceRoleAssociationGroupKind)

--- a/pkg/controller/rds/dbparametergroup/setup.go
+++ b/pkg/controller/rds/dbparametergroup/setup.go
@@ -34,6 +34,11 @@ const (
 	errNoDBEngineVersions                        = "no DB engine versions returned by AWS"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.DBParameterGroupGroupKind
+}
+
 // SetupDBParameterGroup adds a controller that reconciles DBParametergroup.
 func SetupDBParameterGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.DBParameterGroupGroupKind)

--- a/pkg/controller/rds/globalcluster/setup.go
+++ b/pkg/controller/rds/globalcluster/setup.go
@@ -20,6 +20,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.GlobalClusterGroupKind
+}
+
 // SetupGlobalCluster adds a controller that reconciles GlobalCluster.
 func SetupGlobalCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.GlobalClusterGroupKind)

--- a/pkg/controller/rds/optiongroup/setup.go
+++ b/pkg/controller/rds/optiongroup/setup.go
@@ -23,6 +23,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.OptionGroupGroupKind
+}
+
 // SetupOptionGroup adds a controller that reconciles OptionGroup.
 func SetupOptionGroup(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.OptionGroupGroupKind)

--- a/pkg/controller/redshift/controller.go
+++ b/pkg/controller/redshift/controller.go
@@ -53,6 +53,11 @@ const (
 	errUpToDateFailed   = "cannot check whether object is up-to-date"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return redshiftv1alpha1.ClusterGroupKind
+}
+
 // SetupCluster adds a controller that reconciles Redshift clusters.
 func SetupCluster(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(redshiftv1alpha1.ClusterGroupKind)

--- a/pkg/controller/route53/hostedzone/controller.go
+++ b/pkg/controller/route53/hostedzone/controller.go
@@ -52,6 +52,11 @@ const (
 	errGet    = "failed to get the Hosted Zone resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return route53v1alpha1.HostedZoneGroupKind
+}
+
 // SetupHostedZone adds a controller that reconciles Hosted Zones.
 func SetupHostedZone(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(route53v1alpha1.HostedZoneGroupKind)

--- a/pkg/controller/route53/resourcerecordset/controller.go
+++ b/pkg/controller/route53/resourcerecordset/controller.go
@@ -51,6 +51,11 @@ const (
 	errState            = "failed to determine resource state"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return route53v1alpha1.ResourceRecordSetGroupKind
+}
+
 // SetupResourceRecordSet adds a controller that reconciles ResourceRecordSets.
 func SetupResourceRecordSet(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(route53v1alpha1.ResourceRecordSetGroupKind)

--- a/pkg/controller/route53resolver/resolverendpoint/hooks.go
+++ b/pkg/controller/route53resolver/resolverendpoint/hooks.go
@@ -21,6 +21,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return route53resolverv1alpha1.ResolverEndpointGroupKind
+}
+
 // SetupResolverEndpoint adds a controller that reconciles ResolverEndpoints
 func SetupResolverEndpoint(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(route53resolverv1alpha1.ResolverEndpointGroupKind)

--- a/pkg/controller/route53resolver/resolverrule/hooks.go
+++ b/pkg/controller/route53resolver/resolverrule/hooks.go
@@ -21,6 +21,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return route53resolverv1alpha1.ResolverRuleGroupKind
+}
+
 // SetupResolverRule adds a controller that reconciles ResolverRule
 func SetupResolverRule(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(route53resolverv1alpha1.ResolverRuleGroupKind)

--- a/pkg/controller/route53resolver/resolverruleassociation/hooks.go
+++ b/pkg/controller/route53resolver/resolverruleassociation/hooks.go
@@ -46,6 +46,11 @@ const (
 	errGet              = "failed to get the AssociatedResolverRule"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return manualv1alpha1.ResolverRuleAssociationGroupKind
+}
+
 // SetupResolverRuleAssociation adds a controller that reconciles ResolverRuleAssociation
 func SetupResolverRuleAssociation(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(manualv1alpha1.ResolverRuleAssociationGroupKind)

--- a/pkg/controller/s3/bucket.go
+++ b/pkg/controller/s3/bucket.go
@@ -53,6 +53,11 @@ const (
 	errKubeUpdateFailed = "cannot update S3 custom resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.BucketGroupKind
+}
+
 // SetupBucket adds a controller that reconciles Buckets.
 func SetupBucket(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.BucketGroupKind)

--- a/pkg/controller/s3/bucketpolicy/bucketpolicy.go
+++ b/pkg/controller/s3/bucketpolicy/bucketpolicy.go
@@ -50,6 +50,11 @@ const (
 	errNotSpecified     = "failed to format bucketPolicy, no rawPolicy or policy specified"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1alpha3.BucketPolicyGroupKind
+}
+
 // SetupBucketPolicy adds a controller that reconciles
 // BucketPolicies.
 func SetupBucketPolicy(mgr ctrl.Manager, o controller.Options) error {

--- a/pkg/controller/secretsmanager/secret/setup.go
+++ b/pkg/controller/secretsmanager/secret/setup.go
@@ -64,6 +64,11 @@ const (
 	errOnlyOneSecretRef     = "only one of binarySecretRef or stringSecretRef must be set"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.SecretGroupKind
+}
+
 // SetupSecret adds a controller that reconciles a Secret.
 func SetupSecret(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.SecretGroupKind)

--- a/pkg/controller/servicediscovery/httpnamespace/setup.go
+++ b/pkg/controller/servicediscovery/httpnamespace/setup.go
@@ -39,6 +39,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.HTTPNamespaceGroupKind
+}
+
 // SetupHTTPNamespace adds a controller that reconciles HTTPNamespace.
 func SetupHTTPNamespace(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.HTTPNamespaceGroupKind)

--- a/pkg/controller/servicediscovery/privatednsnamespace/setup.go
+++ b/pkg/controller/servicediscovery/privatednsnamespace/setup.go
@@ -40,6 +40,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.PrivateDNSNamespaceGroupKind
+}
+
 // SetupPrivateDNSNamespace adds a controller that reconciles PrivateDNSNamespaces.
 func SetupPrivateDNSNamespace(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.PrivateDNSNamespaceGroupKind)

--- a/pkg/controller/servicediscovery/publicdnsnamespace/setup.go
+++ b/pkg/controller/servicediscovery/publicdnsnamespace/setup.go
@@ -39,6 +39,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.PublicDNSNamespaceGroupKind
+}
+
 // SetupPublicDNSNamespace adds a controller that reconciles PublicDNSNamespaces.
 func SetupPublicDNSNamespace(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.PublicDNSNamespaceGroupKind)

--- a/pkg/controller/sfn/activity/hooks.go
+++ b/pkg/controller/sfn/activity/hooks.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ActivityGroupKind
+}
+
 // SetupActivity adds a controller that reconciles Activity.
 func SetupActivity(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ActivityGroupKind)

--- a/pkg/controller/sfn/statemachine/hooks.go
+++ b/pkg/controller/sfn/statemachine/hooks.go
@@ -36,6 +36,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.StateMachineGroupKind
+}
+
 // SetupStateMachine adds a controller that reconciles StateMachine.
 func SetupStateMachine(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.StateMachineGroupKind)

--- a/pkg/controller/sns/subscription/controller.go
+++ b/pkg/controller/sns/subscription/controller.go
@@ -50,6 +50,11 @@ const (
 	errUpdate              = "failed to update the SNS Subscription"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.SubscriptionGroupKind
+}
+
 // SetupSubscription adds a controller than reconciles Subscription
 func SetupSubscription(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.SubscriptionGroupKind)

--- a/pkg/controller/sns/topic/controller.go
+++ b/pkg/controller/sns/topic/controller.go
@@ -50,6 +50,11 @@ const (
 	errUpdate           = "failed to update the SNS Topic"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.TopicGroupKind
+}
+
 // SetupSNSTopic adds a controller that reconciles Topic.
 func SetupSNSTopic(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.TopicGroupKind)

--- a/pkg/controller/sqs/queue/controller.go
+++ b/pkg/controller/sqs/queue/controller.go
@@ -54,6 +54,11 @@ const (
 	errUpdateFailed             = "failed to update the Queue resource"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return v1beta1.QueueGroupKind
+}
+
 // SetupQueue adds a controller that reconciles Queue.
 func SetupQueue(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(v1beta1.QueueGroupKind)

--- a/pkg/controller/transfer/server/setup.go
+++ b/pkg/controller/transfer/server/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.ServerGroupKind
+}
+
 // SetupServer adds a controller that reconciles Server.
 func SetupServer(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.ServerGroupKind)

--- a/pkg/controller/transfer/user/setup.go
+++ b/pkg/controller/transfer/user/setup.go
@@ -33,6 +33,11 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
 )
 
+// ManagesKind returns the kind this controller manages
+func ManagesKind() string {
+	return svcapitypes.UserGroupKind
+}
+
 // SetupUser adds a controller that reconciles User.
 func SetupUser(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.UserGroupKind)


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This poc enables filtering of crds when applying a provider. Crossplane-core sets an env variable that can be used to only setup controllers for applied crds.

For each controller that can be applied a method returning the group and kind of the reconciled resource is added. The return value of this method is used to filter the list of activated controllers. 

The corresponding implentation in crossplane core can be seen in PR #

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
