### PR TITLE
fix: readd missed empty initializers after tagging removal

### DIFF
--- a/pkg/controller/acm/controller.go
+++ b/pkg/controller/acm/controller.go
@@ -67,6 +67,7 @@ func SetupCertificate(mgr ctrl.Manager, o controller.Options) error {
 	reconcilerOpts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: acm.NewClient}),
 		managed.WithConnectionPublishers(),
+		managed.WithInitializers(),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),

--- a/pkg/controller/acmpca/certificateauthority/controller.go
+++ b/pkg/controller/acmpca/certificateauthority/controller.go
@@ -69,6 +69,7 @@ func SetupCertificateAuthority(mgr ctrl.Manager, o controller.Options) error {
 	reconcilerOpts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: acmpca.NewClient}),
 		managed.WithConnectionPublishers(),
+		managed.WithInitializers(),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),

--- a/pkg/controller/ec2/transitgatewayvpcattachment/setup.go
+++ b/pkg/controller/ec2/transitgatewayvpcattachment/setup.go
@@ -44,6 +44,7 @@ func SetupTransitGatewayVPCAttachment(mgr ctrl.Manager, o controller.Options) er
 	reconcilerOpts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithInitializers(),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
 	}

--- a/pkg/controller/ec2/vpcpeeringconnection/setup.go
+++ b/pkg/controller/ec2/vpcpeeringconnection/setup.go
@@ -49,6 +49,7 @@ func SetupVPCPeeringConnection(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), opts: opts}),
 		managed.WithCreationGracePeriod(3 * time.Minute),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithInitializers(),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
 	}

--- a/pkg/controller/iam/openidconnectprovider/controller.go
+++ b/pkg/controller/iam/openidconnectprovider/controller.go
@@ -73,6 +73,7 @@ func SetupOpenIDConnectProvider(mgr ctrl.Manager, o controller.Options) error {
 	reconcilerOpts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewOpenIDConnectProviderClient}),
 		managed.WithPollInterval(o.PollInterval),
+		managed.WithInitializers(),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),

--- a/pkg/controller/iam/policy/controller.go
+++ b/pkg/controller/iam/policy/controller.go
@@ -72,6 +72,7 @@ func SetupPolicy(mgr ctrl.Manager, o controller.Options) error {
 	reconcilerOpts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{kube: mgr.GetClient(), newClientFn: iam.NewPolicyClient, newSTSClientFn: iam.NewSTSClient}),
 		managed.WithConnectionPublishers(),
+		managed.WithInitializers(),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),


### PR DESCRIPTION
### Description of your changes

Similar to #1942, this fixes - hopefully all - missed cases where the empty `managed.WithInitializers()` is needed.

My guess is that resources, that where only affected through #1938 and not through #1935, were missed in fix #1942

`acm.Certificate`, `acmpca.CertificateAuthority`, and `iam.Policy` are actually not working (not possible to create new claims) in v0.45.0, due to AWS validating/expecting ARNs in Describe/Get requests. `iam.OpenIDConnectProvider` probably also, did not manually test here.

> failed to satisfy constraint: Member must satisfy regular expression pattern: arn:[\w+=/,.@-]+:acm:[\w+=/,.@-]*:[0-9]+:[\w+=,.@-]+(/[\w+=,.@-]+)*

`ec2.TransitGatewayVPCAttachment` and `ec2.VPCPeeringConnection` seem to be fine currently, as AWS is not validating IDs.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
