### PR TITLE
fix: enable encryptionatrest and inCluster

### DIFF
--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -754,11 +754,6 @@ func (u *updater) update(ctx context.Context, mg cpresource.Managed) (managed.Ex
 
 			if !encryptionUpToDate {
 				input.EncryptionInfo = generateEncryptionInfo(wanted.EncryptionInfo)
-
-				// input.EncryptionInfo.EncryptionAtRest = nil // "Updating encryption-at-rest settings on your cluster is not currently supported."
-				// if input.EncryptionInfo.EncryptionInTransit != nil {
-				// 	input.EncryptionInfo.EncryptionInTransit.InCluster = nil // "Updating the inter-broker encryption setting on your cluster is not currently supported."
-				// }
 			}
 
 			_, err := u.client.UpdateSecurityWithContext(ctx, input)

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -755,10 +755,10 @@ func (u *updater) update(ctx context.Context, mg cpresource.Managed) (managed.Ex
 			if !encryptionUpToDate {
 				input.EncryptionInfo = generateEncryptionInfo(wanted.EncryptionInfo)
 
-				input.EncryptionInfo.EncryptionAtRest = nil // "Updating encryption-at-rest settings on your cluster is not currently supported."
-				if input.EncryptionInfo.EncryptionInTransit != nil {
-					input.EncryptionInfo.EncryptionInTransit.InCluster = nil // "Updating the inter-broker encryption setting on your cluster is not currently supported."
-				}
+				// input.EncryptionInfo.EncryptionAtRest = nil // "Updating encryption-at-rest settings on your cluster is not currently supported."
+				// if input.EncryptionInfo.EncryptionInTransit != nil {
+				// 	input.EncryptionInfo.EncryptionInTransit.InCluster = nil // "Updating the inter-broker encryption setting on your cluster is not currently supported."
+				// }
 			}
 
 			_, err := u.client.UpdateSecurityWithContext(ctx, input)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This update should fix the error  "cannot update Security of Cluster in AWS: BadRequestException: The request does not include any updates to the security setting of the cluster. Verify the request, then try again."

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
