### PR TITLE
S3 examples: ACLs no longer supported for new buckets in many regions

### DIFF
--- a/examples/mwaa/infra.yaml
+++ b/examples/mwaa/infra.yaml
@@ -39,7 +39,7 @@ metadata:
 spec:
   deletionPolicy: Delete
   forProvider:
-    acl: private
+    objectOwnership: BucketOwnerEnforced
     locationConstraint: us-east-1
     paymentConfiguration:
       payer: BucketOwner

--- a/examples/s3/bucket-with-policy.yaml
+++ b/examples/s3/bucket-with-policy.yaml
@@ -8,7 +8,7 @@ metadata:
     crossplane.io/external-name: crossplane-example-bucket
 spec:
   forProvider:
-    acl: private
+    objectOwnership: BucketOwnerEnforced
     locationConstraint: us-east-1
     policy:
       version: '2012-10-17'

--- a/examples/s3/bucket.yaml
+++ b/examples/s3/bucket.yaml
@@ -8,7 +8,7 @@ metadata:
     crossplane.io/external-name: crossplane-example-bucket
 spec:
   forProvider:
-    acl: private
+    objectOwnership: BucketOwnerEnforced
     locationConstraint: us-east-1
     publicAccessBlockConfiguration:
       blockPublicPolicy: true


### PR DESCRIPTION
Most regions have disabled ACLs for new buckets.


### Description of your changes

Update examples to code that works out of the box.

Setting BucketOwnerEnforced will disable ACLs explicitly.

Updates #1723


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Created bucket in `eu-north-1`. Failes out of the box. Works with this update.

See https://github.com/crossplane-contrib/provider-aws/issues/1723 for more info.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
