### PR TITLE
fix(bucket): Convert bools to string in policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.1
 	sigs.k8s.io/controller-tools v0.11.1
 	sigs.k8s.io/yaml v1.3.0
@@ -153,7 +154,6 @@ require (
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/pkg/controller/s3/bucket/policy.go
+++ b/pkg/controller/s3/bucket/policy.go
@@ -27,16 +27,18 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/crossplane-contrib/provider-aws/apis/s3/v1beta1"
-	aws "github.com/crossplane-contrib/provider-aws/pkg/clients"
 	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
 	"github.com/crossplane-contrib/provider-aws/pkg/clients/s3"
+	policyutils "github.com/crossplane-contrib/provider-aws/pkg/utils/policy"
 )
 
 const (
-	policyGetFailed    = "cannot get bucket policy"
-	policyFormatFailed = "cannot format bucket policy"
-	policyPutFailed    = "cannot put bucket policy"
-	policyDeleteFailed = "cannot delete bucket policy"
+	policyGetFailed     = "cannot get bucket policy"
+	policyFormatFailed  = "cannot format bucket policy"
+	policyParseSpec     = "cannot parse spec policy"
+	policyPutFailed     = "cannot put bucket policy"
+	policyDeleteFailed  = "cannot delete bucket policy"
+	policyParseExternal = "cannot parse external policy"
 )
 
 // PolicyClient is the client for API methods and reconciling the PublicAccessBlock
@@ -50,7 +52,7 @@ func NewPolicyClient(client s3.BucketPolicyClient) *PolicyClient {
 }
 
 // Observe checks if the resource exists and if it matches the local configuration
-func (e *PolicyClient) Observe(ctx context.Context, cr *v1beta1.Bucket) (ResourceStatus, error) {
+func (e *PolicyClient) Observe(ctx context.Context, cr *v1beta1.Bucket) (ResourceStatus, error) { //nolint:gocyclo
 	resp, err := e.client.GetBucketPolicy(ctx, &awss3.GetBucketPolicyInput{
 		Bucket: awsclient.String(meta.GetExternalName(cr)),
 	})
@@ -63,45 +65,35 @@ func (e *PolicyClient) Observe(ctx context.Context, cr *v1beta1.Bucket) (Resourc
 		}
 		return NeedsUpdate, errors.Wrap(err, policyGetFailed)
 	}
-	policy, err := e.formatBucketPolicy(cr)
-	if err != nil {
-		return NeedsUpdate, errors.Wrap(err, policyFormatFailed)
-	}
 
 	// To ensure backwards compatbility with the previous behaviour
 	// (Bucket + BucketPolicy).
 	// Only delete the policy on AWS if the user has specified to do so.
-	if policy == nil && resp.Policy != nil && getBucketPolicyDeletionPolicy(cr) == v1beta1.BucketPolicyDeletionPolicyIfNull {
-		return NeedsDeletion, nil
-	}
-
-	if EqualsJSON(aws.StringValue(policy), aws.StringValue(resp.Policy)) {
+	if cr.Spec.ForProvider.Policy == nil {
+		if resp.Policy != nil && getBucketPolicyDeletionPolicy(cr) == v1beta1.BucketPolicyDeletionPolicyIfNull {
+			return NeedsDeletion, nil
+		}
 		return Updated, nil
 	}
 
-	return NeedsUpdate, nil
-}
-
-// JSONNormalize bring JsonStrings to an []byte
-func JSONNormalize(jStr string) *string {
-	var iface any
-	err := json.Unmarshal([]byte(jStr), &iface)
+	specPolicyRaw, err := e.formatBucketPolicy(cr)
 	if err != nil {
-		return &jStr
+		return NeedsUpdate, errors.Wrap(err, policyFormatFailed)
+	}
+	specPolicy, err := policyutils.ParsePolicyString(awsclient.StringValue(specPolicyRaw))
+	if err != nil {
+		return NeedsUpdate, errors.Wrap(err, policyParseSpec)
+	}
+	curPolicy, err := policyutils.ParsePolicyString(awsclient.StringValue(resp.Policy))
+	if err != nil {
+		return NeedsUpdate, errors.Wrap(err, policyParseExternal)
 	}
 
-	jRaw, err := json.Marshal(iface)
-	if err != nil {
-		return &jStr
+	diff := cmp.Diff(specPolicy, curPolicy)
+	if diff != "" {
+		return NeedsUpdate, nil
 	}
-	return aws.String(string(jRaw))
-}
-
-// EqualsJSON whether two JSON structs are equal
-func EqualsJSON(a, b string) bool {
-	pa := JSONNormalize(a)
-	pb := JSONNormalize(b)
-	return cmp.Equal(pa, pb)
+	return Updated, nil
 }
 
 // formatBucketPolicy parses and formats the bucket.Spec.BucketPolicy struct

--- a/pkg/controller/s3/bucket/policy_test.go
+++ b/pkg/controller/s3/bucket/policy_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/pointer"
 
 	"github.com/crossplane-contrib/provider-aws/apis/s3/common"
 	"github.com/crossplane-contrib/provider-aws/apis/s3/v1beta1"
@@ -74,6 +75,127 @@ func TestPolicyObserve(t *testing.T) {
 			},
 		},
 	}
