### PR TITLE
Fixes Update Loop when KubernetesNetworkConfig is Set.

### DIFF
--- a/pkg/clients/eks/eks.go
+++ b/pkg/clients/eks/eks.go
@@ -339,6 +339,13 @@ func LateInitialize(in *v1beta1.ClusterParameters, cluster *ekstypes.Cluster) { 
 			in.ResourcesVpcConfig.SubnetIDs = cluster.ResourcesVpcConfig.SubnetIds
 		}
 	}
+	if in.KubernetesNetworkConfig == nil && cluster.KubernetesNetworkConfig != nil {
+		in.KubernetesNetworkConfig = &v1beta1.KubernetesNetworkConfigRequest{
+			ServiceIpv4Cidr: pointer.StringValue(cluster.KubernetesNetworkConfig.ServiceIpv4Cidr),
+			IPFamily:        v1beta1.IPFamily(cluster.KubernetesNetworkConfig.IpFamily),
+		}
+	}
+
 	in.RoleArn = pointer.LateInitializeValueFromPtr(in.RoleArn, cluster.RoleArn)
 	in.Version = pointer.LateInitialize(in.Version, cluster.Version)
 	// NOTE(hasheddan): we always will set the default Crossplane tags in

--- a/pkg/clients/eks/eks_test.go
+++ b/pkg/clients/eks/eks_test.go
@@ -475,6 +475,8 @@ func TestGenerateObservation(t *testing.T) {
 }
 
 func TestLateInitialize(t *testing.T) {
+	ServiceIpv4Cidr := "172.20.0.0/16"
+	Ipv4Family := "ipv4"
 	cases := map[string]struct {
 		parameters *v1beta1.ClusterParameters
 		cluster    *ekstypes.Cluster
@@ -517,6 +519,10 @@ func TestLateInitialize(t *testing.T) {
 					SecurityGroupIds:      []string{"cool-sg-1"},
 					SubnetIds:             []string{"cool-subnet"},
 				},
+				KubernetesNetworkConfig: &ekstypes.KubernetesNetworkConfigResponse{
+					IpFamily:        ekstypes.IpFamily(Ipv4Family),
+					ServiceIpv4Cidr: &ServiceIpv4Cidr,
+				},
 				RoleArn: &roleArn,
 				Tags:    map[string]string{"key": "val"},
 				Version: &version,
@@ -546,6 +552,10 @@ func TestLateInitialize(t *testing.T) {
 					PublicAccessCidrs:     []string{"0.0.0.0/0"},
 					SecurityGroupIDs:      []string{"cool-sg-1"},
 					SubnetIDs:             []string{"cool-subnet"},
+				},
+				KubernetesNetworkConfig: &v1beta1.KubernetesNetworkConfigRequest{
+					ServiceIpv4Cidr: ServiceIpv4Cidr,
+					IPFamily:        v1beta1.IPFamily(Ipv4Family),
 				},
 				RoleArn: roleArn,
 				Tags:    map[string]string{"key": "val"},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- Adds `KubernetesNetworkConfig` to `LateInitialize` function
- Updates `LateInitialize` Unit tests to tests

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit Tests
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
