### PR TITLE
fix(rds): issue 1121 Fix restore rdsinstance passwords set

### DIFF
--- a/pkg/clients/database/rds.go
+++ b/pkg/clients/database/rds.go
@@ -46,7 +46,7 @@ import (
 const (
 	errGetPasswordSecretFailed = "cannot get password secret"
 
-	// The condition CndtnPaswordSet is used to track whether the RDS master password has been
+	// CndtnPaswordSet This used to track whether the RDS master password has been
 	// set or not.
 	CndtnPaswordSet xpv1.ConditionType = "PasswordSet"
 
@@ -75,17 +75,17 @@ func newPasswordSetCondition(sts corev1.ConditionStatus, rsn xpv1.ConditionReaso
 	}
 }
 
-// Create a CndtnPaswordSet Condition with false status, reason CndtnPaswordSetReasonPending and the provided message
+// PasswordSetPending creates a CndtnPaswordSet Condition with false status, reason CndtnPaswordSetReasonPending and the provided message
 func PasswordSetPending(msg string) xpv1.Condition {
 	return newPasswordSetCondition(corev1.ConditionFalse, CndtnPaswordSetReasonPending, msg)
 }
 
-// Create a CndtnPaswordSet Condition with true status, reason CndtnPaswordSetReasonSet and the provided message
+// PasswordSet creates a CndtnPaswordSet Condition with true status, reason CndtnPaswordSetReasonSet and the provided message
 func PasswordSet(msg string) xpv1.Condition {
 	return newPasswordSetCondition(corev1.ConditionTrue, CndtnPaswordSetReasonSet, msg)
 }
 
-// Create a CndtnPaswordSet Condition with fale status, reason CndtnPaswordSetReasonFailed and the error text in message
+// PasswordSetFail creates a CndtnPaswordSet Condition with fale status, reason CndtnPaswordSetReasonFailed and the error text in message
 func PasswordSetFail(err error) xpv1.Condition {
 	return newPasswordSetCondition(corev1.ConditionFalse, CndtnPaswordSetReasonFailed, err.Error())
 }

--- a/pkg/controller/database/rdsinstance/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance.go
@@ -38,12 +38,13 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/crossplane-contrib/provider-aws/apis/database/v1beta1"
 	"github.com/crossplane-contrib/provider-aws/apis/v1alpha1"
 	awsclient "github.com/crossplane-contrib/provider-aws/pkg/clients"
 	rds "github.com/crossplane-contrib/provider-aws/pkg/clients/database"
 	"github.com/crossplane-contrib/provider-aws/pkg/features"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (


### PR DESCRIPTION
### Description of your changes

[Currrently, 2023-09-27 20:15 Pacific TZ this is a strawman/draft/wip PR]

We found RDSInstance:restoreFrom snapshot isn't useful 'out of the box' if you didn't know the password of the RDS that was the source of the snapshot.     Instead you have to take an extra step to set the password after the RDS is provisioned.

When creating an RDS the provider is able to pass the password to the AWS api.   So the password is set 'out of the box'.   However the AWS restore function doesn't take a password parameter and currently the provider makes no effort to set the password in the case of restore.

This change adds a PasswordSet condition which is used to track whether the provider has managed to set the master password yet or not.    Necessary cause it generally isn't possible to set the RDS password immediately after the call to the AWS restore function.     

The condition is set to False with a reason of Pending when the provider sees the password needs to be set.   This happens in 
- Create 
- Update, if a password change has been detected
The condition is set to False with a reason of Failed if an attempt to set the password was made but it failed.  This happens in 
- CreateOrRestore, where an attempt to set the password is made immediately after the call to the AWS restore function 
- Update, where an attempt to modify DB is made after changes are detected 
The condition is set to True with a reason of PasswordSet if the password was successfully set.   This happens in 
- CreateOrRestore, after successful creation of a new RDS 'from scratch'
- CreateOrRestore, where an attempt to set the password is made immediately after the call to the AWS restore function 
- Update, where an attempt to modify DB is made after changes are detected 

The IsUpToDate function, called by Observe, now takes into account the value of the PasswordSet condition when determining if there was a password change.   If the existing checks don't indicate a password change but PasswordSet == False then IsUpTodate concludes that there was a password change and IsUpdateToDate returns false.

Update's password change check has has been updated similar to IsUpToDate.   Additionally it has been updated to use GeneratePassword like Create does.


Fixes #1121 

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [ X] Run `make reviewable test` to ensure this PR is ready for review. 

### How has this code been tested

After updating condition checks all existing tests pass.
I have performed manual tests.
TODO: Add unit tests specifically for the new logic that was added.

[contribution process]: https://git.io/fj2m9
