### PR TITLE
fix(kms): Parse key policies before compare

### DIFF
--- a/pkg/utils/policy/compare_test.go
+++ b/pkg/utils/policy/compare_test.go
@@ -1,0 +1,73 @@
+package policy
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	//go:embed testdata/Issue1892_a.json
+	policyIssue1892a string
+
+	//go:embed testdata/Issue1892_a_min.json
+	policyIssue1892aMin string
+
+	//go:embed testdata/Issue1892_b.json
+	policyIssue1892b string
+
+	//go:embed testdata/Issue1892_b_min.json
+	policyIssue1892bMin string
+)
+
+func TestCompareRawPolicies(t *testing.T) {
+	type args struct {
+		policyA string
+		policyB string
+	}
+	type want struct {
+		equals bool
+	}
+	cases := map[string]struct {
+		want
+		args
+	}{
+		"Issue1892_a": {
+			args: args{
+				policyA: policyIssue1892a,
+				policyB: policyIssue1892aMin,
+			},
+			want: want{
+				equals: true,
+			},
+		},
+		"Issue1892_b": {
+			args: args{
+				policyA: policyIssue1892b,
+				policyB: policyIssue1892bMin,
+			},
+			want: want{
+				equals: true,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			pA, err := ParsePolicyString(tc.args.policyA)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pB, err := ParsePolicyString(tc.args.policyB)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			equal, pDiff := ArePoliciesEqal(&pA, &pB)
+			if diff := cmp.Diff(&tc.want.equals, &equal); diff != "" {
+				t.Errorf("ArePoliciesEqal(...): -want, +got\n:%s\nDiff: -want +got\n:%s", diff, pDiff)
+			}
+		})
+	}
+}

--- a/pkg/utils/policy/parse.go
+++ b/pkg/utils/policy/parse.go
@@ -14,6 +14,15 @@ func ParsePolicyString(raw string) (Policy, error) {
 	return ParsePolicyBytes([]byte(raw))
 }
 
+// ParsePolicyStringPtr from a raw JSON string pointer.
+func ParsePolicyStringPtr(raw *string) (*Policy, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	pol, err := ParsePolicyBytes([]byte(*raw))
+	return &pol, err
+}
+
 // ParsePolicyObject parses a policy from an object (i.e. an API struct) which
 // can be marshalled into JSON.
 func ParsePolicyObject(obj any) (Policy, error) {

--- a/pkg/utils/policy/testdata/Issue1892_a.json
+++ b/pkg/utils/policy/testdata/Issue1892_a.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "Enable IAM User Permissions",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::123456789012:root"
+        },
+        "Action": "kms:*",
+        "Resource": "*"
+      }
+    ]
+}

--- a/pkg/utils/policy/testdata/Issue1892_a_min.json
+++ b/pkg/utils/policy/testdata/Issue1892_a_min.json
@@ -1,0 +1,1 @@
+{"Version":"2012-10-17","Statement":[{"Sid":"Enable IAM User Permissions","Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789012:root"},"Action":"kms:*","Resource":"*"}]}

--- a/pkg/utils/policy/testdata/Issue1892_b.json
+++ b/pkg/utils/policy/testdata/Issue1892_b.json
@@ -1,0 +1,12 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [ {
+      "Sid" : "Enable IAM User Permissions",
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "arn:aws:iam::512236375848:root"
+      },
+      "Action" : "kms:*",
+      "Resource" : "*"
+    } ]
+}

--- a/pkg/utils/policy/testdata/Issue1892_b_min.json
+++ b/pkg/utils/policy/testdata/Issue1892_b_min.json
@@ -1,0 +1,12 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [ {
+      "Sid" : "Enable IAM User Permissions",
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "arn:aws:iam::512236375848:root"
+      },
+      "Action" : "kms:*",
+      "Resource" : "*"
+    } ]
+}


### PR DESCRIPTION
### Description of your changes

Avoid unnecessary JSON diffs for KMS key policies by parsing them into a resource policy struct before comparing them, similar to #1757.

Fixes #1892

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests

[contribution process]: https://git.io/fj2m9
