### PR TITLE
Handle VPCCIDRBlock delete case in Observe

### DIFF
--- a/pkg/controller/ec2/vpccidrblock/controller.go
+++ b/pkg/controller/ec2/vpccidrblock/controller.go
@@ -140,6 +140,12 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	case awsec2types.VpcCidrBlockStateCodeAssociating:
 		cr.SetConditions(xpv1.Creating())
 	case awsec2types.VpcCidrBlockStateCodeDisassociated:
+		if meta.WasDeleted(mgd) {
+			return managed.ExternalObservation{
+				ResourceExists:   false,
+				ResourceUpToDate: false,
+			}, nil
+		}
 		cr.Status.SetConditions(xpv1.Deleting())
 	case awsec2types.VpcCidrBlockStateCodeDisassociating:
 		cr.Status.SetConditions(xpv1.Deleting())


### PR DESCRIPTION
### Description of your changes
The VPCCIDRBlock association is never actually removed from the VPC when the VPCCIDRBlock is deleted, it is put into the `disassociated` state where it remains until the VPC is deleted.

This change modifies the Observe function to check to see if the managed resource has been deleted when it finds the VPCCIDRBlock is in the `disassociated` state and return `ResourceExists: false` so that the reconciler will remove the finalizer and allow the MR to be deleted.

Fixes #1729 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Verified that the VPCCIDRBlock resource is deleted properly when this fix is applied.

[contribution process]: https://git.io/fj2m9
