### PR TITLE
fix(dbinstance): remove DeleteAutomatedBackups from isUpToDate-check

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -357,7 +357,7 @@ func (e *custom) isUpToDate(cr *svcapitypes.DBInstance, out *svcsdk.DescribeDBIn
 	// This could be matured a bit more for specific statuses, such as not allowing storage changes
 	// when the status is "storage-optimization"
 	status := aws.StringValue(out.DBInstances[0].DBInstanceStatus)
-	if status == "modifying" || status == "upgrading" || status == "rebooting" || status == "creating" {
+	if status == "modifying" || status == "upgrading" || status == "rebooting" || status == "creating" || status == "deleting" {
 		return true, nil
 	}
 
@@ -412,6 +412,7 @@ func (e *custom) isUpToDate(cr *svcapitypes.DBInstance, out *svcsdk.DescribeDBIn
 		cmpopts.IgnoreFields(svcapitypes.CustomDBInstanceParameters{}, "ApplyImmediately"),
 		cmpopts.IgnoreFields(svcapitypes.CustomDBInstanceParameters{}, "RestoreFrom"),
 		cmpopts.IgnoreFields(svcapitypes.CustomDBInstanceParameters{}, "VPCSecurityGroupIDs"),
+		cmpopts.IgnoreFields(svcapitypes.CustomDBInstanceParameters{}, "DeleteAutomatedBackups"),
 	)
 
 	if diff == "" && !maintenanceWindowChanged && !backupWindowChanged && !pwChanged && !versionChanged && !vpcSGsChanged && !dbParameterGroupChanged {


### PR DESCRIPTION


### Description of your changes

The parameter `DeleteAutomatedBackups` causes an update-loop, if set (true or false) in the claim.

This change adds it to the ignored fields in `isUpToDate`. The parameter is only relevant on delete. [(AWS delete-db-instance)](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/delete-db-instance.html)

Also small change: there is no need to run through `isUpToDate` while the DB is in `deleting` state/status.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually with db-instance example
