### PR TITLE
Handle the VPCPeeringConnection delete case

### DIFF
--- a/pkg/controller/ec2/vpcpeeringconnection/setup.go
+++ b/pkg/controller/ec2/vpcpeeringconnection/setup.go
@@ -82,12 +82,12 @@ func filterList(cr *svcapitypes.VPCPeeringConnection, obj *svcsdk.DescribeVpcPee
 	return resp
 }
 
-func (e *custom) postObserve(_ context.Context, cr *svcapitypes.VPCPeeringConnection, obj *svcsdk.DescribeVpcPeeringConnectionsOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
+func (e *custom) postObserve(_ context.Context, cr *svcapitypes.VPCPeeringConnection, obj *svcsdk.DescribeVpcPeeringConnectionsOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) { // nolint:gocyclo
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
 
-	if awsclients.StringValue(obj.VpcPeeringConnections[0].Status.Code) == "pending-acceptance" && cr.Spec.ForProvider.AcceptRequest {
+	if awsclients.StringValue(obj.VpcPeeringConnections[0].Status.Code) == "pending-acceptance" && cr.Spec.ForProvider.AcceptRequest && !meta.WasDeleted(cr) {
 		req := svcsdk.AcceptVpcPeeringConnectionInput{
 			VpcPeeringConnectionId: awsclients.String(*obj.VpcPeeringConnections[0].VpcPeeringConnectionId),
 		}
@@ -98,17 +98,26 @@ func (e *custom) postObserve(_ context.Context, cr *svcapitypes.VPCPeeringConnec
 		}
 	}
 
-	if !reflect.DeepEqual(obj.VpcPeeringConnections[0].AccepterVpcInfo.PeeringOptions, cr.Spec.ForProvider.AccepterPeeringOptions) ||
-		!reflect.DeepEqual(obj.VpcPeeringConnections[0].RequesterVpcInfo.PeeringOptions, cr.Spec.ForProvider.RequesterPeeringOptions) {
-		req := svcsdk.ModifyVpcPeeringConnectionOptionsInput{
-			VpcPeeringConnectionId: awsclients.String(*obj.VpcPeeringConnections[0].VpcPeeringConnectionId),
-		}
-		setAccepterRequester(&req, cr)
+	if meta.WasDeleted(cr) && awsclients.StringValue(obj.VpcPeeringConnections[0].Status.Code) == "deleted" {
+		return managed.ExternalObservation{
+			ResourceExists:   false,
+			ResourceUpToDate: false,
+		}, nil
+	}
 
-		request, _ := e.client.ModifyVpcPeeringConnectionOptionsRequest(&req)
-		err := request.Send()
-		if err != nil {
-			return obs, err
+	if awsclients.StringValue(obj.VpcPeeringConnections[0].Status.Code) == "active" {
+		if !reflect.DeepEqual(obj.VpcPeeringConnections[0].AccepterVpcInfo.PeeringOptions, cr.Spec.ForProvider.AccepterPeeringOptions) ||
+			!reflect.DeepEqual(obj.VpcPeeringConnections[0].RequesterVpcInfo.PeeringOptions, cr.Spec.ForProvider.RequesterPeeringOptions) {
+			req := svcsdk.ModifyVpcPeeringConnectionOptionsInput{
+				VpcPeeringConnectionId: awsclients.String(*obj.VpcPeeringConnections[0].VpcPeeringConnectionId),
+			}
+			setAccepterRequester(&req, cr)
+
+			request, _ := e.client.ModifyVpcPeeringConnectionOptionsRequest(&req)
+			err := request.Send()
+			if err != nil {
+				return obs, err
+			}
 		}
 	}
 
@@ -139,10 +148,10 @@ func setAccepterRequester(req *svcsdk.ModifyVpcPeeringConnectionOptionsInput, cr
 
 func setCondition(code *svcsdk.VpcPeeringConnectionStateReason, cr *svcapitypes.VPCPeeringConnection) bool {
 	switch aws.StringValue(code.Code) {
-	case string(svcapitypes.VPCPeeringConnectionStateReasonCode_pending_acceptance):
+	case string(svcapitypes.VPCPeeringConnectionStateReasonCode_pending_acceptance), string(svcapitypes.VPCPeeringConnectionStateReasonCode_provisioning):
 		cr.SetConditions(xpv1.Creating())
 		return true
-	case string(svcapitypes.VPCPeeringConnectionStateReasonCode_deleted), string(svcapitypes.VPCPeeringConnectionStateReasonCode_failed):
+	case string(svcapitypes.VPCPeeringConnectionStateReasonCode_deleted), string(svcapitypes.VPCPeeringConnectionStateReasonCode_deleting), string(svcapitypes.VPCPeeringConnectionStateReasonCode_failed), string(svcapitypes.VPCPeeringConnectionStateReasonCode_rejected), string(svcapitypes.VPCPeeringConnectionStateReasonCode_expired):
 		cr.SetConditions(xpv1.Unavailable())
 		return false
 	case string(svcapitypes.VPCPeeringConnectionStateReasonCode_active):


### PR DESCRIPTION
### Description of your changes
Update the postObserve() function for VPCPeeringConnection to handle the delete case.  Also handle some corner cases to
prevent the resource from getting stuck during cleanup from error conditions.

Fixes #1732 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Created a VPCPeeringConnection and verified that the delete process works as expected and the resource does not get stuck.

Also verified that a failed VPCPeeringConnection does not get stuck, and the code does not try to apply peer options updates when the connection is not active.