### PR TITLE
chore(ci): Increase golangci timeout to 30min

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 10m
+  timeout: 30m
 
   skip-files:
   - "zz_generated\\..+\\.go$"


### PR DESCRIPTION
### Description of your changes

Increase the linter timeout to 30 minutes to avoid failing pipelines due to context deadlines.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
