### PR TITLE
fix(rds/dbinstance): remove minor engineVersion lateinit

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -267,12 +267,6 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 		in.StorageEncrypted = aws.LateInitializeBoolPtr(in.StorageEncrypted, db.StorageEncrypted)
 		in.StorageType = aws.LateInitializeStringPtr(in.StorageType, db.StorageType)
 		in.EngineVersion = aws.LateInitializeStringPtr(in.EngineVersion, db.EngineVersion)
-		// When version 5.6 is chosen, AWS creates 5.6.41 and that's totally valid.
-		// But we detect as if we need to update it all the time. Here, we assign
-		// the actual full version to our spec to avoid unnecessary update signals.
-		if strings.HasPrefix(aws.StringValue(db.EngineVersion), aws.StringValue(in.EngineVersion)) {
-			in.EngineVersion = db.EngineVersion
-		}
 		if in.DBParameterGroupName == nil {
 			for i := range db.DBParameterGroups {
 				if db.DBParameterGroups[i].DBParameterGroupName != nil {


### PR DESCRIPTION
### Description of your changes


Since the change from https://github.com/crossplane-contrib/provider-aws/pull/1765, the handling of major and minor engine version is now thoroughly in isUpToDate(). Also the actual `engineVersion` is now displayed in `status.atProvider`.
I noticed that for DBInstance, there was still some code in lateInit(), that also tackled that issue. This results in "unclean" display of the complete engine version also in `forProvider` even when the user only wants to set the major engine version.
This can and should now be removed.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually