### PR TITLE
fix(iam): Stop considering AWS initialized fields in diff

### DIFF
--- a/pkg/clients/iam/role.go
+++ b/pkg/clients/iam/role.go
@@ -79,7 +79,6 @@ func GenerateRoleObservation(role iamtypes.Role) v1beta1.RoleExternalStatus {
 
 // GenerateRole assigns the in RoleParamters to role.
 func GenerateRole(in v1beta1.RoleParameters, role *iamtypes.Role) error {
-
 	if in.AssumeRolePolicyDocument != "" {
 		s, err := legacypolicy.CompactAndEscapeJSON(in.AssumeRolePolicyDocument)
 		if err != nil {
@@ -179,7 +178,10 @@ func IsRoleUpToDate(in v1beta1.RoleParameters, observed iamtypes.Role) (bool, st
 		return false, "", err
 	}
 
-	diff := cmp.Diff(desired, &observed, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}), cmpopts.IgnoreFields(observed, "AssumeRolePolicyDocument"), cmpopts.IgnoreTypes(document.NoSerde{}), cmpopts.SortSlices(lessTag))
+	diff := cmp.Diff(desired, &observed,
+		cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{}),
+		cmpopts.IgnoreFields(observed, "AssumeRolePolicyDocument", "CreateDate", "PermissionsBoundary.PermissionsBoundaryType"),
+		cmpopts.IgnoreTypes(document.NoSerde{}), cmpopts.SortSlices(lessTag))
 	if diff == "" && policyUpToDate {
 		return true, diff, nil
 	}

--- a/pkg/clients/iam/role_test.go
+++ b/pkg/clients/iam/role_test.go
@@ -46,10 +46,12 @@ var (
 		  }
 		]
 	   }`
-	roleID   = "some Id"
-	roleName = "some name"
-	tagKey   = "key"
-	tagValue = "value"
+	roleID             = "some Id"
+	roleName           = "some name"
+	tagKey             = "key"
+	tagValue           = "value"
+	permissionBoundary = "arn:aws:iam::111111111111:policy/permission-boundary"
+	createDate         = time.Now()
 )
 
 func roleParams(m ...func(*v1beta1.RoleParameters)) *v1beta1.RoleParameters {
@@ -262,6 +264,38 @@ func TestIsRoleUpToDate(t *testing.T) {
 					AssumeRolePolicyDocument: assumeRolePolicyDocument,
 					MaxSessionDuration:       pointer.ToIntAsInt32(1),
 					Path:                     pointer.ToOrNilIfZeroValue("/"),
+					Tags: []v1beta1.Tag{{
+						Key:   "key1",
+						Value: "value1",
+					}},
+				},
+			},
+			want:     true,
+			wantDiff: "",
+		},
+		"AWSInitializedFields": {
+			args: args{
+				role: iamtypes.Role{
+					AssumeRolePolicyDocument: escapedPolicyJSON(),
+					CreateDate:               &createDate,
+					Description:              &description,
+					MaxSessionDuration:       pointer.ToIntAsInt32(1),
+					Path:                     pointer.ToOrNilIfZeroValue("/"),
+					PermissionsBoundary: &iamtypes.AttachedPermissionsBoundary{
+						PermissionsBoundaryArn:  &permissionBoundary,
+						PermissionsBoundaryType: "Policy",
+					},
+					Tags: []iamtypes.Tag{{
+						Key:   pointer.ToOrNilIfZeroValue("key1"),
+						Value: pointer.ToOrNilIfZeroValue("value1"),
+					}},
+				},
+				p: v1beta1.RoleParameters{
+					Description:              &description,
+					AssumeRolePolicyDocument: assumeRolePolicyDocument,
+					MaxSessionDuration:       pointer.ToIntAsInt32(1),
+					Path:                     pointer.ToOrNilIfZeroValue("/"),
+					PermissionsBoundary:      &permissionBoundary,
 					Tags: []v1beta1.Tag{{
 						Key:   "key1",
 						Value: "value1",


### PR DESCRIPTION

### Description of your changes

Fixes # https://github.com/crossplane-contrib/provider-aws/issues/1945

Stop considering AWS initialized fields in diff. 

Let me know if there's another way that's more idiomatic to Crossplane.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've added a test to cover this scenario.