### PR TITLE
feat(ecs)!: Make force deletion explicit

### DIFF
--- a/apis/ecs/v1alpha1/custom_types.go
+++ b/apis/ecs/v1alpha1/custom_types.go
@@ -96,6 +96,10 @@ type CustomServiceParameters struct {
 	ClusterRef      *xpv1.Reference `json:"clusterRef,omitempty"`
 	ClusterSelector *xpv1.Selector  `json:"clusterSelector,omitempty"`
 
+	// Force Service to be deleted, even with task Running or Pending
+	// +optional
+	ForceDeletion bool `json:"forceDeletion,omitempty"`
+
 	// A load balancer object representing the load balancers to use with your service.
 	// For more information, see Service Load Balancing (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html)
 	// in the Amazon Elastic Container Service Developer Guide.

--- a/package/crds/ecs.aws.crossplane.io_services.yaml
+++ b/package/crds/ecs.aws.crossplane.io_services.yaml
@@ -240,6 +240,10 @@ spec:
                       is enabled for the service. If true, this enables execute command
                       functionality on all containers in the service tasks.
                     type: boolean
+                  forceDeletion:
+                    description: Force Service to be deleted, even with task Running
+                      or Pending
+                    type: boolean
                   healthCheckGracePeriodSeconds:
                     description: "The period of time, in seconds, that the Amazon
                       ECS service scheduler ignores unhealthy Elastic Load Balancing

--- a/pkg/controller/ecs/service/setup.go
+++ b/pkg/controller/ecs/service/setup.go
@@ -99,13 +99,8 @@ func preCreate(_ context.Context, cr *svcapitypes.Service, obj *svcsdk.CreateSer
 }
 
 func preDelete(_ context.Context, cr *svcapitypes.Service, obj *svcsdk.DeleteServiceInput) (bool, error) {
-	if aws.StringValue(cr.Spec.ForProvider.SchedulingStrategy) == svcsdk.SchedulingStrategyReplica {
-		if aws.Int64Value(cr.Status.AtProvider.RunningCount) > 0 || aws.Int64Value(cr.Status.AtProvider.PendingCount) > 0 {
-			// Force deletion of services even if they are not scaled down.
-			obj.SetForce(true)
-		}
-	}
 
+	obj.SetForce(cr.Spec.ForProvider.ForceDeletion)
 	obj.Cluster = cr.Spec.ForProvider.Cluster
 	obj.SetService(meta.GetExternalName(cr))
 


### PR DESCRIPTION
### Description of your changes

Fix ECS Service deletion when the task are in error

Currently with the validation, if the ecs service creates a task that is not possible to spin up (e.g. wrong image), it is also not possible to delete the service, because the cr.Status.AtProvider.RunningCount and cr.Status.AtProvider.PendingCount won't be greater than 0.
In aws console it was also possible to delete the service (with task in error) by selecting the "force" option
 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Created a ECS Task Definition with non existing image, created a ECS Service pointing to this Task Definition, and then removed the Service CR