### PR TITLE
fix(rds): Infer cache secret namespace from pod environment

### DIFF
--- a/pkg/clients/rds/common.go
+++ b/pkg/clients/rds/common.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/rds/v1alpha1"
+	kubeutils "github.com/crossplane-contrib/provider-aws/pkg/utils/kube"
 )
 
 // Publicly usable variables
@@ -53,8 +54,6 @@ const (
 	errGetCachedPassword    = "cannot get cached password"
 	errGetCachedRestoreInfo = "cannot get cached restore info"
 	errGetMasterPassword    = "cannot get master password"
-
-	secretNamespace = "crossplane-system"
 )
 
 type restoreSate string
@@ -168,6 +167,7 @@ func getCachedPassword(ctx context.Context, kube client.Client, mg resource.Mana
 func getCachingSecretRef(mg resource.Managed) xpv1.SecretReference {
 	secretName := mg.GetObjectKind().GroupVersionKind().Kind + "." + string(mg.GetUID())
 	secretName = strings.ToLower(secretName)
+	secretNamespace := kubeutils.GetProviderNamespace()
 
 	return xpv1.SecretReference{
 		Name:      secretName,

--- a/pkg/clients/rds/common_test.go
+++ b/pkg/clients/rds/common_test.go
@@ -20,6 +20,10 @@ import (
 	kubemock "github.com/crossplane-contrib/provider-aws/pkg/clients/mock/kube"
 )
 
+const (
+	secretNamespace = "crossplane-system"
+)
+
 var (
 	errBoom = errors.New("boom")
 )

--- a/pkg/utils/kube/context_namespace.go
+++ b/pkg/utils/kube/context_namespace.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"os"
+)
+
+const (
+	fileServiceAccountNamespace = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	environPodNamespace         = "POD_NAMESPACE"
+	defaultNamespace            = "crossplane-system"
+)
+
+// GetProviderNamespace that is considered the default to store and access
+// namespaced resources like cache secrets.
+// This function is necessary since client-go does not set a namespace by
+// default and the provider is not guaranteed to always run in the
+// crossplane-system namespace.
+func GetProviderNamespace() string {
+	// Try inferring the namespace from the environment
+	if podNs := os.Getenv(environPodNamespace); podNs != "" {
+		return podNs
+	}
+
+	// Try to get the service account namespace from file
+	saNsRaw, err := os.ReadFile(fileServiceAccountNamespace)
+	saNs := string(saNsRaw)
+	if err == nil && saNs != "" {
+		return saNs
+	}
+
+	// TODO: Do we want to read from the local kubeconfig if the provider is
+	//       running on a local dev machine?
+	//       While this might certainly work, it could produce trigger
+	//       unintended behaviour if the user context points to something else
+	//       then crossplane-system (which he might expect).
+
+	return defaultNamespace
+}


### PR DESCRIPTION
### Description of your changes

This adds a function that infers the namespace of the RDS password cache secret from the following locations (in order):

1. `POD_NAMESPACE` env var
2. `/var/run/secrets/kubernetes.io/serviceaccount/namespace` file
3. fallback to `crossplane-system`

Until now `crossplane-system` was the hardcoded value.

Fixes #1834

Please note that this might cause a regeneration of passwords if the provider is running in another namespace than `crossplane-system`, but, due to the change, is now looking for the secret in another namespace where it does not exist.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
