### PR TITLE
fix(rdsinstance/dbinstance): check optiongroupname correctly

### DIFF
--- a/examples/database/rdsinstance.yaml
+++ b/examples/database/rdsinstance.yaml
@@ -6,6 +6,7 @@ spec:
   forProvider:
     region: us-east-1
     allocatedStorage: 20
+    applyModificationsImmediately: true # default is false
     autoMinorVersionUpgrade: true
     backupRetentionPeriod: 0
     caCertificateIdentifier: rds-ca-2019
@@ -15,7 +16,7 @@ spec:
     enableIAMDatabaseAuthentication: false
     enablePerformanceInsights: false
     engine: mysql
-    engineVersion: 8.0.28
+    engineVersion: "8.0.28"
     finalDBSnapshotIdentifier: muvaf-test
     licenseModel: general-public-license
     masterUsername: admin


### PR DESCRIPTION
### Description of your changes

In the controllers of the resources database `RDSInstance` and rds `DBInstance` an extra check for the parameter `OptionGroupName` is added as this needs to be checked against the entries of `OptionGroupMemberships` given by the Describe output.


Fixes #1795 (similar `CloudwatchLogsExportConfiguration` issue will be addressed in separate PR)


**Note**: rds `DBCluster` also has the field `OptionGroupName` , so I tried implementing the same logic here too. However I got this error: 

> create failed: cannot create DBCluster in AWS: InvalidParameterCombination: Option groups are not supported for DB Clusters

So one may consider removing the field here? (see also no such field 
 at terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster)


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually
