### PR TITLE
feat(ack): Do not call isUpToDate if resource is deleted

### DIFF
--- a/pkg/controller/apigateway/apikey/zz_controller.go
+++ b/pkg/controller/apigateway/apikey/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAPIKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/authorizer/zz_controller.go
+++ b/pkg/controller/apigateway/authorizer/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAuthorizer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/basepathmapping/zz_controller.go
+++ b/pkg/controller/apigateway/basepathmapping/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateBasePathMapping(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/deployment/zz_controller.go
+++ b/pkg/controller/apigateway/deployment/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDeployment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/documentationpart/zz_controller.go
+++ b/pkg/controller/apigateway/documentationpart/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDocumentationPart(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/documentationversion/zz_controller.go
+++ b/pkg/controller/apigateway/documentationversion/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDocumentationVersion(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/domainname/zz_controller.go
+++ b/pkg/controller/apigateway/domainname/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomainName(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/gatewayresponse/zz_controller.go
+++ b/pkg/controller/apigateway/gatewayresponse/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGatewayResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/integration/zz_controller.go
+++ b/pkg/controller/apigateway/integration/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/integrationresponse/zz_controller.go
+++ b/pkg/controller/apigateway/integrationresponse/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegrationResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/method/zz_controller.go
+++ b/pkg/controller/apigateway/method/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateMethod(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/methodresponse/zz_controller.go
+++ b/pkg/controller/apigateway/methodresponse/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateMethodResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/model/zz_controller.go
+++ b/pkg/controller/apigateway/model/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateModel(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/requestvalidator/zz_controller.go
+++ b/pkg/controller/apigateway/requestvalidator/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRequestValidator(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/resource/zz_controller.go
+++ b/pkg/controller/apigateway/resource/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResource(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/restapi/zz_controller.go
+++ b/pkg/controller/apigateway/restapi/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRestAPI(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/stage/zz_controller.go
+++ b/pkg/controller/apigateway/stage/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStage(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/usageplan/zz_controller.go
+++ b/pkg/controller/apigateway/usageplan/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUsagePlan(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/usageplankey/zz_controller.go
+++ b/pkg/controller/apigateway/usageplankey/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUsagePlanKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigateway/vpclink/zz_controller.go
+++ b/pkg/controller/apigateway/vpclink/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCLink(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/api/zz_controller.go
+++ b/pkg/controller/apigatewayv2/api/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAPI(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/apimapping/zz_controller.go
+++ b/pkg/controller/apigatewayv2/apimapping/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAPIMapping(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/authorizer/zz_controller.go
+++ b/pkg/controller/apigatewayv2/authorizer/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAuthorizer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/deployment/zz_controller.go
+++ b/pkg/controller/apigatewayv2/deployment/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDeployment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/domainname/zz_controller.go
+++ b/pkg/controller/apigatewayv2/domainname/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomainName(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/integration/zz_controller.go
+++ b/pkg/controller/apigatewayv2/integration/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/integrationresponse/zz_controller.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegrationResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/model/zz_controller.go
+++ b/pkg/controller/apigatewayv2/model/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateModel(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/route/zz_controller.go
+++ b/pkg/controller/apigatewayv2/route/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRoute(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/routeresponse/zz_controller.go
+++ b/pkg/controller/apigatewayv2/routeresponse/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRouteResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/stage/zz_controller.go
+++ b/pkg/controller/apigatewayv2/stage/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStage(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/apigatewayv2/vpclink/zz_controller.go
+++ b/pkg/controller/apigatewayv2/vpclink/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCLink(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/athena/workgroup/zz_controller.go
+++ b/pkg/controller/athena/workgroup/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateWorkGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/autoscaling/autoscalinggroup/zz_controller.go
+++ b/pkg/controller/autoscaling/autoscalinggroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAutoScalingGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/batch/computeenvironment/zz_controller.go
+++ b/pkg/controller/batch/computeenvironment/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateComputeEnvironment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/batch/jobqueue/zz_controller.go
+++ b/pkg/controller/batch/jobqueue/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateJobQueue(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cloudfront/cachepolicy/zz_controller.go
+++ b/pkg/controller/cloudfront/cachepolicy/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCachePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/zz_controller.go
+++ b/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCloudFrontOriginAccessIdentity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cloudfront/distribution/zz_controller.go
+++ b/pkg/controller/cloudfront/distribution/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDistribution(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cloudfront/responseheaderspolicy/zz_controller.go
+++ b/pkg/controller/cloudfront/responseheaderspolicy/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResponseHeadersPolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cloudsearch/domain/zz_controller.go
+++ b/pkg/controller/cloudsearch/domain/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomain(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cloudwatchlogs/loggroup/zz_controller.go
+++ b/pkg/controller/cloudwatchlogs/loggroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLogGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cognitoidentityprovider/group/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/group/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cognitoidentityprovider/identityprovider/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/identityprovider/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIdentityProvider(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cognitoidentityprovider/resourceserver/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/resourceserver/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResourceServer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cognitoidentityprovider/userpool/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/userpool/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUserPool(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cognitoidentityprovider/userpoolclient/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/userpoolclient/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUserPoolClient(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/cognitoidentityprovider/userpooldomain/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/userpooldomain/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUserPoolDomain(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/dax/cluster/zz_controller.go
+++ b/pkg/controller/dax/cluster/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/dax/parametergroup/zz_controller.go
+++ b/pkg/controller/dax/parametergroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/dax/subnetgroup/zz_controller.go
+++ b/pkg/controller/dax/subnetgroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateSubnetGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/docdb/dbcluster/setup_test.go
+++ b/pkg/controller/docdb/dbcluster/setup_test.go
@@ -1758,14 +1758,12 @@ func TestObserve(t *testing.T) {
 					withDeletionTimestamp(&metav1.Time{Time: timeNow}),
 					withPreferredMaintenanceWindow(testOtherPreferredMaintenanceWindow),
 					withExternalName(testDBClusterIdentifier),
-					withConditions(xpv1.Available()),
 					withStatus(svcapitypes.DocDBInstanceStateAvailable),
 					withVpcSecurityGroupIds(),
 				),
 				result: managed.ExternalObservation{
-					ResourceExists:    true,
-					ResourceUpToDate:  true,
-					ConnectionDetails: generateConnectionDetails("", "", "", "", 0),
+					ResourceExists:   true,
+					ResourceUpToDate: true,
 				},
 				docdb: fake.MockDocDBClientCall{
 					DescribeDBClustersWithContext: []*fake.CallDescribeDBClustersWithContext{

--- a/pkg/controller/docdb/dbcluster/zz_controller.go
+++ b/pkg/controller/docdb/dbcluster/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBClusterParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/docdb/dbinstance/zz_controller.go
+++ b/pkg/controller/docdb/dbinstance/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBInstance(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/docdb/dbsubnetgroup/zz_controller.go
+++ b/pkg/controller/docdb/dbsubnetgroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBSubnetGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/dynamodb/backup/zz_controller.go
+++ b/pkg/controller/dynamodb/backup/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateBackup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/dynamodb/globaltable/zz_controller.go
+++ b/pkg/controller/dynamodb/globaltable/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGlobalTable(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/dynamodb/table/zz_controller.go
+++ b/pkg/controller/dynamodb/table/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTable(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/flowlog/zz_controller.go
+++ b/pkg/controller/ec2/flowlog/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFlowLog(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/launchtemplate/zz_controller.go
+++ b/pkg/controller/ec2/launchtemplate/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLaunchTemplate(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/launchtemplateversion/zz_controller.go
+++ b/pkg/controller/ec2/launchtemplateversion/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLaunchTemplateVersion(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/transitgateway/zz_controller.go
+++ b/pkg/controller/ec2/transitgateway/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTransitGateway(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/transitgatewayroutetable/zz_controller.go
+++ b/pkg/controller/ec2/transitgatewayroutetable/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTransitGatewayRouteTable(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/transitgatewayvpcattachment/zz_controller.go
+++ b/pkg/controller/ec2/transitgatewayvpcattachment/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTransitGatewayVPCAttachment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/volume/zz_controller.go
+++ b/pkg/controller/ec2/volume/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVolume(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/vpcendpoint/zz_controller.go
+++ b/pkg/controller/ec2/vpcendpoint/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCEndpoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/vpcendpointserviceconfiguration/zz_controller.go
+++ b/pkg/controller/ec2/vpcendpointserviceconfiguration/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCEndpointServiceConfiguration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ec2/vpcpeeringconnection/zz_controller.go
+++ b/pkg/controller/ec2/vpcpeeringconnection/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCPeeringConnection(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ecr/lifecyclepolicy/zz_controller.go
+++ b/pkg/controller/ecr/lifecyclepolicy/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLifecyclePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ecs/cluster/zz_controller.go
+++ b/pkg/controller/ecs/cluster/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ecs/service/zz_controller.go
+++ b/pkg/controller/ecs/service/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateService(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ecs/taskdefinition/zz_controller.go
+++ b/pkg/controller/ecs/taskdefinition/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTaskDefinition(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/efs/accesspoint/zz_controller.go
+++ b/pkg/controller/efs/accesspoint/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAccessPoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/efs/filesystem/zz_controller.go
+++ b/pkg/controller/efs/filesystem/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFileSystem(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/efs/mounttarget/zz_controller.go
+++ b/pkg/controller/efs/mounttarget/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateMountTarget(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/eks/addon/zz_controller.go
+++ b/pkg/controller/eks/addon/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAddon(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/elasticache/cacheparametergroup/zz_controller.go
+++ b/pkg/controller/elasticache/cacheparametergroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCacheParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/elbv2/listener/zz_controller.go
+++ b/pkg/controller/elbv2/listener/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateListener(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/elbv2/loadbalancer/zz_controller.go
+++ b/pkg/controller/elbv2/loadbalancer/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLoadBalancer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/elbv2/targetgroup/zz_controller.go
+++ b/pkg/controller/elbv2/targetgroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTargetGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/emrcontainers/jobrun/zz_controller.go
+++ b/pkg/controller/emrcontainers/jobrun/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateJobRun(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/emrcontainers/virtualcluster/zz_controller.go
+++ b/pkg/controller/emrcontainers/virtualcluster/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVirtualCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/globalaccelerator/accelerator/zz_controller.go
+++ b/pkg/controller/globalaccelerator/accelerator/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAccelerator(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/globalaccelerator/endpointgroup/zz_controller.go
+++ b/pkg/controller/globalaccelerator/endpointgroup/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEndpointGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/globalaccelerator/listener/zz_controller.go
+++ b/pkg/controller/globalaccelerator/listener/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateListener(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/glue/classifier/zz_controller.go
+++ b/pkg/controller/glue/classifier/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateClassifier(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/glue/connection/zz_controller.go
+++ b/pkg/controller/glue/connection/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateConnection(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/glue/crawler/zz_controller.go
+++ b/pkg/controller/glue/crawler/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCrawler(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/glue/database/zz_controller.go
+++ b/pkg/controller/glue/database/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDatabase(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/glue/job/zz_controller.go
+++ b/pkg/controller/glue/job/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateJob(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/glue/securityconfiguration/zz_controller.go
+++ b/pkg/controller/glue/securityconfiguration/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateSecurityConfiguration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/iam/instanceprofile/zz_controller.go
+++ b/pkg/controller/iam/instanceprofile/zz_controller.go
@@ -85,7 +85,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateInstanceProfile(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/iot/policy/zz_controller.go
+++ b/pkg/controller/iot/policy/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GeneratePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/iot/thing/zz_controller.go
+++ b/pkg/controller/iot/thing/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateThing(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/kafka/cluster/zz_controller.go
+++ b/pkg/controller/kafka/cluster/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/kafka/configuration/zz_controller.go
+++ b/pkg/controller/kafka/configuration/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateConfiguration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/kinesis/stream/zz_controller.go
+++ b/pkg/controller/kinesis/stream/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStream(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/kms/key/zz_controller.go
+++ b/pkg/controller/kms/key/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/lambda/function/zz_controller.go
+++ b/pkg/controller/lambda/function/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFunction(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/lambda/functionurlconfig/zz_controller.go
+++ b/pkg/controller/lambda/functionurlconfig/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFunctionURLConfig(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/mq/broker/zz_controller.go
+++ b/pkg/controller/mq/broker/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateBroker(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/mq/user/zz_controller.go
+++ b/pkg/controller/mq/user/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUser(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/mwaa/environment/zz_controller.go
+++ b/pkg/controller/mwaa/environment/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEnvironment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/neptune/dbcluster/zz_controller.go
+++ b/pkg/controller/neptune/dbcluster/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/opensearchservice/domain/zz_controller.go
+++ b/pkg/controller/opensearchservice/domain/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomain(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/prometheusservice/alertmanagerdefinition/zz_controller.go
+++ b/pkg/controller/prometheusservice/alertmanagerdefinition/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAlertManagerDefinition(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/prometheusservice/rulegroupsnamespace/zz_controller.go
+++ b/pkg/controller/prometheusservice/rulegroupsnamespace/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRuleGroupsNamespace(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/prometheusservice/workspace/zz_controller.go
+++ b/pkg/controller/prometheusservice/workspace/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateWorkspace(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/ram/resourceshare/zz_controller.go
+++ b/pkg/controller/ram/resourceshare/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResourceShare(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/rds/dbcluster/zz_controller.go
+++ b/pkg/controller/rds/dbcluster/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/rds/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/rds/dbclusterparametergroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBClusterParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/rds/dbinstance/zz_controller.go
+++ b/pkg/controller/rds/dbinstance/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBInstance(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/rds/dbparametergroup/zz_controller.go
+++ b/pkg/controller/rds/dbparametergroup/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/rds/globalcluster/zz_controller.go
+++ b/pkg/controller/rds/globalcluster/zz_controller.go
@@ -92,7 +92,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGlobalCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/rds/optiongroup/zz_controller.go
+++ b/pkg/controller/rds/optiongroup/zz_controller.go
@@ -93,7 +93,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateOptionGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/route53resolver/resolverendpoint/zz_controller.go
+++ b/pkg/controller/route53resolver/resolverendpoint/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResolverEndpoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/route53resolver/resolverrule/zz_controller.go
+++ b/pkg/controller/route53resolver/resolverrule/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResolverRule(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/s3control/accesspoint/zz_controller.go
+++ b/pkg/controller/s3control/accesspoint/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAccessPoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/secretsmanager/secret/zz_controller.go
+++ b/pkg/controller/secretsmanager/secret/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateSecret(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/servicediscovery/service/zz_controller.go
+++ b/pkg/controller/servicediscovery/service/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateService(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/sesv2/configurationset/zz_controller.go
+++ b/pkg/controller/sesv2/configurationset/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateConfigurationSet(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/sesv2/emailidentity/zz_controller.go
+++ b/pkg/controller/sesv2/emailidentity/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEmailIdentity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/sesv2/emailtemplate/zz_controller.go
+++ b/pkg/controller/sesv2/emailtemplate/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEmailTemplate(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/sfn/activity/zz_controller.go
+++ b/pkg/controller/sfn/activity/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateActivity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/sfn/statemachine/zz_controller.go
+++ b/pkg/controller/sfn/statemachine/zz_controller.go
@@ -89,7 +89,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStateMachine(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/transfer/server/zz_controller.go
+++ b/pkg/controller/transfer/server/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateServer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/pkg/controller/transfer/user/zz_controller.go
+++ b/pkg/controller/transfer/user/zz_controller.go
@@ -88,7 +88,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUser(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -104,7 +104,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	Generate{{ .CRD.Names.Camel }}(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists:   true,
+			ResourceUpToDate: true,
+		}, nil
+	}
 	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")


### PR DESCRIPTION
### Description of your changes

Modifies the ACK controller template to only call `isUpToDate` if not `meta.WasDeleted(cr)`. This may safe some time and unnecessary AWS calls.

Only affects controllers that are generated with ACK.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