+
+	var testPolicyIssue1771 = &common.BucketPolicyBody{
+		Version: "2012-10-17",
+		Statements: []common.BucketPolicyStatement{
+			{
+				Action: []string{
+					"s3:PutObject",
+				},
+				Condition: []common.Condition{
+					{
+						OperatorKey: "StringNotEquals",
+						Conditions: []common.ConditionPair{
+							{
+								ConditionKey: "s3:x-amz-server-side-encryption",
+								ConditionListValue: []string{
+									"AES256",
+									"aws:kms",
+								},
+							},
+						},
+					},
+				},
+				Effect: "Deny",
+				Principal: &common.BucketPrincipal{
+					AllowAnon: true,
+				},
+				Resource: []string{
+					"arn:aws:s3:::test-bucket-xxxx/*",
+				},
+				SID: awsclient.String("DenyIncorrectEncryptionHeader"),
+			},
+			{
+				Action: []string{
+					"s3:PutObject",
+				},
+				Condition: []common.Condition{
+					{
+						OperatorKey: "Null",
+						Conditions: []common.ConditionPair{
+							{
+								ConditionKey:          "s3:x-amz-server-side-encryption",
+								ConditionBooleanValue: awsclient.Bool(true),
+							},
+						},
+					},
+				},
+				Effect: "Deny",
+				Principal: &common.BucketPrincipal{
+					AllowAnon: true,
+				},
+				Resource: []string{
+					"arn:aws:s3:::test-bucket-xxxx/*",
+				},
+				SID: awsclient.String("DenyUnEncryptedObjectUploads"),
+			},
+			{
+				Action: []string{
+					"s3:GetBucketLocation",
+					"s3:GetBucketVersioning",
+					"s3:GetLifecycleConfiguration",
+					"s3:GetObject",
+					"s3:GetObjectAcl",
+					"s3:GetObjectVersion",
+					"s3:GetObjectTagging",
+					"s3:GetObjectRetention",
+					"s3:PutObject",
+					"s3:PutObjectAcl",
+					"s3:DeleteObject",
+					"s3:ListBucket",
+					"s3:ListBucketVersions",
+				},
+				Condition: []common.Condition{
+					{
+						OperatorKey: "StringEquals",
+						Conditions: []common.ConditionPair{
+							{
+								ConditionKey:         "aws:PrincipalAccount",
+								ConditionStringValue: awsclient.String("123456789012"),
+							},
+						},
+					},
+				},
+				Effect: "Allow",
+				Principal: &common.BucketPrincipal{
+					AllowAnon: true,
+				},
+				Resource: []string{
+					"arn:aws:s3:::test-bucket-xxxx",
+					"arn:aws:s3:::test-bucket-xxxx/*",
+				},
+				SID: awsclient.String("AllowTenantReadWrite"),
+			},
+			{
+				Action: []string{
+					"s3:*",
+				},
+				Condition: []common.Condition{
+					{
+						OperatorKey: "Bool",
+						Conditions: []common.ConditionPair{
+							{
+								ConditionKey:          "aws:SecureTransport",
+								ConditionBooleanValue: pointer.Bool(false),
+							},
+						},
+					},
+				},
+				Effect: "Deny",
+				Principal: &common.BucketPrincipal{
+					AllowAnon: true,
+				},
+				Resource: []string{
+					"arn:aws:s3:::test-bucket-xxxx",
+					"arn:aws:s3:::test-bucket-xxxx/*",
+				},
+				SID: awsclient.String("AllowSSLRequestsOnly"),
+			},
+		},
+	}
+
+	testPolicyIssue1771External := "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"DenyIncorrectEncryptionHeader\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::test-bucket-xxxx/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}},{\"Sid\":\"DenyUnEncryptedObjectUploads\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::test-bucket-xxxx/*\",\"Condition\":{\"Null\":{\"s3:x-amz-server-side-encryption\":\"true\"}}},{\"Sid\":\"AllowTenantReadWrite\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetBucketLocation\",\"s3:GetBucketVersioning\",\"s3:GetLifecycleConfiguration\",\"s3:GetObject\",\"s3:GetObjectAcl\",\"s3:GetObjectVersion\",\"s3:GetObjectTagging\",\"s3:GetObjectRetention\",\"s3:PutObject\",\"s3:PutObjectAcl\",\"s3:DeleteObject\",\"s3:ListBucket\",\"s3:ListBucketVersions\"],\"Resource\":[\"arn:aws:s3:::test-bucket-xxxx\",\"arn:aws:s3:::test-bucket-xxxx/*\"],\"Condition\":{\"StringEquals\":{\"aws:PrincipalAccount\":\"123456789012\"}}},{\"Sid\":\"AllowSSLRequestsOnly\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:*\",\"Resource\":[\"arn:aws:s3:::test-bucket-xxxx\",\"arn:aws:s3:::test-bucket-xxxx/*\"],\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"false\"}}}]}"
 
 	testPolicyRawShuffled := "{\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"s3:ListBucket\",\"Principal\":\"*\",\"Resource\":\"arn:aws:s3:::test.s3.crossplane.com\"}],\"Version\":\"2012-10-17\"}"
 	testPolicyRaw := makeRawPolicy(testPolicy)
@@ -215,6 +337,23 @@ func TestPolicyObserve(t *testing.T) {
 			want: want{
 				status: Updated,
 				err:    nil,
+			},
+		},
+		"TestIssue1771Updated": {
+			args: args{
+				b: s3testing.Bucket(s3testing.WithPolicy(testPolicyIssue1771)),
+				cl: NewPolicyClient(fake.MockBucketClient{
+					MockBucketPolicyClient: fake.MockBucketPolicyClient{
+						MockGetBucketPolicy: func(ctx context.Context, input *s3.GetBucketPolicyInput, opts []func(*s3.Options)) (*s3.GetBucketPolicyOutput, error) {
+							return &s3.GetBucketPolicyOutput{
+								Policy: &testPolicyIssue1771External,
+							}, nil
+						},
+					},
+				}),
+			},
+			want: want{
+				status: Updated,
 			},
 		},
 	}

