### PR TITLE
feat: expose metrics for all AWS API calls

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/crossplane-contrib/provider-aws/apis/v1alpha1"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller"
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
+	"github.com/crossplane-contrib/provider-aws/pkg/utils/metrics"
 )
 
 func main() {
@@ -123,6 +124,7 @@ func main() {
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaManagementPolicies)
 	}
 
+	kingpin.FatalIfError(metrics.SetupMetrics(), "Cannot setup AWS metrics hook")
 	kingpin.FatalIfError(controller.Setup(mgr, o), "Cannot setup AWS controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/onsi/gomega v1.27.7
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.15.1
 	go.uber.org/zap v1.24.0
 	golang.org/x/net v0.12.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
@@ -121,10 +122,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/operator-framework/api v0.6.0 // indirect
-	github.com/prometheus/client_golang v1.15.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
-	github.com/prometheus/procfs v0.10.0 // indirect
+	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/samber/lo v1.37.0 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -683,8 +683,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.10.0 h1:UkG7GPYkO4UZyLnyXjaWYcgOSONqwdBqFUT95ugmt6I=
-github.com/prometheus/procfs v0.10.0/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
+github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
+github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/pkg/utils/metrics/setup.go
+++ b/pkg/utils/metrics/setup.go
@@ -1,0 +1,24 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	metricAWSAPICalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "aws_api_calls_total",
+		Help: "Number of API calls to the AWS API",
+	}, []string{"service", "operation", "api_version"})
+)
+
+// SetupMetrics will register the known Prometheus metrics with controller-runtime's metrics registry
+func SetupMetrics() error {
+	return k8smetrics.Registry.Register(metricAWSAPICalls)
+}
+
+// IncAWSAPICall will increment the aws_api_calls_total metric for the specified service, operation, and apiVersion tuple
+func IncAWSAPICall(service, operation, apiVersion string) {
+	metricAWSAPICalls.WithLabelValues(service, operation, apiVersion).Inc()
+}


### PR DESCRIPTION
### Description of your changes

This change will add a new Prometheus metric, `aws_api_calls_total`, exposed by controller-runtime that counts all requests made to the AWS APIs. This is useful when using expensive APIs like the Service Catalog API ($0.0007/request) for accounting purposes on accounts with multiple clusters.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This has been built and deployed to a test cluster where it was successfully observed to cause no errors when calling either v1 or v2 SDK methods, and successfully included the new metric on the `/metrics` endpoint.
