### PR TITLE
fix: Package names for mwaa and mq

### DIFF
--- a/pkg/controller/mq/setup.go
+++ b/pkg/controller/mq/setup.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mwaa
+package mq
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/controller/mwaa/setup.go
+++ b/pkg/controller/mwaa/setup.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mq
+package mwaa
 
 import (
 	ctrl "sigs.k8s.io/controller-runtime"


### PR DESCRIPTION
### Description of your changes

Uses the correct package names for `mwaa` and `mq`. No functional code changes were made.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