--- a/pkg/utils/policy/compare.go
+++ b/pkg/utils/policy/compare.go
@@ -1,0 +1,12 @@
+package policy
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+// ArePoliciesEqal determines if the two Policy objects can be considered
+// equal.
+func ArePoliciesEqal(a, b *Policy) (equal bool, diff string) {
+	diff = cmp.Diff(a, b)
+	return diff == "", diff
+}

--- a/pkg/utils/policy/parse.go
+++ b/pkg/utils/policy/parse.go
@@ -1,0 +1,25 @@
+package policy
+
+import "encoding/json"
+
+// ParsePolicyBytes from a byte array representing a raw JSOn string.
+func ParsePolicyBytes(raw []byte) (Policy, error) {
+	policy := Policy{}
+	err := json.Unmarshal(raw, &policy)
+	return policy, err
+}
+
+// ParsePolicyString from a raw JSON string.
+func ParsePolicyString(raw string) (Policy, error) {
+	return ParsePolicyBytes([]byte(raw))
+}
+
+// ParsePolicyObject parses a policy from an object (i.e. an API struct) which
+// can be marshalled into JSON.
+func ParsePolicyObject(obj any) (Policy, error) {
+	input, err := json.Marshal(obj)
+	if err != nil {
+		return Policy{}, err
+	}
+	return ParsePolicyBytes(input)
+}

