### PR TITLE
fix(iam/policy): Treat single items as array

### DIFF
--- a/pkg/clients/iam/policy.go
+++ b/pkg/clients/iam/policy.go
@@ -2,7 +2,6 @@ package iam
 
 import (
 	"context"
-	"net/url"
 
 	"github.com/crossplane-contrib/provider-aws/apis/iam/v1beta1"
 
@@ -10,9 +9,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/google/go-cmp/cmp"
 
 	awsclients "github.com/crossplane-contrib/provider-aws/pkg/clients"
+	policyutils "github.com/crossplane-contrib/provider-aws/pkg/utils/policy"
 )
 
 // PolicyClient is the external client used for Policy Custom Resource
@@ -44,29 +43,21 @@ func NewSTSClient(cfg aws.Config) STSClient {
 }
 
 // IsPolicyUpToDate checks whether there is a change in any of the modifiable fields in policy.
-func IsPolicyUpToDate(in v1beta1.PolicyParameters, policy iamtypes.PolicyVersion) (bool, error) {
-	// The AWS API returns Policy Document as an escaped string.
-	// Due to differences in the methods to escape a string, the comparison result between
-	// the spec.Document and policy.Document can sometimes be false negative (due to spaces, line feeds).
-	// Escaping with a common method and then comparing is a safe way.
-
-	if *policy.Document == "" || in.Document == "" {
-		return false, nil
+func IsPolicyUpToDate(in v1beta1.PolicyParameters, policy iamtypes.PolicyVersion) (bool, string, error) {
+	externalPolicyRaw := awsclients.StringValue(policy.Document)
+	if externalPolicyRaw == "" || in.Document == "" {
+		return false, "", nil
 	}
 
-	unescapedPolicy, err := url.QueryUnescape(aws.ToString(policy.Document))
+	externpolicy, err := policyutils.ParsePolicyString(externalPolicyRaw)
 	if err != nil {
-		return false, nil // nolint:nilerr
+		return false, "", err
+	}
+	specPolicy, err := policyutils.ParsePolicyString(in.Document)
+	if err != nil {
+		return false, "", err
 	}
 
-	compactPolicy, err := awsclients.CompactAndEscapeJSON(unescapedPolicy)
-	if err != nil {
-		return false, err
-	}
-	compactSpecPolicy, err := awsclients.CompactAndEscapeJSON(in.Document)
-	if err != nil {
-		return false, err
-	}
-
-	return cmp.Equal(compactPolicy, compactSpecPolicy), nil
+	areEqual, diff := policyutils.ArePoliciesEqal(&specPolicy, &externpolicy)
+	return areEqual, diff, nil
 }

--- a/pkg/controller/iam/policy/controller.go
+++ b/pkg/controller/iam/policy/controller.go
@@ -154,7 +154,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		return managed.ExternalObservation{}, awsclient.Wrap(err, errPolicyVersion)
 	}
 
-	update, err := iam.IsPolicyUpToDate(cr.Spec.ForProvider, *versionRsp.PolicyVersion)
+	update, diff, err := iam.IsPolicyUpToDate(cr.Spec.ForProvider, *versionRsp.PolicyVersion)
 
 	if err != nil {
 		return managed.ExternalObservation{}, awsclient.Wrap(err, errUpToDate)
@@ -169,6 +169,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	return managed.ExternalObservation{
 		ResourceExists:   true,
 		ResourceUpToDate: update && areRolesUpdated,
+		Diff:             diff,
 	}, nil
 }
 


### PR DESCRIPTION
### Description of your changes

Fixes the issue of single items in IAM policies. This treats:

```
action: "s3:PutObject"
```
as
```
action: ["s3:PutObject"]
```

Fixes #932 
Replaces #942

Related to #1772 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests

[contribution process]: https://git.io/fj2m9
