### PR TITLE
fix: ignore returned false value when local nil

### DIFF
--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -334,7 +334,9 @@ func isLoggingInfoUpToDate(wanted *svcapitypes.LoggingInfo, current *svcsdk.Logg
 					return false
 				}
 			} else if current.BrokerLogs.Firehose != nil {
-				return false
+				if aws.BoolValue(current.BrokerLogs.Firehose.Enabled) {
+					return false
+				}
 			}
 
 			if wanted.BrokerLogs.S3 != nil {
@@ -354,7 +356,9 @@ func isLoggingInfoUpToDate(wanted *svcapitypes.LoggingInfo, current *svcsdk.Logg
 					return false
 				}
 			} else if current.BrokerLogs.S3 != nil {
-				return false
+				if aws.BoolValue(current.BrokerLogs.S3.Enabled) {
+					return false
+				}
 			}
 		} else if current.BrokerLogs != nil {
 			return false


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
AWS returns enabled: false for kafka cluster logging settings by default, this pull request updates the provider code to ignore this if the logging settings of the managed resource are set to nil

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

tested locally 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
