### PR TITLE
fix(kafka/cluster): clusterpolicy update + delete

### DIFF
--- a/apis/kafka/generator-config.yaml
+++ b/apis/kafka/generator-config.yaml
@@ -18,3 +18,9 @@ resources:
       errors:
         404:
           code: NotFoundException
+    fields:
+      ClusterPolicyVersion:
+        is_read_only: true
+        from:
+          operation: GetClusterPolicy
+          path: CurrentVersion

--- a/apis/kafka/v1alpha1/zz_cluster.go
+++ b/apis/kafka/v1alpha1/zz_cluster.go
@@ -66,6 +66,8 @@ type ClusterSpec struct {
 type ClusterObservation struct {
 	// The Amazon Resource Name (ARN) of the cluster.
 	ClusterARN *string `json:"clusterARN,omitempty"`
+	// Cluster policy version.
+	ClusterPolicyVersion *string `json:"clusterPolicyVersion,omitempty"`
 	// The state of the cluster. The possible states are ACTIVE, CREATING, DELETING,
 	// FAILED, HEALING, MAINTENANCE, REBOOTING_BROKER, and UPDATING.
 	State *string `json:"state,omitempty"`

--- a/apis/kafka/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/kafka/v1alpha1/zz_generated.deepcopy.go
@@ -506,6 +506,11 @@ func (in *ClusterObservation) DeepCopyInto(out *ClusterObservation) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClusterPolicyVersion != nil {
+		in, out := &in.ClusterPolicyVersion, &out.ClusterPolicyVersion
+		*out = new(string)
+		**out = **in
+	}
 	if in.State != nil {
 		in, out := &in.State, &out.State
 		*out = new(string)

--- a/package/crds/kafka.aws.crossplane.io_clusters.yaml
+++ b/package/crds/kafka.aws.crossplane.io_clusters.yaml
@@ -1295,6 +1295,9 @@ spec:
                   clusterARN:
                     description: The Amazon Resource Name (ARN) of the cluster.
                     type: string
+                  clusterPolicyVersion:
+                    description: Cluster policy version.
+                    type: string
                   state:
                     description: The state of the cluster. The possible states are
                       ACTIVE, CREATING, DELETING, FAILED, HEALING, MAINTENANCE, REBOOTING_BROKER,

--- a/pkg/controller/kafka/cluster/setup.go
+++ b/pkg/controller/kafka/cluster/setup.go
@@ -376,7 +376,7 @@ func (u *hooks) getClusterPolicyState(ctx context.Context, wanted *svcapitypes.C
 	})
 	if IsNotFound(err) {
 		if wanted.Spec.ForProvider.ClusterPolicy == nil {
-			return subResourceOK, "spec.forProvider.clusterPolicy", nil
+			return subResourceOK, "", nil
 		}
 		return subResourceNeedsUpdate, "spec.forProvider.clusterPolicy", nil
 	}
@@ -384,11 +384,16 @@ func (u *hooks) getClusterPolicyState(ctx context.Context, wanted *svcapitypes.C
 		return subResourceOK, "", errors.Wrap(err, errGetClusterPolicy)
 	}
 
+	// write clusterPolicy currentVersion into status to be used in potential update and to be visible for user
+	wanted.Status.AtProvider.ClusterPolicyVersion = res.CurrentVersion
+
 	if res.Policy == nil {
 		if wanted.Spec.ForProvider.ClusterPolicy == nil {
-			return subResourceNeedsDeletion, "spec.forProvider.clusterPolicy", nil
+			return subResourceOK, "", nil
 		}
-		return subResourceOK, "spec.forProvider.clusterPolicy", nil
+		return subResourceNeedsUpdate, "spec.forProvider.clusterPolicy", nil
+	} else if wanted.Spec.ForProvider.ClusterPolicy == nil {
+		return subResourceNeedsDeletion, "spec.forProvider.clusterPolicy", nil
 	}
 
 	currentPolicy, err := policy.ParsePolicyString(*res.Policy)
@@ -991,8 +996,9 @@ func (u *hooks) update(ctx context.Context, mg resource.Managed) (managed.Extern
 				return managed.ExternalUpdate{}, errors.Wrap(err, errMarshalClusterPolicy)
 			}
 			_, err = u.client.PutClusterPolicyWithContext(ctx, &svcsdk.PutClusterPolicyInput{
-				ClusterArn: &currentARN,
-				Policy:     policyRaw,
+				ClusterArn:     &currentARN,
+				CurrentVersion: cr.Status.AtProvider.ClusterPolicyVersion,
+				Policy:         policyRaw,
 			})
 			if err != nil {
 				return managed.ExternalUpdate{}, errors.Wrap(err, errPutClusterPolicy)


### PR DESCRIPTION
### Description of your changes

For `kafka.Cluster`:

- adaptation in `getClusterPolicyState` to allow triggering deletion of `ClusterPolicy` when user sets `clusterPolicy: null` in claim 
- ~~cache~~ the `CurrentVersion` of the `ClusterPolicy` to enable making consecutive `PutClusterPolicy` calls
EDIT: add + use new field `Status.AtProvider.ClusterPolicyVersion` to "cache" the `CurrentVersion` of the `ClusterPolicy` for update. This way user has also access to that data, e.g. for making manual  `PutClusterPolicy` calls.

Fixes #1920

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually
