### PR TITLE
fix(aws): Add missing api groups setup functions

### DIFF
--- a/pkg/controller/aws.go
+++ b/pkg/controller/aws.go
@@ -32,11 +32,13 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/cloudfront"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/cloudsearch"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/cloudwatchlogs"
+	"github.com/crossplane-contrib/provider-aws/pkg/controller/cognitoidentity"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/cognitoidentityprovider"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/config"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/database"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/dax"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/docdb"
+	"github.com/crossplane-contrib/provider-aws/pkg/controller/dynamodb"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/ec2"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/ecr"
 	"github.com/crossplane-contrib/provider-aws/pkg/controller/ecs"
@@ -92,11 +94,13 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		cloudfront.Setup,
 		cloudsearch.Setup,
 		cloudwatchlogs.Setup,
+		cognitoidentity.Setup,
 		cognitoidentityprovider.Setup,
 		config.Setup,
 		database.Setup,
 		dax.Setup,
 		docdb.Setup,
+		dynamodb.Setup,
 		ec2.Setup,
 		ecr.Setup,
 		ecs.Setup,


### PR DESCRIPTION
### Description of your changes

Fixes #1874 by adding missing setup functions. 

It appears #1827 missed a few api groups during the refactor.

To identify missing groups I simply ran `find pkg/controller -name 'setup.go' -maxdepth 2 | sort` and compared to the existing `aws.go` file and added missing lines. Not sure if I missed anything else so happy to hear feedback on the approach.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

After making my changes and running the provider locally I've executed:
```
kubectl apply -f examples/dynamodb/table.yaml
```

And saw successful handling of DynamoDB resources:
```
NAME                                                                     READY   SYNCED   EXTERNAL-NAME
table.dynamodb.aws.crossplane.io/sample-table                            True    True     sample-table
table.dynamodb.aws.crossplane.io/sample-table-global-secondary-indexes   True    True     sample-table-global-secondary-indexes
table.dynamodb.aws.crossplane.io/sample-table-ppr                        True    True     sample-table-ppr
table.dynamodb.aws.crossplane.io/sample-table-with-sse                   True    True     sample-table-with-sse
table.dynamodb.aws.crossplane.io/sample-table-without-sse                True    True     sample-table-without-sse
```
