### PR TITLE
fix(docdb): Exit isUpToDate early if MR is deleted

### DIFF
--- a/pkg/controller/docdb/dbcluster/setup.go
+++ b/pkg/controller/docdb/dbcluster/setup.go
@@ -162,6 +162,10 @@ func lateInitialize(cr *svcapitypes.DBClusterParameters, resp *svcsdk.DescribeDB
 }
 
 func (e *hooks) isUpToDate(cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClustersOutput) (bool, error) { // nolint:gocyclo
+	if meta.WasDeleted(cr) {
+		return true, nil // There is no need to check for updates when we want to delete.
+	}
+
 	cluster := resp.DBClusters[0]
 
 	ctx := context.Background()


### PR DESCRIPTION
### Description of your changes

This lets `isUpToDate` exit early if the resource is deleted as the check is not needed.

Fixes a `secret not found` error that blocks a `DBCluster` from being deleted when the referenced password secret does not exist anymore.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests

[contribution process]: https://git.io/fj2m9
