### PR TITLE
fix(kinesis): fix bug related with the use of external-name

### DIFF
--- a/pkg/controller/kinesis/stream/setup.go
+++ b/pkg/controller/kinesis/stream/setup.go
@@ -58,6 +58,10 @@ func SetupStream(mgr ctrl.Manager, o controller.Options) error {
 
 	reconcilerOpts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
+		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
+		managed.WithInitializers(
+			managed.NewDefaultProviderConfig(mgr.GetClient()),
+			managed.NewNameAsExternalName(mgr.GetClient())),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
@@ -124,7 +128,6 @@ func postCreate(_ context.Context, cr *svcapitypes.Stream, obj *svcsdk.CreateStr
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-	meta.SetExternalName(cr, *awsclients.String(meta.GetExternalName(cr)))
 	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
 }
 

--- a/pkg/controller/kinesis/stream/setup.go
+++ b/pkg/controller/kinesis/stream/setup.go
@@ -124,7 +124,7 @@ func postCreate(_ context.Context, cr *svcapitypes.Stream, obj *svcsdk.CreateStr
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-	meta.SetExternalName(cr, cr.Name)
+	meta.SetExternalName(cr, *awsclients.String(meta.GetExternalName(cr)))
 	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
 }
 
@@ -189,7 +189,7 @@ func (u *updater) update(ctx context.Context, mg resource.Managed) (managed.Exte
 
 	// we need information from stream for decisions
 	obj, err := u.client.DescribeStreamWithContext(ctx, &svcsdk.DescribeStreamInput{
-		StreamName: &cr.Name,
+		StreamName: awsclients.String(meta.GetExternalName(cr)),
 	})
 	if err != nil {
 		return managed.ExternalUpdate{}, awsclients.Wrap(err, errCreate)
@@ -376,7 +376,7 @@ func (u *updater) ActiveShards(cr *svcapitypes.Stream) (int64, error) {
 	var count int64
 
 	shards, err := u.client.ListShards(&svcsdk.ListShardsInput{
-		StreamName: &cr.Name,
+		StreamName: awsclients.String(meta.GetExternalName(cr)),
 	})
 	if err != nil {
 		return count, err
@@ -395,7 +395,7 @@ func (u *updater) ActiveShards(cr *svcapitypes.Stream) (int64, error) {
 func (u *updater) ListTags(cr *svcapitypes.Stream) (*svcsdk.ListTagsForStreamOutput, error) {
 
 	tags, err := u.client.ListTagsForStream(&svcsdk.ListTagsForStreamInput{
-		StreamName: &cr.Name,
+		StreamName: awsclients.String(meta.GetExternalName(cr)),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When you have a different external-name compared to name and a bug occurres and generates 2 different streams one with the original name and other with the external name, also solves the problem related with getting the correct stream status.

Signed-off-by: Domene Esteban, Nil
<nildomenee@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1751 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested locally using Localstack creating multiple Streams with different configurations.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
