### PR TITLE
chore: Add context to ACK isUpToDate and return diff

### DIFF
--- a/pkg/clients/dax/fake/fake.go
+++ b/pkg/clients/dax/fake/fake.go
@@ -46,7 +46,8 @@ type MockDaxClient struct {
 	MockDescribeParameterGroups            func(*dax.DescribeParameterGroupsInput) (*dax.DescribeParameterGroupsOutput, error)
 	MockDescribeParameterGroupsWithContext func(context.Context, *dax.DescribeParameterGroupsInput, []request.Option) (*dax.DescribeParameterGroupsOutput, error)
 
-	MockDescribeParameters func(*dax.DescribeParametersInput) (*dax.DescribeParametersOutput, error)
+	MockDescribeParameters            func(*dax.DescribeParametersInput) (*dax.DescribeParametersOutput, error)
+	MockDescribeParametersWithContext func(context.Context, *dax.DescribeParametersInput, []request.Option) (*dax.DescribeParametersOutput, error)
 
 	MockDescribeSubnetGroups            func(*dax.DescribeSubnetGroupsInput) (*dax.DescribeSubnetGroupsOutput, error)
 	MockDescribeSubnetGroupsWithContext func(context.Context, *dax.DescribeSubnetGroupsInput, []request.Option) (*dax.DescribeSubnetGroupsOutput, error)
@@ -123,6 +124,20 @@ func (m *MockDaxClient) DescribeParameters(i *dax.DescribeParametersInput) (*dax
 	m.Called.DescribeParameters = append(m.Called.DescribeParameters, &CallDescribeParameters{I: i})
 
 	return m.MockDescribeParameters(i)
+}
+
+// CallDescribeParametersWithContext to log calls
+type CallDescribeParametersWithContext struct {
+	Ctx  context.Context
+	I    *dax.DescribeParametersInput
+	Opts []request.Option
+}
+
+// DescribeParametersWithContext mocks DescribeParametersWithContext method
+func (m *MockDaxClient) DescribeParametersWithContext(ctx context.Context, i *dax.DescribeParametersInput, opts ...request.Option) (*dax.DescribeParametersOutput, error) {
+	m.Called.DescribeParametersWithContext = append(m.Called.DescribeParametersWithContext, &CallDescribeParametersWithContext{Ctx: ctx, I: i})
+
+	return m.MockDescribeParametersWithContext(ctx, i, opts)
 }
 
 // CallCreateParameterGroupWithContext to log calls
@@ -316,6 +331,7 @@ type MockDaxClientCall struct {
 	DescribeParameterGroupsWithContext []*CallDescribeParameterGroupsWithContext
 	DescribeParameterGroups            []*CallDescribeParameterGroups
 	DescribeParameters                 []*CallDescribeParameters
+	DescribeParametersWithContext      []*CallDescribeParametersWithContext
 	CreateParameterGroupWithContext    []*CallCreateParameterGroupWithContext
 	DeleteParameterGroupWithContext    []*CallDeleteParameterGroupWithContext
 

--- a/pkg/clients/docdb/fake/fake.go
+++ b/pkg/clients/docdb/fake/fake.go
@@ -43,6 +43,7 @@ type MockDocDBClient struct {
 	MockDeleteDBSubnetGroupWithContext    func(context.Context, *docdb.DeleteDBSubnetGroupInput, []request.Option) (*docdb.DeleteDBSubnetGroupOutput, error)
 
 	MockDescribeDBClusterParameters                 func(*docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error)
+	MockDescribeDBClusterParametersWithContext      func(context.Context, *docdb.DescribeDBClusterParametersInput, []request.Option) (*docdb.DescribeDBClusterParametersOutput, error)
 	MockDescribeDBClusterParameterGroupsWithContext func(context.Context, *docdb.DescribeDBClusterParameterGroupsInput, []request.Option) (*docdb.DescribeDBClusterParameterGroupsOutput, error)
 	MockCreateDBClusterParameterGroupWithContext    func(context.Context, *docdb.CreateDBClusterParameterGroupInput, []request.Option) (*docdb.CreateDBClusterParameterGroupOutput, error)
 	MockModifyDBClusterParameterGroupWithContext    func(context.Context, *docdb.ModifyDBClusterParameterGroupInput, []request.Option) (*docdb.ModifyDBClusterParameterGroupOutput, error)
@@ -219,6 +220,20 @@ func (m *MockDocDBClient) DescribeDBClusterParameters(i *docdb.DescribeDBCluster
 	return m.MockDescribeDBClusterParameters(i)
 }
 
+// CallDescribeDBClusterParametersWithContext to log call
+type CallDescribeDBClusterParametersWithContext struct {
+	Ctx  aws.Context
+	I    *docdb.DescribeDBClusterParametersInput
+	Opts []request.Option
+}
+
+// DescribeDBClusterParametersWithContext calls MockDescribeDBClusterParametersWithContext
+func (m *MockDocDBClient) DescribeDBClusterParametersWithContext(ctx context.Context, i *docdb.DescribeDBClusterParametersInput, opts ...request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
+	m.Called.DescribeDBClusterParametersWithContext = append(m.Called.DescribeDBClusterParametersWithContext, &CallDescribeDBClusterParametersWithContext{I: i, Ctx: ctx, Opts: opts})
+
+	return m.MockDescribeDBClusterParametersWithContext(ctx, i, opts)
+}
+
 // CallDescribeDBClusterParameterGroupsWithContext to log call
 type CallDescribeDBClusterParameterGroupsWithContext struct {
 	Ctx  aws.Context
@@ -375,6 +390,7 @@ type MockDocDBClientCall struct {
 	DeleteDBSubnetGroupWithContext    []*CallDeleteDBSubnetGroupWithContext
 
 	DescribeDBClusterParameters                 []*CallDescribeDBClusterParameters
+	DescribeDBClusterParametersWithContext      []*CallDescribeDBClusterParametersWithContext
 	DescribeDBClusterParameterGroupsWithContext []*CallDescribeDBClusterParameterGroupsWithContext
 	CreateDBClusterParameterGroupWithContext    []*CallCreateDBClusterParameterGroupWithContext
 	ModifyDBClusterParameterGroupWithContext    []*CallModifyDBClusterParameterGroupWithContext

--- a/pkg/controller/apigateway/requestvalidator/zz_controller.go
+++ b/pkg/controller/apigateway/requestvalidator/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateRequestValidator(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -198,7 +199,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.RequestValidator, *svcsdk.GetRequestValidatorInput) error
 	postObserve    func(context.Context, *svcapitypes.RequestValidator, *svcsdk.UpdateRequestValidatorOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.RequestValidatorParameters, *svcsdk.UpdateRequestValidatorOutput) error
-	isUpToDate     func(*svcapitypes.RequestValidator, *svcsdk.UpdateRequestValidatorOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.RequestValidator, *svcsdk.UpdateRequestValidatorOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.RequestValidator, *svcsdk.CreateRequestValidatorInput) error
 	postCreate     func(context.Context, *svcapitypes.RequestValidator, *svcsdk.UpdateRequestValidatorOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.RequestValidator, *svcsdk.DeleteRequestValidatorInput) (bool, error)
@@ -217,8 +218,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.RequestValidator, _ *svcsd
 func nopLateInitialize(*svcapitypes.RequestValidatorParameters, *svcsdk.UpdateRequestValidatorOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.RequestValidator, *svcsdk.UpdateRequestValidatorOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.RequestValidator, *svcsdk.UpdateRequestValidatorOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.RequestValidator, *svcsdk.CreateRequestValidatorInput) error {

--- a/pkg/controller/apigateway/resource/setup_test.go
+++ b/pkg/controller/apigateway/resource/setup_test.go
@@ -244,7 +244,7 @@ func TestIsUpToDate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			// Act
-			result, err := isUpToDate(tc.args.cr, tc.args.obj)
+			result, _, err := isUpToDate(context.Background(), tc.args.cr, tc.args.obj)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/controller/apigateway/restapi/setup_test.go
+++ b/pkg/controller/apigateway/restapi/setup_test.go
@@ -374,7 +374,7 @@ func TestIsUpToDate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			// Act
-			result, err := isUpToDate(tc.args.cr, tc.args.obj)
+			result, _, err := isUpToDate(context.Background(), tc.args.cr, tc.args.obj)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/controller/apigateway/vpclink/zz_controller.go
+++ b/pkg/controller/apigateway/vpclink/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateVPCLink(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -225,7 +226,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.VPCLink, *svcsdk.GetVpcLinkInput) error
 	postObserve    func(context.Context, *svcapitypes.VPCLink, *svcsdk.UpdateVpcLinkOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.VPCLinkParameters, *svcsdk.UpdateVpcLinkOutput) error
-	isUpToDate     func(*svcapitypes.VPCLink, *svcsdk.UpdateVpcLinkOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.VPCLink, *svcsdk.UpdateVpcLinkOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.VPCLink, *svcsdk.CreateVpcLinkInput) error
 	postCreate     func(context.Context, *svcapitypes.VPCLink, *svcsdk.UpdateVpcLinkOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.VPCLink, *svcsdk.DeleteVpcLinkInput) (bool, error)
@@ -244,8 +245,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.VPCLink, _ *svcsdk.UpdateV
 func nopLateInitialize(*svcapitypes.VPCLinkParameters, *svcsdk.UpdateVpcLinkOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.VPCLink, *svcsdk.UpdateVpcLinkOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.VPCLink, *svcsdk.UpdateVpcLinkOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.VPCLink, *svcsdk.CreateVpcLinkInput) error {

--- a/pkg/controller/apigatewayv2/deployment/zz_controller.go
+++ b/pkg/controller/apigatewayv2/deployment/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDeployment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -209,7 +210,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Deployment, *svcsdk.GetDeploymentInput) error
 	postObserve    func(context.Context, *svcapitypes.Deployment, *svcsdk.GetDeploymentOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.DeploymentParameters, *svcsdk.GetDeploymentOutput) error
-	isUpToDate     func(*svcapitypes.Deployment, *svcsdk.GetDeploymentOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Deployment, *svcsdk.GetDeploymentOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Deployment, *svcsdk.CreateDeploymentInput) error
 	postCreate     func(context.Context, *svcapitypes.Deployment, *svcsdk.CreateDeploymentOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Deployment, *svcsdk.DeleteDeploymentInput) (bool, error)
@@ -228,8 +229,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Deployment, _ *svcsdk.GetD
 func nopLateInitialize(*svcapitypes.DeploymentParameters, *svcsdk.GetDeploymentOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Deployment, *svcsdk.GetDeploymentOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Deployment, *svcsdk.GetDeploymentOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Deployment, *svcsdk.CreateDeploymentInput) error {

--- a/pkg/controller/apigatewayv2/domainname/zz_controller.go
+++ b/pkg/controller/apigatewayv2/domainname/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDomainName(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -252,7 +253,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.DomainName, *svcsdk.GetDomainNameInput) error
 	postObserve    func(context.Context, *svcapitypes.DomainName, *svcsdk.GetDomainNameOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.DomainNameParameters, *svcsdk.GetDomainNameOutput) error
-	isUpToDate     func(*svcapitypes.DomainName, *svcsdk.GetDomainNameOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DomainName, *svcsdk.GetDomainNameOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DomainName, *svcsdk.CreateDomainNameInput) error
 	postCreate     func(context.Context, *svcapitypes.DomainName, *svcsdk.CreateDomainNameOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DomainName, *svcsdk.DeleteDomainNameInput) (bool, error)
@@ -271,8 +272,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.DomainName, _ *svcsdk.GetD
 func nopLateInitialize(*svcapitypes.DomainNameParameters, *svcsdk.GetDomainNameOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DomainName, *svcsdk.GetDomainNameOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DomainName, *svcsdk.GetDomainNameOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DomainName, *svcsdk.CreateDomainNameInput) error {

--- a/pkg/controller/apigatewayv2/model/zz_controller.go
+++ b/pkg/controller/apigatewayv2/model/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateModel(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -203,7 +204,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Model, *svcsdk.GetModelInput) error
 	postObserve    func(context.Context, *svcapitypes.Model, *svcsdk.GetModelOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ModelParameters, *svcsdk.GetModelOutput) error
-	isUpToDate     func(*svcapitypes.Model, *svcsdk.GetModelOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Model, *svcsdk.GetModelOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Model, *svcsdk.CreateModelInput) error
 	postCreate     func(context.Context, *svcapitypes.Model, *svcsdk.CreateModelOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Model, *svcsdk.DeleteModelInput) (bool, error)
@@ -222,8 +223,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Model, _ *svcsdk.GetModelO
 func nopLateInitialize(*svcapitypes.ModelParameters, *svcsdk.GetModelOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Model, *svcsdk.GetModelOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Model, *svcsdk.GetModelOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Model, *svcsdk.CreateModelInput) error {

--- a/pkg/controller/apigatewayv2/stage/zz_controller.go
+++ b/pkg/controller/apigatewayv2/stage/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateStage(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -304,7 +305,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Stage, *svcsdk.GetStageInput) error
 	postObserve    func(context.Context, *svcapitypes.Stage, *svcsdk.GetStageOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.StageParameters, *svcsdk.GetStageOutput) error
-	isUpToDate     func(*svcapitypes.Stage, *svcsdk.GetStageOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Stage, *svcsdk.GetStageOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Stage, *svcsdk.CreateStageInput) error
 	postCreate     func(context.Context, *svcapitypes.Stage, *svcsdk.CreateStageOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Stage, *svcsdk.DeleteStageInput) (bool, error)
@@ -323,8 +324,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Stage, _ *svcsdk.GetStageO
 func nopLateInitialize(*svcapitypes.StageParameters, *svcsdk.GetStageOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Stage, *svcsdk.GetStageOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Stage, *svcsdk.GetStageOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Stage, *svcsdk.CreateStageInput) error {

--- a/pkg/controller/autoscaling/autoscalinggroup/setup.go
+++ b/pkg/controller/autoscaling/autoscalinggroup/setup.go
@@ -67,20 +67,20 @@ func SetupAutoScalingGroup(mgr ctrl.Manager, o controller.Options) error {
 		Complete(r)
 }
 
-func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScalingGroupsOutput) (bool, error) { // nolint:gocyclo
+func isUpToDate(_ context.Context, obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScalingGroupsOutput) (bool, string, error) { // nolint:gocyclo
 	in := obj.Spec.ForProvider
 	asg := obs.AutoScalingGroups[0]
 
 	if !cmp.Equal(in.CapacityRebalance, asg.CapacityRebalance) {
-		return false, nil
+		return false, "", nil
 	}
 	// DefaultInstanceWarmup can be updated
 	if !cmp.Equal(in.DefaultInstanceWarmup, asg.DefaultInstanceWarmup) {
-		return false, nil
+		return false, "", nil
 	}
 	// DesiredCapacityType can be updated
 	if !cmp.Equal(in.DesiredCapacityType, asg.DesiredCapacityType) {
-		return false, nil
+		return false, "", nil
 	}
 	// Context is reserved
 	// if !cmp.Equal(*in.Context, *asg.Context) {
@@ -88,68 +88,68 @@ func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScali
 	// }
 	// DefaultCooldown can be updated
 	if !cmp.Equal(in.DefaultCooldown, asg.DefaultCooldown) {
-		return false, nil
+		return false, "", nil
 	}
 	// DesiredCapacity can be updated
 	if !cmp.Equal(in.DesiredCapacity, asg.DesiredCapacity) {
-		return false, nil
+		return false, "", nil
 	}
 	// HealthCheckGracePeriod can be updated
 	if !cmp.Equal(in.HealthCheckGracePeriod, asg.HealthCheckGracePeriod) {
-		return false, nil
+		return false, "", nil
 	}
 	// HealthCheckType can be updated
 	if !cmp.Equal(in.HealthCheckType, asg.HealthCheckType) {
-		return false, nil
+		return false, "", nil
 	}
 	// MaxInstanceLifetime can be updated
 	if !cmp.Equal(in.MaxInstanceLifetime, asg.MaxInstanceLifetime) {
-		return false, nil
+		return false, "", nil
 	}
 	// MaxSize can be updated
 	if !cmp.Equal(in.MaxSize, asg.MaxSize) {
-		return false, nil
+		return false, "", nil
 	}
 	// MinSize can be updated
 	if !cmp.Equal(in.MinSize, asg.MinSize) {
-		return false, nil
+		return false, "", nil
 	}
 	// NewInstancesProtectedFromScaleIn can be updated
 	if !cmp.Equal(in.NewInstancesProtectedFromScaleIn, asg.NewInstancesProtectedFromScaleIn) {
-		return false, nil
+		return false, "", nil
 	}
 	if !cmp.Equal(in.PlacementGroup, asg.PlacementGroup) {
-		return false, nil
+		return false, "", nil
 	}
 	// VPCZoneIdentifier can be updated
 	if !cmp.Equal(in.VPCZoneIdentifier, asg.VPCZoneIdentifier) {
-		return false, nil
+		return false, "", nil
 	}
 	// LaunchTemplate can be updated
 	if in.LaunchTemplate != nil && asg.LaunchTemplate != nil {
 		if !cmp.Equal(in.LaunchTemplate.LaunchTemplateID, asg.LaunchTemplate.LaunchTemplateId) {
-			return false, nil
+			return false, "", nil
 		}
 		if !cmp.Equal(in.LaunchTemplate.LaunchTemplateName, asg.LaunchTemplate.LaunchTemplateName) {
-			return false, nil
+			return false, "", nil
 		}
 		if !cmp.Equal(in.LaunchTemplate.Version, asg.LaunchTemplate.Version) {
-			return false, nil
+			return false, "", nil
 		}
 	}
 	// MixedInstancesPolicy can be updated
 	if in.MixedInstancesPolicy != nil && asg.MixedInstancesPolicy != nil {
 		if in.MixedInstancesPolicy.InstancesDistribution != nil && asg.MixedInstancesPolicy.InstancesDistribution != nil {
 			if !cmp.Equal(in.MixedInstancesPolicy.InstancesDistribution, asg.MixedInstancesPolicy.InstancesDistribution) {
-				return false, nil
+				return false, "", nil
 			}
 		}
 		if in.MixedInstancesPolicy.LaunchTemplate != nil && asg.MixedInstancesPolicy.LaunchTemplate != nil {
 			if !cmp.Equal(in.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification, asg.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification) {
-				return false, nil
+				return false, "", nil
 			}
 			if !cmp.Equal(in.MixedInstancesPolicy.LaunchTemplate.Overrides, asg.MixedInstancesPolicy.LaunchTemplate.Overrides) {
-				return false, nil
+				return false, "", nil
 			}
 		}
 	}
@@ -161,7 +161,7 @@ func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScali
 		return *asg.AvailabilityZones[i] < *asg.AvailabilityZones[j]
 	})
 	if !cmp.Equal(in.AvailabilityZones, asg.AvailabilityZones) {
-		return false, nil
+		return false, "", nil
 	}
 	// LoadBalancerNames can be updated
 	sort.Slice(in.LoadBalancerNames, func(i, j int) bool {
@@ -171,7 +171,7 @@ func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScali
 		return *asg.LoadBalancerNames[i] < *asg.LoadBalancerNames[j]
 	})
 	if !cmp.Equal(in.LoadBalancerNames, asg.LoadBalancerNames) {
-		return false, nil
+		return false, "", nil
 	}
 	// Tags can be updated
 	sort.Slice(in.Tags, func(i, j int) bool {
@@ -181,7 +181,7 @@ func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScali
 		return *asg.Tags[i].Key < *asg.Tags[j].Key
 	})
 	if !cmp.Equal(in.Tags, asg.Tags) {
-		return false, nil
+		return false, "", nil
 	}
 
 	// TargetGroupARNs
@@ -203,7 +203,7 @@ func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScali
 		return *asg.TerminationPolicies[i] < *asg.TerminationPolicies[j]
 	})
 	if !cmp.Equal(in.TerminationPolicies, asg.TerminationPolicies) {
-		return false, nil
+		return false, "", nil
 	}
 
 	// TrafficSources
@@ -216,7 +216,7 @@ func isUpToDate(obj *svcapitypes.AutoScalingGroup, obs *svcsdk.DescribeAutoScali
 	// if !cmp.Equal(in.TrafficSources, asg.TrafficSources) {
 	// 	return false, nil
 	// }
-	return true, nil
+	return true, "", nil
 }
 
 func lateInitialize(in *svcapitypes.AutoScalingGroupParameters, asg *svcsdk.DescribeAutoScalingGroupsOutput) error {

--- a/pkg/controller/cloudfront/cachepolicy/setup.go
+++ b/pkg/controller/cloudfront/cachepolicy/setup.go
@@ -126,7 +126,7 @@ func lateInitialize(in *svcapitypes.CachePolicyParameters, gpo *svcsdk.GetCacheP
 	return err
 }
 
-func isUpToDate(cp *svcapitypes.CachePolicy, gpo *svcsdk.GetCachePolicyOutput) (bool, error) {
+func isUpToDate(_ context.Context, cp *svcapitypes.CachePolicy, gpo *svcsdk.GetCachePolicyOutput) (bool, string, error) {
 	return cloudfront.IsUpToDate(gpo.CachePolicy.CachePolicyConfig, cp.Spec.ForProvider.CachePolicyConfig,
 		mappingOptions...)
 }

--- a/pkg/controller/cloudfront/cachepolicy/zz_controller.go
+++ b/pkg/controller/cloudfront/cachepolicy/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateCachePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -296,7 +297,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.CachePolicy, *svcsdk.GetCachePolicyInput) error
 	postObserve    func(context.Context, *svcapitypes.CachePolicy, *svcsdk.GetCachePolicyOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.CachePolicyParameters, *svcsdk.GetCachePolicyOutput) error
-	isUpToDate     func(*svcapitypes.CachePolicy, *svcsdk.GetCachePolicyOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.CachePolicy, *svcsdk.GetCachePolicyOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.CachePolicy, *svcsdk.CreateCachePolicyInput) error
 	postCreate     func(context.Context, *svcapitypes.CachePolicy, *svcsdk.CreateCachePolicyOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.CachePolicy, *svcsdk.DeleteCachePolicyInput) (bool, error)
@@ -315,8 +316,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.CachePolicy, _ *svcsdk.Get
 func nopLateInitialize(*svcapitypes.CachePolicyParameters, *svcsdk.GetCachePolicyOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.CachePolicy, *svcsdk.GetCachePolicyOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.CachePolicy, *svcsdk.GetCachePolicyOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.CachePolicy, *svcsdk.CreateCachePolicyInput) error {

--- a/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/setup.go
+++ b/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/setup.go
@@ -124,6 +124,7 @@ func preDelete(_ context.Context, cp *svcapitypes.CloudFrontOriginAccessIdentity
 	return false, nil
 }
 
-func isUpToDate(cp *svcapitypes.CloudFrontOriginAccessIdentity, gpo *svcsdk.GetCloudFrontOriginAccessIdentityOutput) (bool, error) {
-	return cmp.Equal(cp.Spec.ForProvider.CloudFrontOriginAccessIdentityConfig.Comment, gpo.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig.Comment), nil
+func isUpToDate(_ context.Context, cp *svcapitypes.CloudFrontOriginAccessIdentity, gpo *svcsdk.GetCloudFrontOriginAccessIdentityOutput) (bool, string, error) {
+	diff := cmp.Diff(cp.Spec.ForProvider.CloudFrontOriginAccessIdentityConfig.Comment, gpo.CloudFrontOriginAccessIdentity.CloudFrontOriginAccessIdentityConfig.Comment)
+	return diff == "", diff, nil
 }

--- a/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/zz_controller.go
+++ b/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateCloudFrontOriginAccessIdentity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -207,7 +208,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.GetCloudFrontOriginAccessIdentityInput) error
 	postObserve    func(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.GetCloudFrontOriginAccessIdentityOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.CloudFrontOriginAccessIdentityParameters, *svcsdk.GetCloudFrontOriginAccessIdentityOutput) error
-	isUpToDate     func(*svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.GetCloudFrontOriginAccessIdentityOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.GetCloudFrontOriginAccessIdentityOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.CreateCloudFrontOriginAccessIdentityInput) error
 	postCreate     func(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.CreateCloudFrontOriginAccessIdentityOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.DeleteCloudFrontOriginAccessIdentityInput) (bool, error)
@@ -226,8 +227,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.CloudFrontOriginAccessIden
 func nopLateInitialize(*svcapitypes.CloudFrontOriginAccessIdentityParameters, *svcsdk.GetCloudFrontOriginAccessIdentityOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.GetCloudFrontOriginAccessIdentityOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.GetCloudFrontOriginAccessIdentityOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.CloudFrontOriginAccessIdentity, *svcsdk.CreateCloudFrontOriginAccessIdentityInput) error {

--- a/pkg/controller/cloudfront/responseheaderspolicy/setup.go
+++ b/pkg/controller/cloudfront/responseheaderspolicy/setup.go
@@ -200,7 +200,7 @@ func lateInitialize(in *svcapitypes.ResponseHeadersPolicyParameters, grhpo *svcs
 	return err
 }
 
-func isUpToDate(rhp *svcapitypes.ResponseHeadersPolicy, grhpo *svcsdk.GetResponseHeadersPolicyOutput) (bool, error) {
+func isUpToDate(_ context.Context, rhp *svcapitypes.ResponseHeadersPolicy, grhpo *svcsdk.GetResponseHeadersPolicyOutput) (bool, string, error) {
 	return cloudfront.IsUpToDate(grhpo.ResponseHeadersPolicy, rhp.Spec.ForProvider.ResponseHeadersPolicyConfig,
 		mappingOptions...)
 }

--- a/pkg/controller/cloudfront/responseheaderspolicy/zz_controller.go
+++ b/pkg/controller/cloudfront/responseheaderspolicy/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateResponseHeadersPolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -398,7 +399,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.GetResponseHeadersPolicyInput) error
 	postObserve    func(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.GetResponseHeadersPolicyOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ResponseHeadersPolicyParameters, *svcsdk.GetResponseHeadersPolicyOutput) error
-	isUpToDate     func(*svcapitypes.ResponseHeadersPolicy, *svcsdk.GetResponseHeadersPolicyOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.GetResponseHeadersPolicyOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.CreateResponseHeadersPolicyInput) error
 	postCreate     func(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.CreateResponseHeadersPolicyOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.DeleteResponseHeadersPolicyInput) (bool, error)
@@ -417,8 +418,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.ResponseHeadersPolicy, _ *
 func nopLateInitialize(*svcapitypes.ResponseHeadersPolicyParameters, *svcsdk.GetResponseHeadersPolicyOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.ResponseHeadersPolicy, *svcsdk.GetResponseHeadersPolicyOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.GetResponseHeadersPolicyOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.ResponseHeadersPolicy, *svcsdk.CreateResponseHeadersPolicyInput) error {

--- a/pkg/controller/cloudfront/utils/lateinit_test.go
+++ b/pkg/controller/cloudfront/utils/lateinit_test.go
@@ -716,7 +716,7 @@ func TestIsUpToDate(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := IsUpToDate(tt.args.actual, tt.args.desired, tt.args.opts...)
+			got, _, err := IsUpToDate(tt.args.actual, tt.args.desired, tt.args.opts...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IsUpToDate() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/cloudsearch/domain/setup.go
+++ b/pkg/controller/cloudsearch/domain/setup.go
@@ -164,19 +164,19 @@ func (h *hooks) isUpToDateAccessPolicies(ctx context.Context, cr *svcapitypes.Do
 	return isUpToDate, nil
 }
 
-func (h *hooks) isUpToDate(cr *svcapitypes.Domain, obj *svcsdk.DescribeDomainsOutput) (bool, error) {
+func (h *hooks) isUpToDate(ctx context.Context, cr *svcapitypes.Domain, obj *svcsdk.DescribeDomainsOutput) (bool, string, error) {
 	ds := obj.DomainStatusList[0]
 
-	scalingParametersUpToDate, err := h.isUpToDateScalingParameters(context.TODO(), cr, ds.DomainName)
+	scalingParametersUpToDate, err := h.isUpToDateScalingParameters(ctx, cr, ds.DomainName)
 	if !scalingParametersUpToDate || err != nil {
-		return false, err
+		return false, "", err
 	}
-	accessPoliciesUpToDate, err := h.isUpToDateAccessPolicies(context.TODO(), cr, ds.DomainName)
+	accessPoliciesUpToDate, err := h.isUpToDateAccessPolicies(ctx, cr, ds.DomainName)
 	if !accessPoliciesUpToDate || err != nil {
-		return false, err
+		return false, "", err
 	}
 
-	return !awsclients.BoolValue(ds.RequiresIndexDocuments), nil
+	return !awsclients.BoolValue(ds.RequiresIndexDocuments), "", nil
 }
 
 func updateConditions(cr *svcapitypes.Domain, ds *svcsdk.DomainStatus) {

--- a/pkg/controller/cloudsearch/domain/setup_test.go
+++ b/pkg/controller/cloudsearch/domain/setup_test.go
@@ -366,7 +366,7 @@ func TestIsUpToDate(t *testing.T) {
 				},
 			}
 
-			result, err := h.isUpToDate(&svcapitypes.Domain{
+			result, _, err := h.isUpToDate(context.Background(), &svcapitypes.Domain{
 				Spec: svcapitypes.DomainSpec{
 					ForProvider: svcapitypes.DomainParameters{
 						DomainName: &domainName,

--- a/pkg/controller/cloudwatchlogs/loggroup/setup.go
+++ b/pkg/controller/cloudwatchlogs/loggroup/setup.go
@@ -131,9 +131,9 @@ func postCreate(ctx context.Context, cr *svcapitypes.LogGroup, obj *svcsdk.Creat
 	return managed.ExternalCreation{}, nil
 }
 
-func (u *updater) isUpToDate(cr *svcapitypes.LogGroup, obj *svcsdk.DescribeLogGroupsOutput) (bool, error) {
+func (u *updater) isUpToDate(_ context.Context, cr *svcapitypes.LogGroup, obj *svcsdk.DescribeLogGroupsOutput) (bool, string, error) {
 	if awsclients.Int64Value(cr.Spec.ForProvider.RetentionInDays) != awsclients.Int64Value(obj.LogGroups[0].RetentionInDays) {
-		return false, nil
+		return false, "", nil
 	}
 
 	trimmedArn := trimArnSuffix(*obj.LogGroups[0].Arn)
@@ -141,11 +141,11 @@ func (u *updater) isUpToDate(cr *svcapitypes.LogGroup, obj *svcsdk.DescribeLogGr
 		ResourceArn: &trimmedArn,
 	})
 	if err != nil {
-		return false, errors.Wrap(err, errListTags)
+		return false, "", errors.Wrap(err, errListTags)
 	}
 	add, remove := awsclients.DiffTagsMapPtr(cr.Spec.ForProvider.Tags, tags.Tags)
 
-	return len(add) == 0 && len(remove) == 0, nil
+	return len(add) == 0 && len(remove) == 0, "", nil
 }
 
 func (u *updater) update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) { // nolint:gocyclo

--- a/pkg/controller/cognitoidentityprovider/group/setup.go
+++ b/pkg/controller/cognitoidentityprovider/group/setup.go
@@ -114,11 +114,11 @@ func preUpdate(_ context.Context, cr *svcapitypes.Group, obj *svcsdk.UpdateGroup
 	return nil
 }
 
-func isUpToDate(cr *svcapitypes.Group, resp *svcsdk.GetGroupOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.Group, resp *svcsdk.GetGroupOutput) (bool, string, error) {
 	switch {
 	case awsclients.StringValue(cr.Spec.ForProvider.Description) != awsclients.StringValue(resp.Group.Description),
 		awsclients.Int64Value(cr.Spec.ForProvider.Precedence) != awsclients.Int64Value(resp.Group.Precedence):
-		return false, nil
+		return false, "", nil
 	}
-	return true, nil
+	return true, "", nil
 }

--- a/pkg/controller/cognitoidentityprovider/group/setup_test.go
+++ b/pkg/controller/cognitoidentityprovider/group/setup_test.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"testing"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
@@ -92,7 +93,7 @@ func TestIsUpToDate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			// Act
-			result, err := isUpToDate(tc.args.cr, tc.args.resp)
+			result, _, err := isUpToDate(context.Background(), tc.args.cr, tc.args.resp)
 
 			// Assert
 			if diff := cmp.Diff(tc.want.result, result, test.EquateConditions()); diff != "" {

--- a/pkg/controller/cognitoidentityprovider/identityprovider/setup.go
+++ b/pkg/controller/cognitoidentityprovider/identityprovider/setup.go
@@ -139,13 +139,11 @@ func (e *custom) preUpdate(ctx context.Context, cr *svcapitypes.IdentityProvider
 	return nil
 }
 
-func (e *custom) isUpToDate(cr *svcapitypes.IdentityProvider, resp *svcsdk.DescribeIdentityProviderOutput) (bool, error) {
+func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.IdentityProvider, resp *svcsdk.DescribeIdentityProviderOutput) (bool, string, error) {
 	provider := resp.IdentityProvider
-
-	ctx := context.Background()
 	p, err := e.resolver.GetProviderDetails(ctx, e.kube, &cr.Spec.ForProvider.ProviderDetailsSecretRef)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	providerDetails := p
 
@@ -153,9 +151,9 @@ func (e *custom) isUpToDate(cr *svcapitypes.IdentityProvider, resp *svcsdk.Descr
 	case !reflect.DeepEqual(cr.Spec.ForProvider.AttributeMapping, provider.AttributeMapping),
 		cr.Spec.ForProvider.IDpIdentifiers != nil && !reflect.DeepEqual(cr.Spec.ForProvider.IDpIdentifiers, provider.IdpIdentifiers),
 		!reflect.DeepEqual(providerDetails, provider.ProviderDetails):
-		return false, nil
+		return false, "", nil
 	}
-	return true, nil
+	return true, "", nil
 }
 
 func lateInitialize(cr *svcapitypes.IdentityProviderParameters, current *svcsdk.DescribeIdentityProviderOutput) error {

--- a/pkg/controller/cognitoidentityprovider/identityprovider/setup_test.go
+++ b/pkg/controller/cognitoidentityprovider/identityprovider/setup_test.go
@@ -232,7 +232,7 @@ func TestIsUpToDate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			e := &custom{resolver: tc.args.resolver, kube: nil}
 			// Act
-			result, err := e.isUpToDate(tc.args.cr, tc.args.resp)
+			result, _, err := e.isUpToDate(context.Background(), tc.args.cr, tc.args.resp)
 
 			// Assert
 			if diff := cmp.Diff(tc.want.result, result, test.EquateConditions()); diff != "" {

--- a/pkg/controller/cognitoidentityprovider/userpool/setup_test.go
+++ b/pkg/controller/cognitoidentityprovider/userpool/setup_test.go
@@ -452,7 +452,7 @@ func TestIsUpToDate(t *testing.T) {
 				},
 			}
 			// Act
-			result, err := h.isUpToDate(tc.args.cr, tc.args.resp)
+			result, _, err := h.isUpToDate(context.Background(), tc.args.cr, tc.args.resp)
 
 			// Assert
 			if diff := cmp.Diff(tc.want.result, result, test.EquateConditions()); diff != "" {

--- a/pkg/controller/cognitoidentityprovider/userpoolclient/setup.go
+++ b/pkg/controller/cognitoidentityprovider/userpoolclient/setup.go
@@ -142,7 +142,7 @@ func postUpdate(_ context.Context, cr *svcapitypes.UserPoolClient, obj *svcsdk.U
 	}, nil
 }
 
-func isUpToDate(cr *svcapitypes.UserPoolClient, resp *svcsdk.DescribeUserPoolClientOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.UserPoolClient, resp *svcsdk.DescribeUserPoolClientOutput) (bool, string, error) {
 	client := resp.UserPoolClient
 
 	switch {
@@ -162,9 +162,9 @@ func isUpToDate(cr *svcapitypes.UserPoolClient, resp *svcsdk.DescribeUserPoolCli
 		!reflect.DeepEqual(cr.Spec.ForProvider.SupportedIdentityProviders, client.SupportedIdentityProviders),
 		!areTokenValidityUnitsEqual(cr.Spec.ForProvider.TokenValidityUnits, client.TokenValidityUnits),
 		!reflect.DeepEqual(cr.Spec.ForProvider.WriteAttributes, client.WriteAttributes):
-		return false, nil
+		return false, "", nil
 	}
-	return true, nil
+	return true, "", nil
 }
 
 func areAnalyticsConfigurationEqual(spec *svcapitypes.AnalyticsConfigurationType, current *svcsdk.AnalyticsConfigurationType) bool {

--- a/pkg/controller/cognitoidentityprovider/userpoolclient/setup_test.go
+++ b/pkg/controller/cognitoidentityprovider/userpoolclient/setup_test.go
@@ -312,7 +312,7 @@ func TestIsUpToDate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			// Act
-			result, err := isUpToDate(tc.args.cr, tc.args.resp)
+			result, _, err := isUpToDate(context.Background(), tc.args.cr, tc.args.resp)
 
 			// Assert
 			if diff := cmp.Diff(tc.want.result, result, test.EquateConditions()); diff != "" {

--- a/pkg/controller/dax/cluster/setup.go
+++ b/pkg/controller/dax/cluster/setup.go
@@ -127,39 +127,39 @@ func lateInitialize(in *svcapitypes.ClusterParameters, out *svcsdk.DescribeClust
 	return nil
 }
 
-func isUpToDate(cr *svcapitypes.Cluster, output *svcsdk.DescribeClustersOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.Cluster, output *svcsdk.DescribeClustersOutput) (bool, string, error) {
 	in := cr.Spec.ForProvider
 	out := output.Clusters[0]
 
 	notUpToDate := isNotUpToDate(in, out)
 
 	if notUpToDate {
-		return false, nil
+		return false, "", nil
 	}
 
 	parameterGroupNotEqualNotNil := isUpToDateParameterGroup(in, out)
 
 	if parameterGroupNotEqualNotNil {
-		return false, nil
+		return false, "", nil
 	}
 
 	notificationTopicArnNotEqualNotNil := isUpToDateNotificationTopicArn(in, out)
 
 	if notificationTopicArnNotEqualNotNil {
-		return false, nil
+		return false, "", nil
 	}
 
 	outSecurityGroupIds := getOutSecurityIds(out)
 	if !cmp.Equal(in.SecurityGroupIDs, outSecurityGroupIds) {
-		return false, nil
+		return false, "", nil
 	}
 
 	outAvailabilityZones := getOutAvailabilityZones(out)
 	if !cmp.Equal(in.AvailabilityZones, outAvailabilityZones) {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
 func isNotUpToDate(in svcapitypes.ClusterParameters, out *svcsdk.Cluster) (unequal bool) {

--- a/pkg/controller/dax/parametergroup/setup_test.go
+++ b/pkg/controller/dax/parametergroup/setup_test.go
@@ -141,7 +141,7 @@ func TestObserve(t *testing.T) {
 							},
 						}}, nil
 					},
-					MockDescribeParameters: func(input *dax.DescribeParametersInput) (*dax.DescribeParametersOutput, error) {
+					MockDescribeParametersWithContext: func(ctx context.Context, input *dax.DescribeParametersInput, o []request.Option) (*dax.DescribeParametersOutput, error) {
 						return &dax.DescribeParametersOutput{
 							Parameters: []*dax.Parameter{{
 								ParameterName:  awsclient.String(testParameterName),
@@ -178,8 +178,9 @@ func TestObserve(t *testing.T) {
 							Opts: nil,
 						},
 					},
-					DescribeParameters: []*fake.CallDescribeParameters{
+					DescribeParametersWithContext: []*fake.CallDescribeParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &dax.DescribeParametersInput{
 								MaxResults:         awsclient.Int64(100),
 								ParameterGroupName: awsclient.String(testParameterGroupName),
@@ -200,7 +201,7 @@ func TestObserve(t *testing.T) {
 							},
 						}}, nil
 					},
-					MockDescribeParameters: func(input *dax.DescribeParametersInput) (*dax.DescribeParametersOutput, error) {
+					MockDescribeParametersWithContext: func(ctx context.Context, input *dax.DescribeParametersInput, o []request.Option) (*dax.DescribeParametersOutput, error) {
 						return &dax.DescribeParametersOutput{
 							Parameters: []*dax.Parameter{{
 								ParameterName:  awsclient.String(testParameterName),
@@ -237,8 +238,9 @@ func TestObserve(t *testing.T) {
 							Opts: nil,
 						},
 					},
-					DescribeParameters: []*fake.CallDescribeParameters{
+					DescribeParametersWithContext: []*fake.CallDescribeParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &dax.DescribeParametersInput{
 								MaxResults:         awsclient.Int64(100),
 								ParameterGroupName: awsclient.String(testParameterGroupName),

--- a/pkg/controller/dax/subnetgroup/setup.go
+++ b/pkg/controller/dax/subnetgroup/setup.go
@@ -91,12 +91,12 @@ func preDelete(_ context.Context, cr *svcapitypes.SubnetGroup, obj *svcsdk.Delet
 	return false, nil
 }
 
-func isUpToDate(cr *svcapitypes.SubnetGroup, output *svcsdk.DescribeSubnetGroupsOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.SubnetGroup, output *svcsdk.DescribeSubnetGroupsOutput) (bool, string, error) {
 	in := cr.Spec.ForProvider
 	out := output.SubnetGroups[0]
 
 	if !cmp.Equal(in.Description, out.Description) {
-		return false, nil
+		return false, "", nil
 	}
 
 	subnetsOut := make([]*string, len(out.Subnets))
@@ -105,8 +105,8 @@ func isUpToDate(cr *svcapitypes.SubnetGroup, output *svcsdk.DescribeSubnetGroups
 	}
 
 	if !cmp.Equal(in.SubnetIds, subnetsOut) {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, nil
+	return true, "", nil
 }

--- a/pkg/controller/docdb/dbcluster/zz_controller.go
+++ b/pkg/controller/docdb/dbcluster/zz_controller.go
@@ -93,13 +93,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -402,7 +403,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) *svcsdk.DescribeDBClustersOutput
 	lateInitialize func(*svcapitypes.DBClusterParameters, *svcsdk.DescribeDBClustersOutput) error
-	isUpToDate     func(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterInput) error
 	postCreate     func(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DBCluster, *svcsdk.DeleteDBClusterInput) (bool, error)
@@ -424,8 +425,8 @@ func nopFilterList(_ *svcapitypes.DBCluster, list *svcsdk.DescribeDBClustersOutp
 func nopLateInitialize(*svcapitypes.DBClusterParameters, *svcsdk.DescribeDBClustersOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterInput) error {

--- a/pkg/controller/docdb/dbclusterparametergroup/setup_test.go
+++ b/pkg/controller/docdb/dbclusterparametergroup/setup_test.go
@@ -167,7 +167,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{
 							Parameters: []*docdb.Parameter{},
 						}, nil
@@ -201,13 +201,15 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
 						},
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
@@ -233,7 +235,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{
 							Parameters: []*docdb.Parameter{
 								{
@@ -282,13 +284,15 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
 						},
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
@@ -314,7 +318,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{
 							Parameters: []*docdb.Parameter{
 								{
@@ -372,13 +376,15 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
 						},
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
@@ -405,7 +411,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{
 							Parameters: []*docdb.Parameter{},
 						}, nil
@@ -440,8 +446,9 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
@@ -463,7 +470,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{
 							Parameters: []*docdb.Parameter{},
 						}, nil
@@ -498,8 +505,9 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
@@ -520,7 +528,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{
 							Parameters: []*docdb.Parameter{
 								{
@@ -566,13 +574,15 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
 						},
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},
@@ -625,7 +635,7 @@ func TestObserve(t *testing.T) {
 							},
 						}, nil
 					},
-					MockDescribeDBClusterParameters: func(ddpi *docdb.DescribeDBClusterParametersInput) (*docdb.DescribeDBClusterParametersOutput, error) {
+					MockDescribeDBClusterParametersWithContext: func(ctx context.Context, ddpi *docdb.DescribeDBClusterParametersInput, o []request.Option) (*docdb.DescribeDBClusterParametersOutput, error) {
 						return &docdb.DescribeDBClusterParametersOutput{}, errors.New(testErrDescribeDBClusterParametersFailed)
 					},
 				},
@@ -651,8 +661,9 @@ func TestObserve(t *testing.T) {
 							},
 						},
 					},
-					DescribeDBClusterParameters: []*fake.CallDescribeDBClusterParameters{
+					DescribeDBClusterParametersWithContext: []*fake.CallDescribeDBClusterParametersWithContext{
 						{
+							Ctx: context.Background(),
 							I: &docdb.DescribeDBClusterParametersInput{
 								DBClusterParameterGroupName: awsclient.String(testDBClusterParameterGroupName),
 							},

--- a/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
@@ -92,13 +92,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDBClusterParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -204,7 +205,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) *svcsdk.DescribeDBClusterParameterGroupsOutput
 	lateInitialize func(*svcapitypes.DBClusterParameterGroupParameters, *svcsdk.DescribeDBClusterParameterGroupsOutput) error
-	isUpToDate     func(*svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.CreateDBClusterParameterGroupInput) error
 	postCreate     func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.CreateDBClusterParameterGroupOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DeleteDBClusterParameterGroupInput) (bool, error)
@@ -226,8 +227,8 @@ func nopFilterList(_ *svcapitypes.DBClusterParameterGroup, list *svcsdk.Describe
 func nopLateInitialize(*svcapitypes.DBClusterParameterGroupParameters, *svcsdk.DescribeDBClusterParameterGroupsOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.CreateDBClusterParameterGroupInput) error {

--- a/pkg/controller/docdb/dbinstance/setup.go
+++ b/pkg/controller/docdb/dbinstance/setup.go
@@ -126,7 +126,7 @@ func postObserve(_ context.Context, cr *svcapitypes.DBInstance, resp *svcsdk.Des
 	return obs, nil
 }
 
-func (e *hooks) isUpToDate(cr *svcapitypes.DBInstance, resp *svcsdk.DescribeDBInstancesOutput) (bool, error) { // nolint:gocyclo
+func (e *hooks) isUpToDate(_ context.Context, cr *svcapitypes.DBInstance, resp *svcsdk.DescribeDBInstancesOutput) (bool, string, error) { // nolint:gocyclo
 	instance := resp.DBInstances[0]
 
 	switch {
@@ -135,10 +135,11 @@ func (e *hooks) isUpToDate(cr *svcapitypes.DBInstance, resp *svcsdk.DescribeDBIn
 		awsclient.StringValue(cr.Spec.ForProvider.DBInstanceClass) != awsclient.StringValue(instance.DBInstanceClass),
 		awsclient.StringValue(cr.Spec.ForProvider.PreferredMaintenanceWindow) != awsclient.StringValue(instance.PreferredMaintenanceWindow),
 		awsclient.Int64Value(cr.Spec.ForProvider.PromotionTier) != awsclient.Int64Value(instance.PromotionTier):
-		return false, nil
+		return false, "", nil
 	}
 
-	return svcutils.AreTagsUpToDate(e.client, cr.Spec.ForProvider.Tags, instance.DBInstanceArn)
+	areTagsUpToDate, err := svcutils.AreTagsUpToDate(e.client, cr.Spec.ForProvider.Tags, instance.DBInstanceArn)
+	return areTagsUpToDate, "", err
 }
 
 func lateInitialize(cr *svcapitypes.DBInstanceParameters, resp *svcsdk.DescribeDBInstancesOutput) error {

--- a/pkg/controller/docdb/dbsubnetgroup/setup.go
+++ b/pkg/controller/docdb/dbsubnetgroup/setup.go
@@ -112,16 +112,17 @@ func postObserve(_ context.Context, cr *svcapitypes.DBSubnetGroup, resp *svcsdk.
 	return obs, nil
 }
 
-func (e *hooks) isUpToDate(cr *svcapitypes.DBSubnetGroup, resp *svcsdk.DescribeDBSubnetGroupsOutput) (bool, error) {
+func (e *hooks) isUpToDate(_ context.Context, cr *svcapitypes.DBSubnetGroup, resp *svcsdk.DescribeDBSubnetGroupsOutput) (bool, string, error) {
 	group := resp.DBSubnetGroups[0]
 
 	switch {
 	case awsclient.StringValue(cr.Spec.ForProvider.DBSubnetGroupDescription) != awsclient.StringValue(group.DBSubnetGroupDescription),
 		!areSubnetsEqual(cr.Spec.ForProvider.SubnetIDs, group.Subnets):
-		return false, nil
+		return false, "", nil
 	}
 
-	return svcutils.AreTagsUpToDate(e.client, cr.Spec.ForProvider.Tags, group.DBSubnetGroupArn)
+	areTagsUpToDate, err := svcutils.AreTagsUpToDate(e.client, cr.Spec.ForProvider.Tags, group.DBSubnetGroupArn)
+	return areTagsUpToDate, "", err
 }
 
 func areSubnetsEqual(specSubnetIds []*string, current []*svcsdk.Subnet) bool {

--- a/pkg/controller/dynamodb/globaltable/hooks.go
+++ b/pkg/controller/dynamodb/globaltable/hooks.go
@@ -110,7 +110,7 @@ func postObserve(_ context.Context, cr *svcapitypes.GlobalTable, resp *svcsdk.De
 	return obs, nil
 }
 
-func isUpToDate(cr *svcapitypes.GlobalTable, obj *svcsdk.DescribeGlobalTableOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.GlobalTable, obj *svcsdk.DescribeGlobalTableOutput) (bool, string, error) {
 	existing := make([]string, len(obj.GlobalTableDescription.ReplicationGroup))
 	for i, r := range obj.GlobalTableDescription.ReplicationGroup {
 		existing[i] = aws.StringValue(r.RegionName)
@@ -121,7 +121,8 @@ func isUpToDate(cr *svcapitypes.GlobalTable, obj *svcsdk.DescribeGlobalTableOutp
 		desired[i] = aws.StringValue(r.RegionName)
 	}
 	sort.Strings(desired)
-	return cmp.Equal(existing, desired), nil
+	diff := cmp.Diff(existing, desired)
+	return diff == "", diff, nil
 }
 
 type updater struct {

--- a/pkg/controller/ec2/flowlog/setup.go
+++ b/pkg/controller/ec2/flowlog/setup.go
@@ -204,25 +204,25 @@ func postCreate(ctx context.Context, cr *svcapitypes.FlowLog, obj *svcsdk.Create
 	return cre, nil
 }
 
-func (u *updater) isUpToDate(cr *svcapitypes.FlowLog, obj *svcsdk.DescribeFlowLogsOutput) (bool, error) {
+func (u *updater) isUpToDate(ctx context.Context, cr *svcapitypes.FlowLog, obj *svcsdk.DescribeFlowLogsOutput) (bool, string, error) {
 
 	input := GenerateDescribeFlowLogsInput(cr)
-	resp, err := u.client.DescribeFlowLogs(input)
+	resp, err := u.client.DescribeFlowLogsWithContext(ctx, input)
 	if err != nil {
-		return false, errors.Wrap(err, errDescribe)
+		return false, "", errors.Wrap(err, errDescribe)
 	}
 
 	resp = filterList(cr, resp)
 
 	if len(resp.FlowLogs) == 0 {
-		return false, errors.New(errDescribe)
+		return false, "", errors.New(errDescribe)
 	}
 
 	tags := resp.FlowLogs[0].Tags
 
 	add, remove := DiffTags(cr.Spec.ForProvider.Tags, tags)
 
-	return len(add) == 0 && len(remove) == 0, nil
+	return len(add) == 0 && len(remove) == 0, "", nil
 }
 
 func (u *updater) update(ctx context.Context, mg cpresource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/ec2/flowlog/zz_controller.go
+++ b/pkg/controller/ec2/flowlog/zz_controller.go
@@ -92,13 +92,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateFlowLog(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -171,7 +172,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.FlowLog, *svcsdk.DescribeFlowLogsOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.FlowLog, *svcsdk.DescribeFlowLogsOutput) *svcsdk.DescribeFlowLogsOutput
 	lateInitialize func(*svcapitypes.FlowLogParameters, *svcsdk.DescribeFlowLogsOutput) error
-	isUpToDate     func(*svcapitypes.FlowLog, *svcsdk.DescribeFlowLogsOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.FlowLog, *svcsdk.DescribeFlowLogsOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.FlowLog, *svcsdk.CreateFlowLogsInput) error
 	postCreate     func(context.Context, *svcapitypes.FlowLog, *svcsdk.CreateFlowLogsOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	delete         func(context.Context, cpresource.Managed) error
@@ -191,8 +192,8 @@ func nopFilterList(_ *svcapitypes.FlowLog, list *svcsdk.DescribeFlowLogsOutput) 
 func nopLateInitialize(*svcapitypes.FlowLogParameters, *svcsdk.DescribeFlowLogsOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.FlowLog, *svcsdk.DescribeFlowLogsOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.FlowLog, *svcsdk.DescribeFlowLogsOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.FlowLog, *svcsdk.CreateFlowLogsInput) error {

--- a/pkg/controller/ec2/transitgateway/setup.go
+++ b/pkg/controller/ec2/transitgateway/setup.go
@@ -105,8 +105,8 @@ func postObserve(_ context.Context, cr *svcapitypes.TransitGateway, obj *svcsdk.
 	return obs, nil
 }
 
-func isUpToDate(cr *svcapitypes.TransitGateway, obj *svcsdk.DescribeTransitGatewaysOutput) (bool, error) {
-	return true, nil
+func isUpToDate(_ context.Context, cr *svcapitypes.TransitGateway, obj *svcsdk.DescribeTransitGatewaysOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func postCreate(ctx context.Context, cr *svcapitypes.TransitGateway, obj *svcsdk.CreateTransitGatewayOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {

--- a/pkg/controller/ec2/vpcendpointserviceconfiguration/setup.go
+++ b/pkg/controller/ec2/vpcendpointserviceconfiguration/setup.go
@@ -138,27 +138,27 @@ type updater struct {
 	client svcsdkapi.EC2API
 }
 
-func isUpToDate(cr *svcapitypes.VPCEndpointServiceConfiguration, obj *svcsdk.DescribeVpcEndpointServiceConfigurationsOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.VPCEndpointServiceConfiguration, obj *svcsdk.DescribeVpcEndpointServiceConfigurationsOutput) (bool, string, error) {
 
 	createGlbArns, deleteGlbArns := DifferenceARN(cr.Spec.ForProvider.GatewayLoadBalancerARNs, obj.ServiceConfigurations[0].GatewayLoadBalancerArns)
 	if len(createGlbArns) != 0 || len(deleteGlbArns) != 0 {
-		return false, nil
+		return false, "", nil
 	}
 
 	createNlbArns, deleteNlbArns := DifferenceARN(cr.Spec.ForProvider.NetworkLoadBalancerARNs, obj.ServiceConfigurations[0].NetworkLoadBalancerArns)
 	if len(createNlbArns) != 0 || len(deleteNlbArns) != 0 {
-		return false, nil
+		return false, "", nil
 	}
 
 	if awsclients.StringValue(cr.Spec.ForProvider.PrivateDNSName) != awsclients.StringValue(obj.ServiceConfigurations[0].PrivateDnsName) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if awsclients.BoolValue(cr.Spec.ForProvider.AcceptanceRequired) != awsclients.BoolValue(obj.ServiceConfigurations[0].AcceptanceRequired) {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
 func (u *updater) preUpdate(_ context.Context, cr *svcapitypes.VPCEndpointServiceConfiguration, obj *svcsdk.ModifyVpcEndpointServiceConfigurationInput) error {

--- a/pkg/controller/ec2/vpcpeeringconnection/setup.go
+++ b/pkg/controller/ec2/vpcpeeringconnection/setup.go
@@ -215,8 +215,8 @@ func setCondition(code *svcsdk.VpcPeeringConnectionStateReason, cr *svcapitypes.
 	return false
 }
 
-func (e *custom) isUpToDate(_ *svcapitypes.VPCPeeringConnection, _ *svcsdk.DescribeVpcPeeringConnectionsOutput) (bool, error) {
-	return true, nil
+func (e *custom) isUpToDate(_ context.Context, _ *svcapitypes.VPCPeeringConnection, _ *svcsdk.DescribeVpcPeeringConnectionsOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func preCreate(_ context.Context, cr *svcapitypes.VPCPeeringConnection, obj *svcsdk.CreateVpcPeeringConnectionInput) error {

--- a/pkg/controller/ecr/lifecyclepolicy/setup.go
+++ b/pkg/controller/ecr/lifecyclepolicy/setup.go
@@ -81,11 +81,9 @@ func preDelete(_ context.Context, cr *svcapitypes.LifecyclePolicy, obj *svcsdk.D
 	return false, nil
 }
 
-func isUpToDate(cr *svcapitypes.LifecyclePolicy, obj *svcsdk.GetLifecyclePolicyOutput) (bool, error) {
-	if diff := cmp.Diff(cr.Spec.ForProvider.LifecyclePolicyText, obj.LifecyclePolicyText); diff != "" {
-		return false, nil
-	}
-	return true, nil
+func isUpToDate(_ context.Context, cr *svcapitypes.LifecyclePolicy, obj *svcsdk.GetLifecyclePolicyOutput) (bool, string, error) {
+	diff := cmp.Diff(cr.Spec.ForProvider.LifecyclePolicyText, obj.LifecyclePolicyText)
+	return diff == "", diff, nil
 }
 
 type updateClient struct {

--- a/pkg/controller/ecs/cluster/zz_controller.go
+++ b/pkg/controller/ecs/cluster/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -373,7 +374,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClustersInput) error
 	postObserve    func(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClustersOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ClusterParameters, *svcsdk.DescribeClustersOutput) error
-	isUpToDate     func(*svcapitypes.Cluster, *svcsdk.DescribeClustersOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClustersOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Cluster, *svcsdk.CreateClusterInput) error
 	postCreate     func(context.Context, *svcapitypes.Cluster, *svcsdk.CreateClusterOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Cluster, *svcsdk.DeleteClusterInput) (bool, error)
@@ -392,8 +393,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Cluster, _ *svcsdk.Describ
 func nopLateInitialize(*svcapitypes.ClusterParameters, *svcsdk.DescribeClustersOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Cluster, *svcsdk.DescribeClustersOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClustersOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Cluster, *svcsdk.CreateClusterInput) error {

--- a/pkg/controller/efs/filesystem/setup.go
+++ b/pkg/controller/efs/filesystem/setup.go
@@ -66,13 +66,13 @@ func SetupFileSystem(mgr ctrl.Manager, o controller.Options) error {
 		Complete(r)
 }
 
-func isUpToDate(cr *svcapitypes.FileSystem, obj *svcsdk.DescribeFileSystemsOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.DescribeFileSystemsOutput) (bool, string, error) {
 	for _, res := range obj.FileSystems {
 		if awsclients.Int64Value(cr.Spec.ForProvider.ProvisionedThroughputInMibps) != int64(aws.Float64Value(res.ProvisionedThroughputInMibps)) {
-			return false, nil
+			return false, "", nil
 		}
 	}
-	return true, nil
+	return true, "", nil
 }
 
 func preObserve(_ context.Context, cr *svcapitypes.FileSystem, obj *svcsdk.DescribeFileSystemsInput) error {

--- a/pkg/controller/eks/addon/setup.go
+++ b/pkg/controller/eks/addon/setup.go
@@ -136,16 +136,16 @@ func lateInitialize(spec *eksv1alpha1.AddonParameters, resp *awseks.DescribeAddo
 	return nil
 }
 
-func (h *hooks) isUpToDate(cr *eksv1alpha1.Addon, resp *awseks.DescribeAddonOutput) (bool, error) {
+func (h *hooks) isUpToDate(_ context.Context, cr *eksv1alpha1.Addon, resp *awseks.DescribeAddonOutput) (bool, string, error) {
 	switch {
 	case resp.Addon == nil,
 		cr.Spec.ForProvider.AddonVersion != nil && awsclients.StringValue(cr.Spec.ForProvider.AddonVersion) != awsclients.StringValue(resp.Addon.AddonVersion),
 		cr.Spec.ForProvider.ServiceAccountRoleARN != nil && awsclients.StringValue(cr.Spec.ForProvider.ServiceAccountRoleARN) != awsclients.StringValue(resp.Addon.ServiceAccountRoleArn):
-		return false, nil
+		return false, "", nil
 	}
 
 	add, remove := awsclients.DiffTagsMapPtr(cr.Spec.ForProvider.Tags, resp.Addon.Tags)
-	return len(add) == 0 && len(remove) == 0, nil
+	return len(add) == 0 && len(remove) == 0, "", nil
 }
 
 func preUpdate(_ context.Context, cr *eksv1alpha1.Addon, obj *awseks.UpdateAddonInput) error {

--- a/pkg/controller/eks/addon/zz_controller.go
+++ b/pkg/controller/eks/addon/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateAddon(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -286,7 +287,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Addon, *svcsdk.DescribeAddonInput) error
 	postObserve    func(context.Context, *svcapitypes.Addon, *svcsdk.DescribeAddonOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.AddonParameters, *svcsdk.DescribeAddonOutput) error
-	isUpToDate     func(*svcapitypes.Addon, *svcsdk.DescribeAddonOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Addon, *svcsdk.DescribeAddonOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Addon, *svcsdk.CreateAddonInput) error
 	postCreate     func(context.Context, *svcapitypes.Addon, *svcsdk.CreateAddonOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Addon, *svcsdk.DeleteAddonInput) (bool, error)
@@ -305,8 +306,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Addon, _ *svcsdk.DescribeA
 func nopLateInitialize(*svcapitypes.AddonParameters, *svcsdk.DescribeAddonOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Addon, *svcsdk.DescribeAddonOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Addon, *svcsdk.DescribeAddonOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Addon, *svcsdk.CreateAddonInput) error {

--- a/pkg/controller/elasticache/cacheparametergroup/setup.go
+++ b/pkg/controller/elasticache/cacheparametergroup/setup.go
@@ -104,9 +104,7 @@ func postObserve(_ context.Context, cr *svcapitypes.CacheParameterGroup, resp *s
 	return obs, nil
 }
 
-func (e *hooks) isUpToDate(cr *svcapitypes.CacheParameterGroup, resp *svcsdk.DescribeCacheParameterGroupsOutput) (bool, error) {
-	ctx := context.TODO()
-
+func (e *hooks) isUpToDate(ctx context.Context, cr *svcapitypes.CacheParameterGroup, resp *svcsdk.DescribeCacheParameterGroupsOutput) (bool, string, error) {
 	input := &svcsdk.DescribeCacheParametersInput{
 		CacheParameterGroupName: awsclient.String(meta.GetExternalName(cr)),
 	}
@@ -116,7 +114,7 @@ func (e *hooks) isUpToDate(cr *svcapitypes.CacheParameterGroup, resp *svcsdk.Des
 		return !lastPage
 	})
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	var observed []svcapitypes.ParameterNameValue
@@ -133,8 +131,7 @@ func (e *hooks) isUpToDate(cr *svcapitypes.CacheParameterGroup, resp *svcsdk.Des
 		return awsclient.StringValue(a.ParameterName) < awsclient.StringValue(b.ParameterName)
 	}))
 
-	// TODO: We should be able to return the diff to crossplane-runtime here
-	return diff == "", nil
+	return diff == "", diff, nil
 }
 
 func preUpdate(ctx context.Context, cr *svcapitypes.CacheParameterGroup, obj *svcsdk.ModifyCacheParameterGroupInput) error {

--- a/pkg/controller/elasticache/cacheparametergroup/setup_test.go
+++ b/pkg/controller/elasticache/cacheparametergroup/setup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cacheparametergroup
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -176,7 +177,7 @@ func TestIsUpToDate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			opts := []option{setupExternal}
 			e := newExternal(nil, tc.args.elasticache, opts)
-			upToDate, err := e.isUpToDate(tc.args.cr, tc.args.resp)
+			upToDate, _, err := e.isUpToDate(context.Background(), tc.args.cr, tc.args.resp)
 
 			if diff := cmp.Diff(tc.want.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)

--- a/pkg/controller/elasticache/cacheparametergroup/zz_controller.go
+++ b/pkg/controller/elasticache/cacheparametergroup/zz_controller.go
@@ -92,13 +92,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateCacheParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -209,7 +210,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.DescribeCacheParameterGroupsOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.CacheParameterGroup, *svcsdk.DescribeCacheParameterGroupsOutput) *svcsdk.DescribeCacheParameterGroupsOutput
 	lateInitialize func(*svcapitypes.CacheParameterGroupParameters, *svcsdk.DescribeCacheParameterGroupsOutput) error
-	isUpToDate     func(*svcapitypes.CacheParameterGroup, *svcsdk.DescribeCacheParameterGroupsOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.DescribeCacheParameterGroupsOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.CreateCacheParameterGroupInput) error
 	postCreate     func(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.CreateCacheParameterGroupOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.DeleteCacheParameterGroupInput) (bool, error)
@@ -231,8 +232,8 @@ func nopFilterList(_ *svcapitypes.CacheParameterGroup, list *svcsdk.DescribeCach
 func nopLateInitialize(*svcapitypes.CacheParameterGroupParameters, *svcsdk.DescribeCacheParameterGroupsOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.CacheParameterGroup, *svcsdk.DescribeCacheParameterGroupsOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.DescribeCacheParameterGroupsOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.CacheParameterGroup, *svcsdk.CreateCacheParameterGroupInput) error {

--- a/pkg/controller/emrcontainers/virtualcluster/setup.go
+++ b/pkg/controller/emrcontainers/virtualcluster/setup.go
@@ -130,9 +130,9 @@ func postDelete(ctx context.Context, cr *svcapitypes.VirtualCluster, resp *svcsd
 	return err
 }
 
-func isUpToDate(cr *svcapitypes.VirtualCluster, output *svcsdk.DescribeVirtualClusterOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.VirtualCluster, output *svcsdk.DescribeVirtualClusterOutput) (bool, string, error) {
 	add, remove := awsclients.DiffTagsMapPtr(cr.Spec.ForProvider.Tags, output.VirtualCluster.Tags)
-	return len(add) == 0 && len(remove) == 0, nil
+	return len(add) == 0 && len(remove) == 0, "", nil
 }
 
 func (e *external) updater(ctx context.Context, mg cpresource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/glue/classifier/zz_controller.go
+++ b/pkg/controller/glue/classifier/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateClassifier(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -177,7 +178,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Classifier, *svcsdk.GetClassifierInput) error
 	postObserve    func(context.Context, *svcapitypes.Classifier, *svcsdk.GetClassifierOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ClassifierParameters, *svcsdk.GetClassifierOutput) error
-	isUpToDate     func(*svcapitypes.Classifier, *svcsdk.GetClassifierOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Classifier, *svcsdk.GetClassifierOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Classifier, *svcsdk.CreateClassifierInput) error
 	postCreate     func(context.Context, *svcapitypes.Classifier, *svcsdk.CreateClassifierOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Classifier, *svcsdk.DeleteClassifierInput) (bool, error)
@@ -196,8 +197,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Classifier, _ *svcsdk.GetC
 func nopLateInitialize(*svcapitypes.ClassifierParameters, *svcsdk.GetClassifierOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Classifier, *svcsdk.GetClassifierOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Classifier, *svcsdk.GetClassifierOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Classifier, *svcsdk.CreateClassifierInput) error {

--- a/pkg/controller/glue/crawler/zz_controller.go
+++ b/pkg/controller/glue/crawler/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateCrawler(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -177,7 +178,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Crawler, *svcsdk.GetCrawlerInput) error
 	postObserve    func(context.Context, *svcapitypes.Crawler, *svcsdk.GetCrawlerOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.CrawlerParameters, *svcsdk.GetCrawlerOutput) error
-	isUpToDate     func(*svcapitypes.Crawler, *svcsdk.GetCrawlerOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Crawler, *svcsdk.GetCrawlerOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Crawler, *svcsdk.CreateCrawlerInput) error
 	postCreate     func(context.Context, *svcapitypes.Crawler, *svcsdk.CreateCrawlerOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Crawler, *svcsdk.DeleteCrawlerInput) (bool, error)
@@ -196,8 +197,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Crawler, _ *svcsdk.GetCraw
 func nopLateInitialize(*svcapitypes.CrawlerParameters, *svcsdk.GetCrawlerOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Crawler, *svcsdk.GetCrawlerOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Crawler, *svcsdk.GetCrawlerOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Crawler, *svcsdk.CreateCrawlerInput) error {

--- a/pkg/controller/iot/thing/setup.go
+++ b/pkg/controller/iot/thing/setup.go
@@ -121,14 +121,15 @@ func preDelete(_ context.Context, cr *svcapitypes.Thing, obj *svcsdk.DeleteThing
 	return false, nil
 }
 
-func isUpToDate(cr *svcapitypes.Thing, resp *svcsdk.DescribeThingOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.Thing, resp *svcsdk.DescribeThingOutput) (bool, string, error) {
 	patch, err := createPatch(resp, &cr.Spec.ForProvider)
 
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
-	return cmp.Equal(&svcapitypes.ThingParameters{}, patch), nil
+	diff := cmp.Diff(&svcapitypes.ThingParameters{}, patch)
+	return diff == "", diff, nil
 }
 
 func createPatch(in *svcsdk.DescribeThingOutput, target *svcapitypes.ThingParameters) (*svcapitypes.ThingParameters, error) {

--- a/pkg/controller/iot/thing/setup_test.go
+++ b/pkg/controller/iot/thing/setup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package thing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/iot"
@@ -93,7 +94,7 @@ func TestIsUpToDate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			o, err := isUpToDate(tc.args.cr, &tc.args.resp)
+			o, _, err := isUpToDate(context.Background(), tc.args.cr, &tc.args.resp)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -218,14 +218,14 @@ func LateInitialize(cr *svcapitypes.ClusterParameters, obj *svcsdk.DescribeClust
 	return nil
 }
 
-func isUpToDate(wanted *svcapitypes.Cluster, current *svcsdk.DescribeClusterOutput) (bool, error) { // nolint:gocyclo
+func isUpToDate(_ context.Context, wanted *svcapitypes.Cluster, current *svcsdk.DescribeClusterOutput) (bool, string, error) { // nolint:gocyclo
 	forProvider := wanted.Spec.ForProvider
 	clusterInfo := current.ClusterInfo
 
 	switch {
 	// A cluster can not be updated while not in active status, therefore we consider the cluster as up to date
 	case aws.StringValue(clusterInfo.State) != stateActive:
-		return true, nil
+		return true, "", nil
 	case !isInstanceTypeUpToDate(forProvider.CustomBrokerNodeGroupInfo, clusterInfo.BrokerNodeGroupInfo),
 		!isStorageInfoUpToDate(forProvider.CustomBrokerNodeGroupInfo, clusterInfo.BrokerNodeGroupInfo),
 		!isNumberOfBrokerNodesUpToDate(forProvider, clusterInfo),
@@ -237,9 +237,9 @@ func isUpToDate(wanted *svcapitypes.Cluster, current *svcsdk.DescribeClusterOutp
 		!isEncryptionInfoInTransitUpToDate(forProvider.EncryptionInfo, clusterInfo.EncryptionInfo),
 		!isClientAuthenticationUpToDate(forProvider.ClientAuthentication, clusterInfo.ClientAuthentication),
 		!isTagsUpToDate(forProvider.Tags, clusterInfo.Tags):
-		return false, nil
+		return false, "", nil
 	}
-	return true, nil
+	return true, "", nil
 }
 
 func isInstanceTypeUpToDate(wanted *svcapitypes.CustomBrokerNodeGroupInfo, current *svcsdk.BrokerNodeGroupInfo) bool {

--- a/pkg/controller/kafka/cluster/zz_controller.go
+++ b/pkg/controller/kafka/cluster/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -184,7 +185,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClusterInput) error
 	postObserve    func(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClusterOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ClusterParameters, *svcsdk.DescribeClusterOutput) error
-	isUpToDate     func(*svcapitypes.Cluster, *svcsdk.DescribeClusterOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClusterOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Cluster, *svcsdk.CreateClusterInput) error
 	postCreate     func(context.Context, *svcapitypes.Cluster, *svcsdk.CreateClusterOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Cluster, *svcsdk.DeleteClusterInput) (bool, error)
@@ -202,8 +203,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Cluster, _ *svcsdk.Describ
 func nopLateInitialize(*svcapitypes.ClusterParameters, *svcsdk.DescribeClusterOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Cluster, *svcsdk.DescribeClusterOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Cluster, *svcsdk.DescribeClusterOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Cluster, *svcsdk.CreateClusterInput) error {

--- a/pkg/controller/kinesis/stream/zz_controller.go
+++ b/pkg/controller/kinesis/stream/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateStream(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -168,7 +169,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Stream, *svcsdk.DescribeStreamInput) error
 	postObserve    func(context.Context, *svcapitypes.Stream, *svcsdk.DescribeStreamOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.StreamParameters, *svcsdk.DescribeStreamOutput) error
-	isUpToDate     func(*svcapitypes.Stream, *svcsdk.DescribeStreamOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Stream, *svcsdk.DescribeStreamOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Stream, *svcsdk.CreateStreamInput) error
 	postCreate     func(context.Context, *svcapitypes.Stream, *svcsdk.CreateStreamOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Stream, *svcsdk.DeleteStreamInput) (bool, error)
@@ -186,8 +187,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Stream, _ *svcsdk.Describe
 func nopLateInitialize(*svcapitypes.StreamParameters, *svcsdk.DescribeStreamOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Stream, *svcsdk.DescribeStreamOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Stream, *svcsdk.DescribeStreamOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Stream, *svcsdk.CreateStreamInput) error {

--- a/pkg/controller/kms/key/zz_controller.go
+++ b/pkg/controller/kms/key/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -331,7 +332,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Key, *svcsdk.DescribeKeyInput) error
 	postObserve    func(context.Context, *svcapitypes.Key, *svcsdk.DescribeKeyOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.KeyParameters, *svcsdk.DescribeKeyOutput) error
-	isUpToDate     func(*svcapitypes.Key, *svcsdk.DescribeKeyOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Key, *svcsdk.DescribeKeyOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Key, *svcsdk.CreateKeyInput) error
 	postCreate     func(context.Context, *svcapitypes.Key, *svcsdk.CreateKeyOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	delete         func(context.Context, cpresource.Managed) error
@@ -348,8 +349,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Key, _ *svcsdk.DescribeKey
 func nopLateInitialize(*svcapitypes.KeyParameters, *svcsdk.DescribeKeyOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Key, *svcsdk.DescribeKeyOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Key, *svcsdk.DescribeKeyOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Key, *svcsdk.CreateKeyInput) error {

--- a/pkg/controller/lambda/function/setup.go
+++ b/pkg/controller/lambda/function/setup.go
@@ -139,7 +139,7 @@ func preDelete(_ context.Context, cr *svcapitypes.Function, obj *svcsdk.DeleteFu
 }
 
 // nolint:gocyclo
-func isUpToDate(cr *svcapitypes.Function, obj *svcsdk.GetFunctionOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.Function, obj *svcsdk.GetFunctionOutput) (bool, string, error) {
 
 	// Compare CODE
 	// GetFunctionOutput returns
@@ -151,29 +151,29 @@ func isUpToDate(cr *svcapitypes.Function, obj *svcsdk.GetFunctionOutput) (bool, 
 	// It is partially possible for code supplied via FunctionCode.ImageUri
 
 	if !isUpToDateCodeImage(cr, obj) {
-		return false, nil
+		return false, "", nil
 	}
 
 	// Compare CONFIGURATION
 	if aws.StringValue(cr.Spec.ForProvider.Description) != aws.StringValue(obj.Configuration.Description) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isUpToDateEnvironment(cr, obj) {
-		return false, nil
+		return false, "", nil
 	}
 
 	// Connection settings for an Amazon EFS file system.
 	if !isUpToDateFileSystemConfigs(cr, obj) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if aws.StringValue(cr.Spec.ForProvider.Handler) != aws.StringValue(obj.Configuration.Handler) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if aws.StringValue(cr.Spec.ForProvider.KMSKeyARN) != aws.StringValue(obj.Configuration.KMSKeyArn) {
-		return false, nil
+		return false, "", nil
 	}
 
 	// The function's layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
@@ -184,32 +184,32 @@ func isUpToDate(cr *svcapitypes.Function, obj *svcsdk.GetFunctionOutput) (bool, 
 
 	// set default
 	if aws.Int64Value(cr.Spec.ForProvider.MemorySize) != aws.Int64Value(obj.Configuration.MemorySize) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if aws.StringValue(cr.Spec.ForProvider.Role) != aws.StringValue(obj.Configuration.Role) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if aws.StringValue(cr.Spec.ForProvider.Runtime) != aws.StringValue(obj.Configuration.Runtime) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if aws.Int64Value(cr.Spec.ForProvider.Timeout) != aws.Int64Value(obj.Configuration.Timeout) {
-		return false, nil
+		return false, "", nil
 	}
 
 	// This should never be nil.  We set this in LateInit as aws will initialize a default value
 	if aws.StringValue(cr.Spec.ForProvider.TracingConfig.Mode) != aws.StringValue(obj.Configuration.TracingConfig.Mode) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isUpToDateSecurityGroupIDs(cr, obj) {
-		return false, nil
+		return false, "", nil
 	}
 
 	addTags, removeTags := aws.DiffTagsMapPtr(cr.Spec.ForProvider.Tags, obj.Tags)
-	return len(addTags) == 0 && len(removeTags) == 0, nil
+	return len(addTags) == 0 && len(removeTags) == 0, "", nil
 
 }
 

--- a/pkg/controller/lambda/functionurlconfig/setup.go
+++ b/pkg/controller/lambda/functionurlconfig/setup.go
@@ -99,12 +99,12 @@ func postObserve(_ context.Context, cr *svcapitypes.FunctionURLConfig, _ *svcsdk
 	return obs, nil
 }
 
-func isUpToDate(cr *svcapitypes.FunctionURLConfig, obj *svcsdk.GetFunctionUrlConfigOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.FunctionURLConfig, obj *svcsdk.GetFunctionUrlConfigOutput) (bool, string, error) {
 	if aws.StringValue(cr.Spec.ForProvider.AuthType) != aws.StringValue(obj.AuthType) {
-		return false, nil
+		return false, "", nil
 	}
 
-	return isUpToDateCors(cr, obj), nil
+	return isUpToDateCors(cr, obj), "", nil
 }
 
 func isUpToDateCors(cr *svcapitypes.FunctionURLConfig, obj *svcsdk.GetFunctionUrlConfigOutput) bool {

--- a/pkg/controller/lambda/functionurlconfig/zz_controller.go
+++ b/pkg/controller/lambda/functionurlconfig/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateFunctionURLConfig(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -246,7 +247,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.GetFunctionUrlConfigInput) error
 	postObserve    func(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.GetFunctionUrlConfigOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.FunctionURLConfigParameters, *svcsdk.GetFunctionUrlConfigOutput) error
-	isUpToDate     func(*svcapitypes.FunctionURLConfig, *svcsdk.GetFunctionUrlConfigOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.GetFunctionUrlConfigOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.CreateFunctionUrlConfigInput) error
 	postCreate     func(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.CreateFunctionUrlConfigOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.DeleteFunctionUrlConfigInput) (bool, error)
@@ -265,8 +266,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.FunctionURLConfig, _ *svcs
 func nopLateInitialize(*svcapitypes.FunctionURLConfigParameters, *svcsdk.GetFunctionUrlConfigOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.FunctionURLConfig, *svcsdk.GetFunctionUrlConfigOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.GetFunctionUrlConfigOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.FunctionURLConfig, *svcsdk.CreateFunctionUrlConfigInput) error {

--- a/pkg/controller/mq/user/setup.go
+++ b/pkg/controller/mq/user/setup.go
@@ -184,15 +184,13 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.User, obj *svcs
 	return managed.ExternalUpdate{ConnectionDetails: conn}, nil
 }
 
-func (e *custom) isUpToDate(cr *svcapitypes.User, obj *svcsdk.DescribeUserResponse) (bool, error) {
-	ctx := context.Background()
-
+func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.User, obj *svcsdk.DescribeUserResponse) (bool, string, error) {
 	if obj.Pending != nil {
-		return true, nil
+		return true, "", nil
 	}
 	_, pwChanged, err := mq.GetPassword(ctx, e.kube, &cr.Spec.ForProvider.PasswordSecretRef, cr.Spec.WriteConnectionSecretToReference)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
-	return !pwChanged, nil
+	return !pwChanged, "", nil
 }

--- a/pkg/controller/mq/user/zz_controller.go
+++ b/pkg/controller/mq/user/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateUser(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -177,7 +178,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.User, *svcsdk.DescribeUserInput) error
 	postObserve    func(context.Context, *svcapitypes.User, *svcsdk.DescribeUserResponse, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.UserParameters, *svcsdk.DescribeUserResponse) error
-	isUpToDate     func(*svcapitypes.User, *svcsdk.DescribeUserResponse) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.User, *svcsdk.DescribeUserResponse) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.User, *svcsdk.CreateUserRequest) error
 	postCreate     func(context.Context, *svcapitypes.User, *svcsdk.CreateUserOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.User, *svcsdk.DeleteUserInput) (bool, error)
@@ -196,8 +197,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.User, _ *svcsdk.DescribeUs
 func nopLateInitialize(*svcapitypes.UserParameters, *svcsdk.DescribeUserResponse) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.User, *svcsdk.DescribeUserResponse) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.User, *svcsdk.DescribeUserResponse) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.User, *svcsdk.CreateUserRequest) error {

--- a/pkg/controller/mwaa/environment/setup.go
+++ b/pkg/controller/mwaa/environment/setup.go
@@ -202,19 +202,20 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.Environment, ob
 	return managed.ExternalUpdate{}, nil
 }
 
-func isUpToDate(cr *svcapitypes.Environment, obj *svcsdk.GetEnvironmentOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.Environment, obj *svcsdk.GetEnvironmentOutput) (bool, string, error) {
 	if obj.Environment == nil {
-		return false, nil
+		return false, "", nil
 	}
 
 	env := generateEnvironment(obj)
-	return cmp.Equal(
+	diff := cmp.Diff(
 		cr.Spec.ForProvider,
 		env.Spec.ForProvider,
 		cmpopts.IgnoreTypes(&xpv1.Reference{}, &xpv1.Selector{}, []xpv1.Reference{}),
 		cmpopts.IgnoreFields(svcapitypes.EnvironmentParameters{}, "Region"),
 		cmpopts.IgnoreFields(svcapitypes.CustomEnvironmentParameters{}, "KMSKey"),
-	), nil
+	)
+	return diff == "", diff, nil
 }
 
 func lateInitialize(spec *svcapitypes.EnvironmentParameters, obj *svcsdk.GetEnvironmentOutput) error {

--- a/pkg/controller/neptune/dbcluster/setup.go
+++ b/pkg/controller/neptune/dbcluster/setup.go
@@ -189,39 +189,39 @@ func lateInitialize(in *svcapitypes.DBClusterParameters, out *svcsdk.DescribeDBC
 }
 
 // nolint:gocyclo
-func isUpToDate(cr *svcapitypes.DBCluster, output *svcsdk.DescribeDBClustersOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.DBCluster, output *svcsdk.DescribeDBClustersOutput) (bool, string, error) {
 	in := cr.Spec.ForProvider
 	out := output.DBClusters[0]
 
 	if aws.Int64Value(in.BackupRetentionPeriod) != aws.Int64Value(out.BackupRetentionPeriod) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.StringValue(in.DBClusterParameterGroupName) != aws.StringValue(out.DBClusterParameterGroup) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.BoolValue(in.DeletionProtection) != aws.BoolValue(out.DeletionProtection) {
-		return false, nil
+		return false, "", nil
 	}
 	if !cmp.Equal(in.EnableCloudwatchLogsExports, out.EnabledCloudwatchLogsExports) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.StringValue(in.EngineVersion) != aws.StringValue(out.EngineVersion) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.BoolValue(in.EnableIAMDatabaseAuthentication) != aws.BoolValue(out.IAMDatabaseAuthenticationEnabled) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.Int64Value(in.Port) != aws.Int64Value(out.Port) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.StringValue(in.PreferredBackupWindow) != aws.StringValue(out.PreferredBackupWindow) {
-		return false, nil
+		return false, "", nil
 	}
 	if aws.StringValue(in.PreferredMaintenanceWindow) != aws.StringValue(out.PreferredMaintenanceWindow) {
-		return false, nil
+		return false, "", nil
 	}
 	if len(in.VPCSecurityGroupIDs) != len(out.VpcSecurityGroups) {
-		return true, nil
+		return false, "", nil
 	}
 
 	vcpArr := make([]*string, len(in.VPCSecurityGroupIDs))
@@ -229,10 +229,10 @@ func isUpToDate(cr *svcapitypes.DBCluster, output *svcsdk.DescribeDBClustersOutp
 		vcpArr[i] = out.VpcSecurityGroups[i].VpcSecurityGroupId
 	}
 	if !cmp.Equal(in.VPCSecurityGroupIDs, vcpArr) {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
 func postObserve(_ context.Context, cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClustersOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {

--- a/pkg/controller/neptune/dbcluster/zz_controller.go
+++ b/pkg/controller/neptune/dbcluster/zz_controller.go
@@ -93,13 +93,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -468,7 +469,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) *svcsdk.DescribeDBClustersOutput
 	lateInitialize func(*svcapitypes.DBClusterParameters, *svcsdk.DescribeDBClustersOutput) error
-	isUpToDate     func(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterInput) error
 	postCreate     func(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DBCluster, *svcsdk.DeleteDBClusterInput) (bool, error)
@@ -490,8 +491,8 @@ func nopFilterList(_ *svcapitypes.DBCluster, list *svcsdk.DescribeDBClustersOutp
 func nopLateInitialize(*svcapitypes.DBClusterParameters, *svcsdk.DescribeDBClustersOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterInput) error {

--- a/pkg/controller/opensearchservice/domain/setup.go
+++ b/pkg/controller/opensearchservice/domain/setup.go
@@ -359,7 +359,7 @@ func GenerateObservation(obj *svcsdk.DomainStatus) svcapitypes.DomainObservation
 	return o
 }
 
-func isUpToDate(obj *svcapitypes.Domain, out *svcsdk.DescribeDomainOutput) (bool, error) { // nolint:gocyclo
+func isUpToDate(_ context.Context, obj *svcapitypes.Domain, out *svcsdk.DescribeDomainOutput) (bool, string, error) { // nolint:gocyclo
 
 	switch {
 	case aws.StringValue(obj.Spec.ForProvider.AccessPolicies) != aws.StringValue(out.DomainStatus.AccessPolicies),
@@ -376,12 +376,12 @@ func isUpToDate(obj *svcapitypes.Domain, out *svcsdk.DescribeDomainOutput) (bool
 		!isSnapshotOptionsUpToDate(obj.Spec.ForProvider.SnapshotOptions, out.DomainStatus.SnapshotOptions),
 		!isVpcOptionsUpToDate(obj.Spec.ForProvider.VPCOptions, out.DomainStatus.VPCOptions),
 		!isEncryptionAtRestUpToDate(obj.Spec.ForProvider.EncryptionAtRestOptions, out.DomainStatus.EncryptionAtRestOptions):
-		return false, nil
+		return false, "", nil
 	case !*out.DomainStatus.Processing && !*out.DomainStatus.UpgradeProcessing && aws.StringValue(obj.Spec.ForProvider.EngineVersion) != aws.StringValue(out.DomainStatus.EngineVersion):
 		// We cant update when processing or already updating so we consider this as up to date for now
-		return false, nil
+		return false, "", nil
 	default:
-		return true, nil
+		return true, "", nil
 	}
 }
 

--- a/pkg/controller/prometheusservice/alertmanagerdefinition/setup.go
+++ b/pkg/controller/prometheusservice/alertmanagerdefinition/setup.go
@@ -125,19 +125,19 @@ func postObserve(_ context.Context, cr *svcapitypes.AlertManagerDefinition, resp
 	return obs, nil
 }
 
-func isUpToDate(cr *svcapitypes.AlertManagerDefinition, resp *svcsdk.DescribeAlertManagerDefinitionOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.AlertManagerDefinition, resp *svcsdk.DescribeAlertManagerDefinitionOutput) (bool, string, error) {
 	// An AlertManager Definition that's currently creating, deleting, or updating can't be
 	// updated, so we temporarily consider it to be up-to-date no matter
 	// what.
 	switch aws.StringValue(cr.Status.AtProvider.StatusCode) {
 	case string(svcapitypes.AlertManagerDefinitionStatusCode_CREATING), string(svcapitypes.AlertManagerDefinitionStatusCode_UPDATING), string(svcapitypes.AlertManagerDefinitionStatusCode_DELETING):
-		return true, nil
+		return true, "", nil
 	}
 
 	if cmp := bytes.Compare(cr.Spec.ForProvider.Data, resp.AlertManagerDefinition.Data); cmp != 0 {
-		return false, nil
+		return false, "", nil
 	}
-	return true, nil
+	return true, "", nil
 }
 
 type updateClient struct {

--- a/pkg/controller/prometheusservice/rulegroupsnamespace/setup.go
+++ b/pkg/controller/prometheusservice/rulegroupsnamespace/setup.go
@@ -154,19 +154,19 @@ func (t *tagger) Initialize(ctx context.Context, mg resource.Managed) error {
 	return errors.Wrap(t.kube.Update(ctx, cr), errKubeUpdateFailed)
 }
 
-func isUpToDate(cr *svcapitypes.RuleGroupsNamespace, resp *svcsdk.DescribeRuleGroupsNamespaceOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.RuleGroupsNamespace, resp *svcsdk.DescribeRuleGroupsNamespaceOutput) (bool, string, error) {
 	// A rule that's currently creating, deleting, or updating can't be
 	// updated, so we temporarily consider it to be up-to-date no matter
 	// what.
 	switch aws.StringValue(cr.Status.AtProvider.Status.StatusCode) {
 	case string(svcapitypes.RuleGroupsNamespaceStatusCode_CREATING), string(svcapitypes.RuleGroupsNamespaceStatusCode_UPDATING), string(svcapitypes.RuleGroupsNamespaceStatusCode_DELETING):
-		return true, nil
+		return true, "", nil
 	}
 
 	if cmp := bytes.Compare(cr.Spec.ForProvider.Data, resp.RuleGroupsNamespace.Data); cmp != 0 {
-		return false, nil
+		return false, "", nil
 	}
-	return true, nil
+	return true, "", nil
 }
 
 type updateClient struct {

--- a/pkg/controller/rds/dbcluster/zz_controller.go
+++ b/pkg/controller/rds/dbcluster/zz_controller.go
@@ -93,13 +93,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -676,7 +677,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) *svcsdk.DescribeDBClustersOutput
 	lateInitialize func(*svcapitypes.DBClusterParameters, *svcsdk.DescribeDBClustersOutput) error
-	isUpToDate     func(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterInput) error
 	postCreate     func(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DBCluster, *svcsdk.DeleteDBClusterInput) (bool, error)
@@ -698,8 +699,8 @@ func nopFilterList(_ *svcapitypes.DBCluster, list *svcsdk.DescribeDBClustersOutp
 func nopLateInitialize(*svcapitypes.DBClusterParameters, *svcsdk.DescribeDBClustersOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DBCluster, *svcsdk.DescribeDBClustersOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DBCluster, *svcsdk.CreateDBClusterInput) error {

--- a/pkg/controller/rds/dbclusterparametergroup/setup.go
+++ b/pkg/controller/rds/dbclusterparametergroup/setup.go
@@ -166,19 +166,17 @@ func lateInitialize(spec *svcapitypes.DBClusterParameterGroupParameters, current
 	return nil
 }
 
-func (c *custom) isUpToDate(cr *svcapitypes.DBClusterParameterGroup, _ *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, error) {
-	// TODO(armsnyder): We need isUpToDate to have context.
-	ctx := context.TODO()
+func (c *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBClusterParameterGroup, _ *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, string, error) {
 	results, err := c.getCurrentDBClusterParameters(ctx, cr)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	if len(c.parametersToUpdate(cr, results)) != 0 || len(c.parametersToReset(cr, results)) != 0 {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, err
+	return true, "", err
 }
 
 func (c *custom) getCurrentDBClusterParameters(ctx context.Context, cr *svcapitypes.DBClusterParameterGroup) ([]*svcsdk.Parameter, error) {

--- a/pkg/controller/rds/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/rds/dbclusterparametergroup/zz_controller.go
@@ -92,13 +92,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDBClusterParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -204,7 +205,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) *svcsdk.DescribeDBClusterParameterGroupsOutput
 	lateInitialize func(*svcapitypes.DBClusterParameterGroupParameters, *svcsdk.DescribeDBClusterParameterGroupsOutput) error
-	isUpToDate     func(*svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.CreateDBClusterParameterGroupInput) error
 	postCreate     func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.CreateDBClusterParameterGroupOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DeleteDBClusterParameterGroupInput) (bool, error)
@@ -226,8 +227,8 @@ func nopFilterList(_ *svcapitypes.DBClusterParameterGroup, list *svcsdk.Describe
 func nopLateInitialize(*svcapitypes.DBClusterParameterGroupParameters, *svcsdk.DescribeDBClusterParameterGroupsOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.DescribeDBClusterParameterGroupsOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DBClusterParameterGroup, *svcsdk.CreateDBClusterParameterGroupInput) error {

--- a/pkg/controller/rds/dbinstance/zz_controller.go
+++ b/pkg/controller/rds/dbinstance/zz_controller.go
@@ -93,13 +93,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateDBInstance(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -903,7 +904,7 @@ type external struct {
 	postObserve    func(context.Context, *svcapitypes.DBInstance, *svcsdk.DescribeDBInstancesOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	filterList     func(*svcapitypes.DBInstance, *svcsdk.DescribeDBInstancesOutput) *svcsdk.DescribeDBInstancesOutput
 	lateInitialize func(*svcapitypes.DBInstanceParameters, *svcsdk.DescribeDBInstancesOutput) error
-	isUpToDate     func(*svcapitypes.DBInstance, *svcsdk.DescribeDBInstancesOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.DBInstance, *svcsdk.DescribeDBInstancesOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.DBInstance, *svcsdk.CreateDBInstanceInput) error
 	postCreate     func(context.Context, *svcapitypes.DBInstance, *svcsdk.CreateDBInstanceOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.DBInstance, *svcsdk.DeleteDBInstanceInput) (bool, error)
@@ -925,8 +926,8 @@ func nopFilterList(_ *svcapitypes.DBInstance, list *svcsdk.DescribeDBInstancesOu
 func nopLateInitialize(*svcapitypes.DBInstanceParameters, *svcsdk.DescribeDBInstancesOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.DBInstance, *svcsdk.DescribeDBInstancesOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.DBInstance, *svcsdk.DescribeDBInstancesOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.DBInstance, *svcsdk.CreateDBInstanceInput) error {

--- a/pkg/controller/rds/dbparametergroup/setup.go
+++ b/pkg/controller/rds/dbparametergroup/setup.go
@@ -165,19 +165,17 @@ func lateInitialize(spec *svcapitypes.DBParameterGroupParameters, current *svcsd
 	return nil
 }
 
-func (c *custom) isUpToDate(cr *svcapitypes.DBParameterGroup, obj *svcsdk.DescribeDBParameterGroupsOutput) (bool, error) {
-	// TODO(Dkaykay): We need isUpToDate to have context.
-	ctx := context.TODO()
+func (c *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBParameterGroup, obj *svcsdk.DescribeDBParameterGroupsOutput) (bool, string, error) {
 	results, err := c.getCurrentDBParameters(ctx, cr)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	if len(c.parametersToUpdate(cr, results)) != 0 || len(c.parametersToReset(cr, results)) != 0 {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, err
+	return true, "", err
 }
 
 func (c *custom) getCurrentDBParameters(ctx context.Context, cr *svcapitypes.DBParameterGroup) ([]*svcsdk.Parameter, error) {

--- a/pkg/controller/route53resolver/resolverrule/zz_controller.go
+++ b/pkg/controller/route53resolver/resolverrule/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateResolverRule(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -259,7 +260,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.ResolverRule, *svcsdk.GetResolverRuleInput) error
 	postObserve    func(context.Context, *svcapitypes.ResolverRule, *svcsdk.GetResolverRuleOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ResolverRuleParameters, *svcsdk.GetResolverRuleOutput) error
-	isUpToDate     func(*svcapitypes.ResolverRule, *svcsdk.GetResolverRuleOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.ResolverRule, *svcsdk.GetResolverRuleOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.ResolverRule, *svcsdk.CreateResolverRuleInput) error
 	postCreate     func(context.Context, *svcapitypes.ResolverRule, *svcsdk.CreateResolverRuleOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.ResolverRule, *svcsdk.DeleteResolverRuleInput) (bool, error)
@@ -278,8 +279,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.ResolverRule, _ *svcsdk.Ge
 func nopLateInitialize(*svcapitypes.ResolverRuleParameters, *svcsdk.GetResolverRuleOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.ResolverRule, *svcsdk.GetResolverRuleOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.ResolverRule, *svcsdk.GetResolverRuleOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.ResolverRule, *svcsdk.CreateResolverRuleInput) error {

--- a/pkg/controller/s3control/accesspoint/hooks.go
+++ b/pkg/controller/s3control/accesspoint/hooks.go
@@ -39,12 +39,12 @@ func newHooks(api svcsdkapi.S3ControlAPI) *hooks {
 	return &hooks{policyClient: &policyClient{client: api}}
 }
 
-func (h *hooks) isUpToDate(point *svcapitypes.AccessPoint, _ *svcsdk.GetAccessPointOutput) (bool, error) {
+func (h *hooks) isUpToDate(_ context.Context, point *svcapitypes.AccessPoint, _ *svcsdk.GetAccessPointOutput) (bool, string, error) {
 	obs, err := h.policyClient.observe(point)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
-	return obs == updated, nil
+	return obs == updated, "", nil
 }
 
 func (h *hooks) update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/servicediscovery/service/setup.go
+++ b/pkg/controller/servicediscovery/service/setup.go
@@ -158,29 +158,29 @@ func postObserve(_ context.Context, cr *svcapitypes.Service, resp *svcsdk.GetSer
 	return obs, nil
 }
 
-func (e *hooks) isUpToDate(cr *svcapitypes.Service, resp *svcsdk.GetServiceOutput) (bool, error) {
+func (e *hooks) isUpToDate(_ context.Context, cr *svcapitypes.Service, resp *svcsdk.GetServiceOutput) (bool, string, error) {
 	if *resp.Service.Description != *cr.Spec.ForProvider.Description {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isEqualDNSRecords(resp.Service.DnsConfig.DnsRecords, cr.Spec.ForProvider.DNSConfig.DNSRecords) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isEqualHealthCheckConfig(resp.Service.HealthCheckConfig, cr.Spec.ForProvider.HealthCheckConfig) {
-		return false, nil
+		return false, "", nil
 	}
 
 	tagsUpToDate, err := commonnamespace.AreTagsUpToDate(e.client, cr.Spec.ForProvider.Tags, cr.Status.AtProvider.ARN)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	if !tagsUpToDate {
-		return false, nil
+		return false, "", nil
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
 func isEqualHealthCheckConfig(outHealthCheck *svcsdk.HealthCheckConfig, crHealthCheck *svcapitypes.HealthCheckConfig) bool {

--- a/pkg/controller/servicediscovery/service/zz_controller.go
+++ b/pkg/controller/servicediscovery/service/zz_controller.go
@@ -89,13 +89,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateService(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -274,7 +275,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Service, *svcsdk.GetServiceInput) error
 	postObserve    func(context.Context, *svcapitypes.Service, *svcsdk.GetServiceOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ServiceParameters, *svcsdk.GetServiceOutput) error
-	isUpToDate     func(*svcapitypes.Service, *svcsdk.GetServiceOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Service, *svcsdk.GetServiceOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Service, *svcsdk.CreateServiceInput) error
 	postCreate     func(context.Context, *svcapitypes.Service, *svcsdk.CreateServiceOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Service, *svcsdk.DeleteServiceInput) (bool, error)
@@ -293,8 +294,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Service, _ *svcsdk.GetServ
 func nopLateInitialize(*svcapitypes.ServiceParameters, *svcsdk.GetServiceOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Service, *svcsdk.GetServiceOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Service, *svcsdk.GetServiceOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Service, *svcsdk.CreateServiceInput) error {

--- a/pkg/controller/sesv2/configurationset/setup.go
+++ b/pkg/controller/sesv2/configurationset/setup.go
@@ -82,32 +82,33 @@ type hooks struct {
 	ConfigurationSetObservation *svcsdk.GetConfigurationSetOutput
 }
 
-func isUpToDate(cr *svcapitypes.ConfigurationSet, resp *svcsdk.GetConfigurationSetOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.ConfigurationSet, resp *svcsdk.GetConfigurationSetOutput) (bool, string, error) {
 	if meta.WasDeleted(cr) {
-		return true, nil // There is no need to check for updates when we want to delete.
+		return true, "", nil // There is no need to check for updates when we want to delete.
 	}
 
 	if !isUpToDateDeliveryOptions(cr, resp) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isUpToDateReputationOptions(cr, resp) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isUpToDateSendingOptions(cr, resp) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isUpToDateSuppressionOptions(cr, resp) {
-		return false, nil
+		return false, "", nil
 	}
 
 	if !isUpToDateTrackingOptions(cr, resp) {
-		return false, nil
+		return false, "", nil
 	}
 
-	return svcutils.AreTagsUpToDate(cr.Spec.ForProvider.Tags, resp.Tags)
+	areTagsUpToDate, err := svcutils.AreTagsUpToDate(cr.Spec.ForProvider.Tags, resp.Tags)
+	return areTagsUpToDate, "", err
 }
 
 // isUpToDateDeliveryOptions checks if DeliveryOptions Object are up to date

--- a/pkg/controller/sesv2/emailtemplate/setup.go
+++ b/pkg/controller/sesv2/emailtemplate/setup.go
@@ -61,23 +61,23 @@ func SetupEmailTemplate(mgr ctrl.Manager, o controller.Options) error {
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }
 
-func isUpToDate(cr *svcapitypes.EmailTemplate, resp *svcsdk.GetEmailTemplateOutput) (bool, error) {
+func isUpToDate(_ context.Context, cr *svcapitypes.EmailTemplate, resp *svcsdk.GetEmailTemplateOutput) (bool, string, error) {
 	if meta.WasDeleted(cr) {
-		return true, nil // There is no need to check for updates when we want to delete.
+		return true, "", nil // There is no need to check for updates when we want to delete.
 	}
 
 	if cr.Spec.ForProvider.TemplateContent != nil && resp.TemplateContent != nil {
 		if awsclient.StringValue(cr.Spec.ForProvider.TemplateContent.HTML) != awsclient.StringValue(resp.TemplateContent.Html) {
-			return false, nil
+			return false, "", nil
 		}
 		if awsclient.StringValue(cr.Spec.ForProvider.TemplateContent.Subject) != awsclient.StringValue(resp.TemplateContent.Subject) {
-			return false, nil
+			return false, "", nil
 		}
 		if awsclient.StringValue(cr.Spec.ForProvider.TemplateContent.Text) != awsclient.StringValue(resp.TemplateContent.Text) {
-			return false, nil
+			return false, "", nil
 		}
 	}
-	return true, nil
+	return true, "", nil
 }
 
 func preObserve(_ context.Context, cr *svcapitypes.EmailTemplate, obj *svcsdk.GetEmailTemplateInput) error {

--- a/pkg/controller/transfer/server/zz_controller.go
+++ b/pkg/controller/transfer/server/zz_controller.go
@@ -88,13 +88,14 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	}
 	GenerateServer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
 
-	upToDate, err := e.isUpToDate(cr, resp)
+	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
+		Diff:                    diff,
 		ResourceLateInitialized: !cmp.Equal(&cr.Spec.ForProvider, currentSpec),
 	}, nil)
 }
@@ -183,7 +184,7 @@ type external struct {
 	preObserve     func(context.Context, *svcapitypes.Server, *svcsdk.DescribeServerInput) error
 	postObserve    func(context.Context, *svcapitypes.Server, *svcsdk.DescribeServerOutput, managed.ExternalObservation, error) (managed.ExternalObservation, error)
 	lateInitialize func(*svcapitypes.ServerParameters, *svcsdk.DescribeServerOutput) error
-	isUpToDate     func(*svcapitypes.Server, *svcsdk.DescribeServerOutput) (bool, error)
+	isUpToDate     func(context.Context, *svcapitypes.Server, *svcsdk.DescribeServerOutput) (bool, string, error)
 	preCreate      func(context.Context, *svcapitypes.Server, *svcsdk.CreateServerInput) error
 	postCreate     func(context.Context, *svcapitypes.Server, *svcsdk.CreateServerOutput, managed.ExternalCreation, error) (managed.ExternalCreation, error)
 	preDelete      func(context.Context, *svcapitypes.Server, *svcsdk.DeleteServerInput) (bool, error)
@@ -202,8 +203,8 @@ func nopPostObserve(_ context.Context, _ *svcapitypes.Server, _ *svcsdk.Describe
 func nopLateInitialize(*svcapitypes.ServerParameters, *svcsdk.DescribeServerOutput) error {
 	return nil
 }
-func alwaysUpToDate(*svcapitypes.Server, *svcsdk.DescribeServerOutput) (bool, error) {
-	return true, nil
+func alwaysUpToDate(context.Context, *svcapitypes.Server, *svcsdk.DescribeServerOutput) (bool, string, error) {
+	return true, "", nil
 }
 
 func nopPreCreate(context.Context, *svcapitypes.Server, *svcsdk.CreateServerInput) error {


### PR DESCRIPTION
### Description of your changes

Fixes #1828
Depends on https://github.com/aws-controllers-k8s/code-generator/pull/458

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Most of the code remains untouched. Only function parameters were added and `context.TODO` was replaced with the real context. In some cases the controllers and tests needed to bed changed since their weren't using the `...WithContext` APIs. In some other cases `cmp.Equal` was replaced with `diff := cmp.Diff(...); diff != ""` to keep the diff and return it later.

[contribution process]: https://git.io/fj2m9
