### PR TITLE
fix: Get web identity token filepath from environment

### DIFF
--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -371,7 +372,7 @@ func UsePodServiceAccountAssumeRoleWithWebIdentity(ctx context.Context, _ []byte
 			stscreds.NewWebIdentityRoleProvider(
 				stsclient,
 				StringValue(roleArn),
-				stscreds.IdentityTokenFile("/var/run/secrets/eks.amazonaws.com/serviceaccount/token"),
+				stscreds.IdentityTokenFile(getWebidentityTokenFilePath()),
 				webIdentityRoleOptions,
 			)),
 		),
@@ -380,6 +381,15 @@ func UsePodServiceAccountAssumeRoleWithWebIdentity(ctx context.Context, _ []byte
 		return nil, errors.Wrap(err, "failed to load assumed role AWS config")
 	}
 	return &cnf, err
+}
+
+const webIdentityTokenFileDefaultPath = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+
+func getWebidentityTokenFilePath() string {
+	if path := os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"); path != "" {
+		return path
+	}
+	return webIdentityTokenFileDefaultPath
 }
 
 // UsePodServiceAccount assumes an IAM role configured via a ServiceAccount.


### PR DESCRIPTION
### Description of your changes

Replaces the hardcoded web identity token filepath for with the environment variable `AWS_WEB_IDENTITY_TOKEN_FILE`.

Fixes #1775

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
