### PR TITLE
ci: Add bot to auto-stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: Stale Issues and PRs
+on:
+  schedule:
+  # Process new stale issues once a day. Folks can /fresh for a fast un-stale
+  # per the commands workflow. Run at 1:15 mostly as a somewhat unique time to
+  # help correlate any issues with this workflow.
+  - cron: '15 1 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
+      with:
+        # This action uses ~2 operations per stale issue per run to determine
+        # whether it's still stale. It also uses 2-3 operations to mark an issue
+        # stale or not. During steady state (no issues to mark stale, check, or
+        # close) we seem to use less than 10 operations with ~150 issues and PRs
+        # open.
+        #
+        # Our hourly rate-limit budget for all workflows that use GITHUB_TOKEN
+        # is 1,000 requests per the below docs.
+        # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions
+        operations-per-run: 100
+        days-before-stale: 90
+        days-before-close: 14
+        stale-issue-label: stale
+        exempt-issue-labels: exempt-from-stale
+        stale-issue-message: >
+          Crossplane does not currently have enough maintainers to address every
+          issue and pull request. This issue has been automatically marked as
+          `stale` because it has had no activity in the last 90 days. It will be
+          closed in 14 days if no further activity occurs. Leaving a comment
+          **starting with** `/fresh` will mark this issue as not stale.
+        stale-pr-label: stale
+        exempt-pr-labels: exempt-from-stale
+        stale-pr-message:
+          Crossplane does not currently have enough maintainers to address every
+          issue and pull request. This pull request has been automatically
+          marked as `stale` because it has had no activity in the last 90 days.
+          It will be closed in 14 days if no further activity occurs.
+          Adding a comment **starting with** `/fresh` will mark this PR as not stale.


### PR DESCRIPTION
### Description of your changes

Adds a Github bot to auto-stale and close issues are older than 90 days.

Analogue to https://github.com/crossplane/crossplane/blob/de0bf59201693a40f1ac0732eca795e5e5136884/.github/workflows/stale.yml.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