--- a/pkg/utils/policy/parse_test.go
+++ b/pkg/utils/policy/parse_test.go
@@ -1,0 +1,147 @@
+package policy
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	//go:embed testdata/UnmarshalSinglesAsList.json
+	policyUnmarshalSinglesAsList string
+
+	//go:embed testdata/UnmarshalArrays.json
+	policyUnmarshalArrays string
+)
+
+func TestParsePolicy(t *testing.T) {
+	type args struct {
+		rawPolicy string
+	}
+	type want struct {
+		policy *Policy
+		err    error
+	}
+	cases := map[string]struct {
+		want
+		args
+	}{
+		"UnmarshalSinglesAsList": {
+			args: args{
+				rawPolicy: policyUnmarshalSinglesAsList,
+			},
+			want: want{
+				policy: &Policy{
+					Version: "2012-10-17",
+					Statements: []Statement{
+						{
+							SID: "AllowPutObjectS3ServerAccessLogsPolicy",
+							Principal: &Principal{
+								Service: StringOrArray{
+									"logging.s3.amazonaws.com",
+								},
+								Federated: "cognito-identity.amazonaws.com",
+								AWSPrincipals: StringOrArray{
+									"123456789012",
+								},
+							},
+							Effect: "Allow",
+							Action: StringOrArray{
+								"s3:PutObject",
+							},
+							Resource: StringOrArray{
+								"arn:aws:s3:::DOC-EXAMPLE-BUCKET-logs/*",
+							},
+							Condition: ConditionMap{
+								"StringEquals": ConditionSettings{
+									"aws:SourceAccount": "111111111111",
+								},
+								"ArnLike": ConditionSettings{
+									"aws:SourceArn": "arn:aws:s3:::EXAMPLE-SOURCE-BUCKET",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"UnmarshalArrays": {
+			args: args{
+				rawPolicy: policyUnmarshalArrays,
+			},
+			want: want{
+				policy: &Policy{
+					Version: "2012-10-17",
+					Statements: []Statement{
+						{
+							SID: "AllowPutObjectS3ServerAccessLogsPolicy",
+							Principal: &Principal{
+								Service: StringOrArray{
+									"logging.s3.amazonaws.com",
+									"s3.amazonaws.com",
+								},
+								Federated: "cognito-identity.amazonaws.com",
+								AWSPrincipals: StringOrArray{
+									"123456789012",
+									"452356421222",
+								},
+							},
+							Effect: "Allow",
+							Action: StringOrArray{
+								"s3:PutObject",
+								"s3:GetObject",
+							},
+							Resource: StringOrArray{
+								"arn:aws:s3:::DOC-EXAMPLE-BUCKET-logs/*",
+							},
+							Condition: ConditionMap{
+								"StringEquals": ConditionSettings{
+									"aws:SourceAccount": []any{
+										"111111111111",
+										"111111111112",
+									},
+								},
+								"ArnLike": ConditionSettings{
+									"aws:SourceArn": "arn:aws:s3:::EXAMPLE-SOURCE-BUCKET",
+								},
+							},
+						},
+						{
+							SID:    "RestrictToS3ServerAccessLogs",
+							Effect: "Deny",
+							Principal: &Principal{
+								AllowAnon: true,
+							},
+							Action: StringOrArray{
+								"s3:PutObject",
+							},
+							Resource: StringOrArray{
+								"arn:aws:s3:::DOC-EXAMPLE-BUCKET-logs/*",
+							},
+							Condition: ConditionMap{
+								"ForAllValues:StringNotEquals": ConditionSettings{
+									"aws:PrincipalServiceNamesList": "logging.s3.amazonaws.com",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			policy, err := ParsePolicyString(tc.args.rawPolicy)
+
+			if diff := cmp.Diff(tc.want.policy, &policy); diff != "" {
+				t.Errorf("ParsePolicyString(...): -want, +got\n:%s", diff)
+			}
+			if diff := cmp.Diff(tc.err, err); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+				return
+			}
+		})
+	}
+}

--- a/pkg/utils/policy/testdata/UnmarshalArrays.json
+++ b/pkg/utils/policy/testdata/UnmarshalArrays.json
@@ -1,0 +1,48 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowPutObjectS3ServerAccessLogsPolicy",
+            "Principal": {
+                "Service": [
+                    "logging.s3.amazonaws.com",
+                    "s3.amazonaws.com"
+                ],
+                "Federated": "cognito-identity.amazonaws.com",
+                "AWS": [
+                    "123456789012",
+                    "452356421222"
+                ]
+            },
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject"
+            ],
+            "Resource": "arn:aws:s3:::DOC-EXAMPLE-BUCKET-logs\/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": [
+                        "111111111111",
+                        "111111111112"
+                    ]
+                },
+                "ArnLike": {
+                    "aws:SourceArn": "arn:aws:s3:::EXAMPLE-SOURCE-BUCKET"
+                }
+            }
+        },
+        {
+            "Sid": "RestrictToS3ServerAccessLogs",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::DOC-EXAMPLE-BUCKET-logs\/*",
+            "Condition": {
+                "ForAllValues:StringNotEquals": {
+                    "aws:PrincipalServiceNamesList": "logging.s3.amazonaws.com"
+                }
+            }
+        }
+    ]
+}

--- a/pkg/utils/policy/testdata/UnmarshalSinglesAsList.json
+++ b/pkg/utils/policy/testdata/UnmarshalSinglesAsList.json
@@ -1,0 +1,22 @@
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Sid": "AllowPutObjectS3ServerAccessLogsPolicy",
+        "Principal": {
+            "Service": "logging.s3.amazonaws.com",
+            "Federated": "cognito-identity.amazonaws.com",
+            "AWS": "123456789012"
+        },
+        "Effect": "Allow",
+        "Action": "s3:PutObject",
+        "Resource": "arn:aws:s3:::DOC-EXAMPLE-BUCKET-logs\/*",
+        "Condition": {
+            "StringEquals": {
+                "aws:SourceAccount": "111111111111"
+            },
+            "ArnLike": {
+                "aws:SourceArn": "arn:aws:s3:::EXAMPLE-SOURCE-BUCKET"
+            }
+        }
+    }
+}

--- a/pkg/utils/policy/types.go
+++ b/pkg/utils/policy/types.go
@@ -1,0 +1,175 @@
+package policy
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// Policy represents an AWS IAM policy.
+type Policy struct {
+	// Version is the current IAM policy version
+	Version string `json:"Version"`
+
+	// ID is the policy's optional identifier
+	ID string `json:"Id,omitempty"`
+
+	// Statements is the list of statement this policy applies.
+	Statements StatementList `json:"Statement,omitempty"`
+}
+
+// StatementList is a list of statements.
+// It implements a custom marshaller to support parsing from a single, non-list
+// statement.
+type StatementList []Statement
+
+// UnmarshalJSON unmarshals data into s.
+func (s *StatementList) UnmarshalJSON(data []byte) error {
+	var single Statement
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = StatementList{single}
+		return nil
+	}
+	list := []Statement{}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+	*s = list
+	return nil
+}
+
+// StatementEffect specifies the effect of a policy statement.
+type StatementEffect string
+
+// Statement effect values.
+const (
+	StatementEffectAllow StatementEffect = "Allow"
+	StatementEffectDeny  StatementEffect = "Deny"
+)
+
+// Statement defines an individual statement within the policy.
+type Statement struct {
+	// Optional identifier for this statement, must be unique within the
+	// policy if provided.
+	SID string `json:"Sid,omitempty"`
+
+	// The effect is required and specifies whether the statement results
+	// in an allow or an explicit deny.
+	// Valid values for Effect are "Allow" and "Deny".
+	Effect StatementEffect `json:"Effect"`
+
+	// Used with the policy to specify the principal that is allowed
+	// or denied access to a resource.
+	Principal *Principal `json:"Principal,omitempty"`
+
+	// Used with the S3 policy to specify the users which are not included
+	// in this policy
+	NotPrincipal *Principal `json:"NotPrincipal,omitempty"`
+
+	// Action specifies the action or actions that will be allowed or denied
+	// with this Statement.
+	Action StringOrArray `json:"Action,omitempty"`
+
+	// NotAction specifies each element that will allow the property to match
+	// all but the listed actions.
+	NotAction StringOrArray `json:"NotAction,omitempty"`
+
+	// Resource specifies paths on which this statement will apply.
+	Resource StringOrArray `json:"Resource,omitempty"`
+
+	// NotResource explicitly specifies all resource paths that are defined in
+	// this array.
+	NotResource StringOrArray `json:"NotResource,omitempty"`
+
+	// Condition specifies where conditions for policy are in effect.
+	// https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html
+	Condition ConditionMap `json:"Condition,omitempty"`
+}
+
+// Principal defines the principal users affected by
+// the PolicyStatement
+// Please see the AWS S3 docs for more information
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+type Principal struct {
+	// This flag indicates if the policy should be made available
+	// to all anonymous users. Also known as "*".
+	// +optional
+	AllowAnon bool `json:"-"`
+
+	// This list contains the all of the AWS IAM users which are affected
+	// by the policy statement.
+	// +optional
+	AWSPrincipals StringOrArray `json:"AWS,omitempty"`
+
+	// This string contains the identifier for any federated web identity
+	// provider.
+	// +optional
+	Federated string `json:"Federated,omitempty"`
+
+	// Service define the services which can have access to this bucket
+	// +optional
+	Service StringOrArray `json:"Service,omitempty"`
+}
+
+type unmarshalPrinciple Principal
+
+// UnmarshalJSON unmarshals data into p.
+func (p *Principal) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		if single == "*" {
+			p.AllowAnon = true
+		}
+		return nil
+	}
+	var res unmarshalPrinciple
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+	*p = Principal(res)
+	return nil
+}
+
+// ConditionMap is map with the operator as key and the setting as values.
+// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html
+// for details.
+type ConditionMap map[string]ConditionSettings
+
+// ConditionSettings is a map of keys and values.
+// Depending on the type of operation, the values can strings, integers,
+// bools or lists of strings.
+type ConditionSettings map[string]any
+
+// UnmarshalJSON unmarshals data into m.
+func (m *ConditionSettings) UnmarshalJSON(data []byte) error {
+	res := map[string]any{}
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+	for k, v := range res {
+		// AWS converts bools into strings in conditions.
+		if b, isBool := v.(bool); isBool {
+			res[k] = strconv.FormatBool(b)
+		}
+	}
+	*m = res
+	return nil
+}
+
+// StringOrArray is a string array that supports parsing from a single string
+// as a single entry array.
+type StringOrArray []string
+
+// UnmarshalJSON unmarshals data into s.
+func (s *StringOrArray) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = StringOrArray{single}
+		return nil
+	}
+	list := []string{}
+	if err := json.Unmarshal(data, &list); err != nil {
+		return err
+	}
+	*s = list
+	return nil
+}


### PR DESCRIPTION
### Description of your changes

AWS converts bool values in policy conditions to strings when getting them from the API.

This adds a new policy parser based on structs that can handle AWS policies correctly, including single items instead of lists.

Fixes #1771

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Using the example provided in #1771. Added it as a unit test as well.

[contribution process]: https://git.io/fj2m9
