### PR TITLE
fix(eks): Add reconciliation for addon configurationValues

### DIFF
--- a/examples/eks/addon.yaml
+++ b/examples/eks/addon.yaml
@@ -9,7 +9,17 @@ spec:
   forProvider:
     region: us-east-1
     addonName: coredns
-    addonVersion: "v1.8.4-eksbuild.1"
+    addonVersion: v1.10.1-eksbuild.2
+    configurationValues: |
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: my-nodegroup
+                    operator: In
+                    values:
+                      - my-nodegroup-name
     clusterNameRef:
       name: sample-cluster
   providerConfigRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
eks addon configurationValues is supported already in the spec but is not included in `isUpToDate` and therefore can never be changed with the provider.
https://github.com/crossplane-contrib/provider-aws/blob/master/apis/eks/v1alpha1/zz_addon.go#L40-L43

This PR adds the custom `isUpToDate` in order to update the `configurationValues`
The configurationValues is a string value but both json and yaml are supported. (See - https://aws.amazon.com/blogs/containers/amazon-eks-add-ons-advanced-configuration/)
Note the implementation for the string comparison.
Whitespace and indendation is difficult to get correct when using a string value.
This PR does UnMarshal and Marshal the json or yaml to ensure that the comparison is more accurate.  It lessens the risk that this provider will continually request an update of the external resource due to formatting, similar to the "normalization" done with iam policies.  Unit test cases have been added for testing format differences.

The addOn example has been updated to reflect yaml definition but json is supported as well.

yaml:
```
    configurationValues: |
      controller:
        podAnnotations:
          fluentbit.io/exclude: "true"
```
json:
```
      configurationValues: '{"controller": {"podAnnotations": {"fluentbit.io/exclude":
      "true"}}}'
```

What this PR does NOT do:  
* Any validation for yaml/json formatting
* Each addOn publishes a configuration schema.  This provider does not validate the cr against the provided schema.  This PR will send the update and aws will reject the change due to invalid schema

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

* define configurationValues for an addOn using the above json
* ensure provider-aws reconciles the resource and json configurationValues appear in the console
* ensure that upon the next reconcile the `External resource is up to date`
* set configurationValues to ""
* ensure provider-aws reconciles the resource and the default value of `-` appears in the console
* ensure that upon the next reconcile the `External resource is up to date`

* do the same as the above but with yaml
* ensure that no changes are made when `configurationValues` is not defined for an `addOn` - provider-aws reconciles the resource and the default value of `-` appears in the console
* ensure that the isUpToDate for configurationValues handles exceptions and returns them so they can be written as errors in the logs
* ensure that when using values which violate the schema the provider throws the exception to the logs:
```
2023-08-18T03:16:27.324Z        DEBUG   events  cannot update Addon in AWS: InvalidParameterException: ConfigurationValue provided in request is not supported: Yaml schema validation failed with error: [$.controller2: is not defined in the schema and the schema does not allow additional properties]
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: ""
  },
```
[contribution process]: https://git.io/fj2m9
