### PR TITLE
fix(database): Ignore AvailabilityZone if MultiAZ is set

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -276,8 +276,9 @@ type RDSInstanceParameters struct {
 	// Default: A random, system-chosen Availability Zone in the endpoint's AWS
 	// Region.
 	// Example: us-east-1d
-	// Constraint: The AvailabilityZone parameter can't be specified if the MultiAZ
-	// parameter is set to true. The specified Availability Zone must be in the
+	// Constraint: The AvailabilityZone parameter is ignored if the MultiAZ
+	// is set to true.
+	// The specified Availability Zone must be in the
 	// same AWS Region as the current endpoint.
 	// +immutable
 	// +optional

--- a/package/crds/database.aws.crossplane.io_rdsinstances.yaml
+++ b/package/crds/database.aws.crossplane.io_rdsinstances.yaml
@@ -146,9 +146,9 @@ spec:
                       and Availability Zones, see Regions and Availability Zones (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).
                       Default: A random, system-chosen Availability Zone in the endpoint''s
                       AWS Region. Example: us-east-1d Constraint: The AvailabilityZone
-                      parameter can''t be specified if the MultiAZ parameter is set
-                      to true. The specified Availability Zone must be in the same
-                      AWS Region as the current endpoint.'
+                      parameter is ignored if the MultiAZ is set to true. The specified
+                      Availability Zone must be in the same AWS Region as the current
+                      endpoint.'
                     type: string
                   backupRetentionPeriod:
                     description: 'BackupRetentionPeriod is the number of days for

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -128,16 +128,19 @@ func TestCreatePatch(t *testing.T) {
 					AllocatedStorage: allocatedStorage,
 					CharacterSetName: &characterSetName,
 					DBName:           &dbName,
+					AvailabilityZone: ptr.To("az1"),
 				},
 				p: &v1beta1.RDSInstanceParameters{
 					AllocatedStorage: awsclient.IntAddress(awsclient.Int64(30)),
 					CharacterSetName: &characterSetName,
 					DBName:           &dbName,
+					AvailabilityZone: ptr.To("az2"),
 				},
 			},
 			want: want{
 				patch: &v1beta1.RDSInstanceParameters{
 					AllocatedStorage: awsclient.IntAddress(awsclient.Int64(30)),
+					AvailabilityZone: ptr.To("az2"),
 				},
 			},
 		},
@@ -204,6 +207,21 @@ func TestCreatePatch(t *testing.T) {
 						{Key: "tag2", Value: "val"},
 						{Key: "tag1", Value: "val"},
 					},
+				},
+			},
+			want: want{
+				patch: &v1beta1.RDSInstanceParameters{},
+			},
+		},
+		"IgnoreDifferentAvailabilityZoneForMultiAZ": {
+			args: args{
+				db: &rdstypes.DBInstance{
+					AvailabilityZone: ptr.To("az1"),
+					MultiAZ:          true,
+				},
+				p: &v1beta1.RDSInstanceParameters{
+					AvailabilityZone: ptr.To("az2"),
+					MultiAZ:          ptr.To(true),
 				},
 			},
 			want: want{
@@ -467,6 +485,23 @@ func TestIsUpToDate(t *testing.T) {
 					Spec: v1beta1.RDSInstanceSpec{
 						ForProvider: v1beta1.RDSInstanceParameters{
 							EngineVersion: ptr.To("12.1"),
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"NoUpdateForDifferentAvailabilityZoneWhenMultiAZ": {
+			args: args{
+				db: rdstypes.DBInstance{
+					AvailabilityZone: ptr.To("az1"),
+					MultiAZ:          true,
+				},
+				r: v1beta1.RDSInstance{
+					Spec: v1beta1.RDSInstanceSpec{
+						ForProvider: v1beta1.RDSInstanceParameters{
+							AvailabilityZone: ptr.To("az2"),
+							MultiAZ:          ptr.To(true),
 						},
 					},
 				},


### PR DESCRIPTION
### Description of your changes

Only pass `spec.forProvider.availabilityZone` during update calls if `spec.forProvider.multiAZ` is false.

Fixes #1870

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests

[contribution process]: https://git.io/fj2m9
