### PR TITLE
1063: Write IAM Role ARN to connection secret if secret ref is given

### DIFF
--- a/pkg/controller/iam/role/controller.go
+++ b/pkg/controller/iam/role/controller.go
@@ -137,7 +137,10 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	return managed.ExternalObservation{
 		ResourceExists:   true,
 		ResourceUpToDate: upToDate,
-		Diff:             diff,
+		ConnectionDetails: managed.ConnectionDetails{
+			"arn": []byte(cr.Status.AtProvider.ARN),
+		},
+		Diff: diff,
 	}, nil
 }
 


### PR DESCRIPTION
### Description of your changes

Adds the ARN for a Role to ConnectionDetails in external observations so that it gets published if a connection secret is requested.

Fixes #1063 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit test amended

Tested on local development environment using the following role and confirmed the connection secret contained the correct arn.

```
apiVersion: iam.aws.crossplane.io/v1beta1
kind: Role
metadata:
  name: "test-role"
spec:
  forProvider:
    description: Test Role Desc
    assumeRolePolicyDocument: |
      {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Principal": {
                    "Service": [
                        "ec2.amazonaws.com"
                    ]
                },
                "Action": [
                    "sts:AssumeRole"
                ]
            }
        ]
      }
    tags:
      - key: ManagedBy
        value: crossplane/provider-aws
  writeConnectionSecretToRef:
    name: "test-role-connection"
    namespace: "default"
```

```
kubectl get secret test-role-connection -o jsonpath='{.data.arn}' | base64 --decode
arn:aws:iam::xxxxxxxxxxxx:role/test-role
```

[contribution process]: https://git.io/fj2m9
