### PR TITLE
feat(efs/filesystem): update tags

### DIFF
--- a/examples/efs/filesystem.yaml
+++ b/examples/efs/filesystem.yaml
@@ -5,5 +5,10 @@ metadata:
 spec:
   forProvider:
     region: us-east-1
+    tags:
+      - key: "customKey"
+        value: "customValue"
+      - key: "Name" # special tagKey "Name" to name filesystem in AWS
+        value: "DisplayNameInAWS"
   providerConfigRef:
     name: example

--- a/pkg/controller/efs/filesystem/setup.go
+++ b/pkg/controller/efs/filesystem/setup.go
@@ -2,10 +2,14 @@ package filesystem
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/efs"
+	"github.com/aws/aws-sdk-go/service/efs/efsiface"
+	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
@@ -18,7 +22,13 @@ import (
 	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/efs/v1alpha1"
 	"github.com/crossplane-contrib/provider-aws/apis/v1alpha1"
 	awsclients "github.com/crossplane-contrib/provider-aws/pkg/clients"
+	svcutils "github.com/crossplane-contrib/provider-aws/pkg/controller/efs"
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
+)
+
+const (
+	errNotFileSystem    = "managed resource is not a FileSystem custom resource"
+	errKubeUpdateFailed = "cannot update EFS FileSystem custom resource"
 )
 
 // SetupFileSystem adds a controller that reconciles FileSystem.
@@ -26,13 +36,16 @@ func SetupFileSystem(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.FileSystemGroupKind)
 	opts := []option{
 		func(e *external) {
-			e.isUpToDate = isUpToDate
+			h := &hooks{client: e.client}
+			e.isUpToDate = h.isUpToDate
 			e.preCreate = preCreate
 			e.postCreate = postCreate
 			e.preObserve = preObserve
-			e.preUpdate = preUpdate
-			e.preDelete = preDelete
 			e.postObserve = postObserve
+			e.preUpdate = preUpdate
+			e.postUpdate = h.postUpdate
+			e.preDelete = preDelete
+			e.lateInitialize = lateInitialize
 		},
 	}
 
