### PR TITLE
Ignore ASG desiredCapacity when it's not set to make it compatible with the cluster-autoscaler

### DIFF
--- a/pkg/controller/autoscaling/autoscalinggroup/setup.go
+++ b/pkg/controller/autoscaling/autoscalinggroup/setup.go
@@ -216,7 +216,10 @@ func lateInitialize(in *svcapitypes.AutoScalingGroupParameters, asg *svcsdk.Desc
 	in.CapacityRebalance = awsclients.LateInitializeBoolPtr(in.CapacityRebalance, obs.CapacityRebalance)
 	in.DefaultCooldown = awsclients.LateInitializeInt64Ptr(in.DefaultCooldown, obs.DefaultCooldown)
 	in.DefaultInstanceWarmup = awsclients.LateInitializeInt64Ptr(in.DefaultInstanceWarmup, obs.DefaultInstanceWarmup)
-	in.DesiredCapacity = awsclients.LateInitializeInt64Ptr(in.DesiredCapacity, obs.DesiredCapacity)
+	// if desiredCapacity is not set, don't update the value
+	if in.DesiredCapacity != nil {
+		in.DesiredCapacity = awsclients.LateInitializeInt64Ptr(in.DesiredCapacity, obs.DesiredCapacity)
+	}
 	in.DesiredCapacityType = awsclients.LateInitializeStringPtr(in.DesiredCapacityType, obs.DesiredCapacityType)
 	in.HealthCheckGracePeriod = awsclients.LateInitializeInt64Ptr(in.HealthCheckGracePeriod, obs.HealthCheckGracePeriod)
 	in.HealthCheckType = awsclients.LateInitializeStringPtr(in.HealthCheckType, obs.HealthCheckType)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

As mentioned in https://github.com/crossplane/crossplane/blob/master/design/one-pager-ignore-changes.md?plain=1#L24-L27 and https://github.com/crossplane-contrib/provider-aws/pull/502, there is a race condition
  between crossplane and cluster autoscaler. When we use asg as self-managed nodegroup with cluster-autoscaler, the reconciling of crossplane asg controller will revert changes from cluster-autoscaler. If `desiredCapacity` is not set, we should leave it blank, and just let the cluster-autoscaler to manage it. This PR implements a similar logic in the managed nodegroup.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've manually test it, the test plan is here:

1. create ASG:
   a. create a ASG without `desiredCapacity`, the ASG can be created.
  ```
    maxSize: 400
    minSize: 0
  ```
  ```
   maxSize: 400
   minSize: 1
  ```
  b. create a ASG with `desiredCapacity`, the ASG configuration is as expected.
  ```
   maxSize: 400
   minSize: 0
   desiredCapacity: 1
```
3. update ASG
  a. modify ASG configuration on AWS console, modify the maxSize to 401, trigger the reconciling, the `desiredCapacity` doesn't change.
  b. add `desiredCapacity` configuration on ASG CR, the ASG configuration on AWS console changes as expected.
  c. remove `desiredCapacity` configuration from ASG CR, and modify the configuration on AWS console, it works as expected.