### PR TITLE
fix(kafka): Resolve configuration ARN instead of external name

### DIFF
--- a/apis/kafka/v1alpha1/custom_types.go
+++ b/apis/kafka/v1alpha1/custom_types.go
@@ -45,6 +45,7 @@ type CustomConfigurationInfo struct {
 	// ARN of the configuration to use.
 	// +optional
 	// +crossplane:generate:reference:type=Configuration
+	// +crossplane:generate:reference:extractor=ConfugurationARN()
 	ARN *string `json:"arn,omitempty"`
 
 	// ARNRef is a reference to a Kafka Configuration used to set ARN.

--- a/apis/kafka/v1alpha1/referencers.go
+++ b/apis/kafka/v1alpha1/referencers.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/reference"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"k8s.io/utils/ptr"
+)
+
+// ConfugurationARN returns the status.atProvider.ARN of a Configuration.
+func ConfugurationARN() reference.ExtractValueFn {
+	return func(mg resource.Managed) string {
+		r, ok := mg.(*Configuration)
+		if !ok {
+			return ""
+		}
+		return ptr.Deref(r.Status.AtProvider.ARN, "")
+
+	}
+}

--- a/apis/kafka/v1alpha1/zz_generated.resolvers.go
+++ b/apis/kafka/v1alpha1/zz_generated.resolvers.go
@@ -73,7 +73,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 	if mg.Spec.ForProvider.CustomClusterParameters.CustomConfigurationInfo != nil {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.CustomClusterParameters.CustomConfigurationInfo.ARN),
-			Extract:      reference.ExternalName(),
+			Extract:      ConfugurationARN(),
 			Reference:    mg.Spec.ForProvider.CustomClusterParameters.CustomConfigurationInfo.ARNRef,
 			Selector:     mg.Spec.ForProvider.CustomClusterParameters.CustomConfigurationInfo.ARNSelector,
 			To: reference.To{


### PR DESCRIPTION
### Description of your changes

Adds a custom resolver for `spec.forProvider.configurationInfo.arn` that returns the actually reqired ARN of the configuration instead of the external name.

Fixes #1673

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
