### PR TITLE
chore(ci): Disable codeql step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,50 +143,52 @@ jobs:
           version: ${{ env.GOLANGCI_VERSION }}
           skip-cache: true # We do our own caching.
 
-  codeql:
-    runs-on: ubuntu-22.04
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
+  # Disabled for now because it takes a very long time to run and we are not
+  # using the results anywhere.
+  # codeql:
+  #   runs-on: ubuntu-22.04
+  #   needs: detect-noop
+  #   if: needs.detect-noop.outputs.noop != 'true'
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
-        with:
-          submodules: true
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+  #       with:
+  #         submodules: true
 
-      - name: Setup Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - name: Setup Go
+  #       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - name: Find the Go Build Cache
-        id: go
-        run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
+  #     - name: Find the Go Build Cache
+  #       id: go
+  #       run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
-      - name: Cache the Go Build Cache
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
-        with:
-          path: ${{ steps.go.outputs.cache }}
-          key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-check-diff-
+  #     - name: Cache the Go Build Cache
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
+  #       with:
+  #         path: ${{ steps.go.outputs.cache }}
+  #         key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: ${{ runner.os }}-build-check-diff-
 
-      - name: Cache Go Dependencies
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
-        with:
-          path: .work/pkg
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
+  #     - name: Cache Go Dependencies
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
+  #       with:
+  #         path: .work/pkg
+  #         key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: ${{ runner.os }}-pkg-
 
-      - name: Vendor Dependencies
-        run: make vendor vendor.check
+  #     - name: Vendor Dependencies
+  #       run: make vendor vendor.check
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2
-        with:
-          languages: go
+  #     - name: Initialize CodeQL
+  #       uses: github/codeql-action/init@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2
+  #       with:
+  #         languages: go
 
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2
+  #     - name: Perform CodeQL Analysis
+  #       uses: github/codeql-action/analyze@ddccb873888234080b77e9bc2d4764d5ccaaccf9 # v2
 
   trivy-scan-fs:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Description of your changes

Removes the `codeql` check that was introduced with #1888 because it takes a very long time to run and we are not using the results anywhere.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