@@ -48,7 +61,7 @@ func SetupFileSystem(mgr ctrl.Manager, o controller.Options) error {
 		For(&svcapitypes.FileSystem{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(svcapitypes.FileSystemGroupVersionKind),
-			managed.WithInitializers(),
+			managed.WithInitializers(&tagger{kube: mgr.GetClient()}),
 			managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 			managed.WithPollInterval(o.PollInterval),
 			managed.WithLogger(o.Logger.WithValues("controller", name)),
@@ -56,13 +69,25 @@ func SetupFileSystem(mgr ctrl.Manager, o controller.Options) error {
 			managed.WithConnectionPublishers(cps...)))
 }
 
-func isUpToDate(cr *svcapitypes.FileSystem, obj *svcsdk.DescribeFileSystemsOutput) (bool, error) {
-	for _, res := range obj.FileSystems {
-		if awsclients.Int64Value(cr.Spec.ForProvider.ProvisionedThroughputInMibps) != int64(aws.Float64Value(res.ProvisionedThroughputInMibps)) {
-			return false, nil
-		}
+type hooks struct {
+	client efsiface.EFSAPI
+}
+
+func (e *hooks) isUpToDate(cr *svcapitypes.FileSystem, obj *svcsdk.DescribeFileSystemsOutput) (bool, error) {
+	in := cr.Spec.ForProvider
+	out := obj.FileSystems[0]
+
+	// to avoid AWS 409-error ("IncorrectFileSystemLifeCycleState" "File system ... is already being updated. Try again later.")
+	if awsclients.StringValue(obj.FileSystems[0].LifeCycleState) == string(svcapitypes.LifeCycleState_updating) {
+		return true, nil
 	}
-	return true, nil
+	switch {
+	case awsclients.StringValue(in.ThroughputMode) != awsclients.StringValue(out.ThroughputMode),
+		awsclients.Int64Value(in.ProvisionedThroughputInMibps) != int64(aws.Float64Value(out.ProvisionedThroughputInMibps)):
+		return false, nil
+	}
+
+	return svcutils.AreTagsUpToDate(e.client, cr.Spec.ForProvider.Tags, cr.Status.AtProvider.FileSystemID)
 }
 
 func preObserve(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.DescribeFileSystemsInput) error {
@@ -76,9 +101,18 @@ func postObserve(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.Desc
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
-	if awsclients.StringValue(obj.FileSystems[0].LifeCycleState) == string(svcapitypes.LifeCycleState_available) {
-		cr.SetConditions(xpv1.Available())
+
+	switch awsclients.StringValue(obj.FileSystems[0].LifeCycleState) {
+	case string(svcapitypes.LifeCycleState_available):
+		cr.Status.SetConditions(xpv1.Available())
+	case string(svcapitypes.LifeCycleState_creating):
+		cr.Status.SetConditions(xpv1.Creating())
+	case string(svcapitypes.LifeCycleState_deleting):
+		cr.Status.SetConditions(xpv1.Deleting())
+	default:
+		cr.Status.SetConditions(xpv1.Unavailable())
 	}
+
 	obs.ConnectionDetails = managed.ConnectionDetails{
 		svcapitypes.ResourceCredentialsSecretIDKey: []byte(meta.GetExternalName(cr)),
 	}
@@ -92,6 +126,17 @@ func preUpdate(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.Update
 		obj.ProvisionedThroughputInMibps = aws.Float64(float64(awsclients.Int64Value(cr.Spec.ForProvider.ProvisionedThroughputInMibps)))
 	}
 	return nil
+}
+
+func (e *hooks) postUpdate(_ context.Context, cr *svcapitypes.FileSystem, resp *svcsdk.UpdateFileSystemOutput, upd managed.ExternalUpdate, err error) (managed.ExternalUpdate, error) {
+	// Ignore a specific error AWS throws, when there were no actual changes in the UpdateFileSystem-Request
+	// to allow case where we only want to update the tags
+	// entire message of the error to ignore: "BadRequest: The file system won't be updated. The requested throughput mode or provisioned throughput value are the same as the current mode and value."
+	if err != nil && !strings.Contains(err.Error(), string("the same as the current")) {
+		return upd, err
+	}
+
+	return upd, svcutils.UpdateTagsForResource(e.client, cr.Spec.ForProvider.Tags, cr.Status.AtProvider.FileSystemID)
 }
 
 func preDelete(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.DeleteFileSystemInput) (bool, error) {
@@ -114,4 +159,24 @@ func postCreate(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.FileS
 	}
 	meta.SetExternalName(cr, awsclients.StringValue(obj.FileSystemId))
 	return managed.ExternalCreation{}, nil
+}
+
+func lateInitialize(spec *svcapitypes.FileSystemParameters, current *svcsdk.DescribeFileSystemsOutput) error {
+	obj := current.FileSystems[0]
+	spec.ThroughputMode = awsclients.LateInitializeStringPtr(spec.ThroughputMode, obj.ThroughputMode)
+	return nil
+}
+
+type tagger struct {
+	kube client.Client
+}
+
+func (t *tagger) Initialize(ctx context.Context, mg resource.Managed) error {
+	cr, ok := mg.(*svcapitypes.FileSystem)
+	if !ok {
+		return errors.New(errNotFileSystem)
+	}
+
+	cr.Spec.ForProvider.Tags = svcutils.AddExternalTags(mg, cr.Spec.ForProvider.Tags)
+	return errors.Wrap(t.kube.Update(ctx, cr), errKubeUpdateFailed)
 }

--- a/pkg/controller/efs/tags.go
+++ b/pkg/controller/efs/tags.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package efs
+
+import (
+	"sort"
+
+	svcsdk "github.com/aws/aws-sdk-go/service/efs"
+	"github.com/aws/aws-sdk-go/service/efs/efsiface"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/pkg/errors"
+
+	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/efs/v1alpha1"
+	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
+)
+
+const (
+	errListTagsForResource = "cannot list tags"
+	errRemoveTags          = "cannot remove tags"
+	errCreateTags          = "cannot create tags"
+)
+
+// AreTagsUpToDate for spec and resourceID
+func AreTagsUpToDate(client efsiface.EFSAPI, spec []*svcapitypes.Tag, resourceID *string) (bool, error) {
+	current, err := ListTagsForResource(client, resourceID)
+	if err != nil {
+		return false, err
+	}
+
+	add, remove := DiffTags(spec, current)
+
+	return len(add) == 0 && len(remove) == 0, nil
+}
+
+// UpdateTagsForResource with resourceID
+func UpdateTagsForResource(client efsiface.EFSAPI, spec []*svcapitypes.Tag, resourceID *string) error {
+	current, err := ListTagsForResource(client, resourceID)
+	if err != nil {
+		return err
+	}
+
+	add, remove := DiffTags(spec, current)
+	if len(remove) != 0 {
+		if _, err := client.UntagResource(&svcsdk.UntagResourceInput{
+			ResourceId: resourceID,
+			TagKeys:    remove,
+		}); err != nil {
+			return errors.Wrap(err, errRemoveTags)
+		}
+	}
+	if len(add) != 0 {
+		if _, err := client.TagResource(&svcsdk.TagResourceInput{
+			ResourceId: resourceID,
+			Tags:       add,
+		}); err != nil {
+			return errors.Wrap(err, errCreateTags)
+		}
+	}
+
+	return nil
+}
+
+// ListTagsForResource for the given resource
+func ListTagsForResource(client efsiface.EFSAPI, resourceID *string) ([]*svcsdk.Tag, error) {
+	req := &svcsdk.ListTagsForResourceInput{
+		ResourceId: resourceID,
+	}
+
+	resp, err := client.ListTagsForResource(req)
+	if err != nil {
+		return nil, errors.Wrap(err, errListTagsForResource)
+	}
+
+	return resp.Tags, nil
+}
+
+// DiffTags between spec and current
+func DiffTags(spec []*svcapitypes.Tag, current []*svcsdk.Tag) (addTags []*svcsdk.Tag, removeTags []*string) {
+	currentMap := make(map[string]string, len(current))
+	for _, t := range current {
+		currentMap[awsclient.StringValue(t.Key)] = awsclient.StringValue(t.Value)
+	}
+
+	specMap := make(map[string]string, len(spec))
+	for _, t := range spec {
+		key := awsclient.StringValue(t.Key)
+		val := awsclient.StringValue(t.Value)
+		specMap[key] = awsclient.StringValue(t.Value)
+
+		if currentVal, exists := currentMap[key]; exists {
+			if currentVal != val {
+				removeTags = append(removeTags, t.Key)
+				addTags = append(addTags, &svcsdk.Tag{
+					Key:   awsclient.String(key),
+					Value: awsclient.String(val),
+				})
+			}
+		} else {
+			addTags = append(addTags, &svcsdk.Tag{
+				Key:   awsclient.String(key),
+				Value: awsclient.String(val),
+			})
+		}
+	}
+
+	for _, t := range current {
+		key := awsclient.StringValue(t.Key)
+		if _, exists := specMap[key]; !exists {
+			removeTags = append(removeTags, awsclient.String(key))
+		}
+	}
+
+	return addTags, removeTags
+}
+
+// AddExternalTags to spec if they don't exist
+func AddExternalTags(mg resource.Managed, spec []*svcapitypes.Tag) []*svcapitypes.Tag {
+	tagMap := make(map[string]struct{}, len(spec))
+	for _, t := range spec {
+		tagMap[awsclient.StringValue(t.Key)] = struct{}{}
+	}
+
+	tags := spec
+	for _, t := range GetExternalTags(mg) {
+		if _, exists := tagMap[awsclient.StringValue(t.Key)]; !exists {
+			tags = append(tags, t)
+		}
+	}
+
+	return tags
+}
+
+// GetExternalTags is a wrapper around resource.GetExternalTags to return a sorted array instead of a map
+func GetExternalTags(mg resource.Managed) []*svcapitypes.Tag {
+	externalTags := []*svcapitypes.Tag{}
+	for k, v := range resource.GetExternalTags(mg) {
+		externalTags = append(externalTags, &svcapitypes.Tag{Key: awsclient.String(k), Value: awsclient.String(v)})
+	}
+
+	sort.Slice(externalTags, func(i, j int) bool {
+		return awsclient.StringValue(externalTags[i].Key) > awsclient.StringValue(externalTags[j].Key)
+	})
+
+	return externalTags
+}


### PR DESCRIPTION
### Description of your changes

Fixes #1284

add tag update functionality to EFS Filesystem

Similar to RDS Optiongroup, I put the tags-update-call into isUpToDate() and not into postUpdate(). (see here: https://github.com/crossplane-contrib/provider-aws/blob/9205a212d0c301cca16697c1c159d4de60cc2826/pkg/controller/rds/optiongroup/setup.go#L115-L122)

The reason is probably the same: AWS denies the "regular" UpdateFileSystem()-Call, if there is no actual change included. See the received error:

> {RespMetadata: {StatusCode: 400, RequestID: ""}, 
ErrorCode: "BadRequest", Message_: "The file system won't be updated. The requested throughput mode or provisioned throughput value are the same as the current mode and value."}

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually with example

[contribution process]: https://git.io/fj2m9
