### PR TITLE
remove required field interfaceType from ec2 instance networkInterface

### DIFF
--- a/package/crds/ec2.aws.crossplane.io_instances.yaml
+++ b/package/crds/ec2.aws.crossplane.io_instances.yaml
@@ -753,7 +753,6 @@ spec:
                       required:
                       - deviceIndex
                       - groups
-                      - interfaceType
                       type: object
                     type: array
                   placement:


### PR DESCRIPTION
### Description of your changes

We want to create ec2 instances with existing network interfaces. To do that we are referencing the network interface id of the existing ENI within the field "networkInterfaceId".  This is an optional filed.
But we need to set the required fields too. These include the field "interfaceType". But the AWS API does not allow specify bot "networkInterfaceId" and "interfaceType". See error message after creating the the CRD.

**Error Message from AWS API:**
```
create failed: failed to create the Instance resource: api error InvalidParameterCombination: A network interface may not specify both a network interface ID and an interface 
```

Here is the example Resource that reproduce this error.
**Invalid example**:
```yaml
apiVersion: ec2.aws.crossplane.io/v1alpha1
kind: Instance
metadata:
  name: test-instance
spec:
  forProvider:
    imageId: ami-testid
    instanceType: t3.micro
    launchTemplate:
      launchTemplateId: ""
      launchTemplateName: metadata-options-crossplane
    monitoring:
      enabled: false
    networkInterfaces:
    - deviceIndex: 0
      groups: []
      interfaceType: interface
      networkInterfaceId: eni-0a5798665e2d4557
    region: eu-central-1
  providerConfigRef:
    name: aws-config
  writeConnectionSecretToRef:
    name: test-instance
    namespace: crossplane-system
```

To fix this issue. We removed the field "interfaceType" from required list from the CRD ec2.aws.crossplane.io_instances.yaml
After that we were able to create the resource and the provider created the ec2 instance as described.

**Valid example:**
```yaml
apiVersion: ec2.aws.crossplane.io/v1alpha1
kind: Instance
metadata:
  name: test-instance
spec:
  forProvider:
    imageId: ami-testid
    instanceType: t3.micro
    launchTemplate:
      launchTemplateId: ""
      launchTemplateName: metadata-options-crossplane
    monitoring:
      enabled: false
    networkInterfaces:
    - deviceIndex: 0
      groups: []
      networkInterfaceId: eni-0a5798665e2d4557
    region: eu-central-1
  providerConfigRef:
    name: aws-config
  writeConnectionSecretToRef:
    name: test-instance
    namespace: crossplane-system
```

I have:

- [x] Read and followed Crossplane's [contribution process].

### How has this code been tested

We testet this change on our crossplane cluster by modifying the CRD directly inside the cluster. It worked like charm.

### Open Question

I don't know if we need to change more than this CRD or if they are generated? Maybe a maintainer could clarify if we need to change the code at some other places too?