### PR TITLE
fix(database): tag-only-change triggers update + add RemoveTag call

### DIFF
--- a/pkg/clients/database/fake/fake.go
+++ b/pkg/clients/database/fake/fake.go
@@ -32,6 +32,7 @@ type MockRDSClient struct {
 	MockModify             func(context.Context, *rds.ModifyDBInstanceInput, []func(*rds.Options)) (*rds.ModifyDBInstanceOutput, error)
 	MockDelete             func(context.Context, *rds.DeleteDBInstanceInput, []func(*rds.Options)) (*rds.DeleteDBInstanceOutput, error)
 	MockAddTags            func(context.Context, *rds.AddTagsToResourceInput, []func(*rds.Options)) (*rds.AddTagsToResourceOutput, error)
+	MockRemoveTags         func(context.Context, *rds.RemoveTagsFromResourceInput, []func(*rds.Options)) (*rds.RemoveTagsFromResourceOutput, error)
 }
 
 // DescribeDBInstances finds RDS Instance by name
@@ -72,4 +73,9 @@ func (m *MockRDSClient) DeleteDBInstance(ctx context.Context, i *rds.DeleteDBIns
 // AddTagsToResource adds tags to RDS Instance.
 func (m *MockRDSClient) AddTagsToResource(ctx context.Context, i *rds.AddTagsToResourceInput, opts ...func(*rds.Options)) (*rds.AddTagsToResourceOutput, error) {
 	return m.MockAddTags(ctx, i, opts)
+}
+
+// RemoveTagsFromResource removes tags from RDS Instance.
+func (m *MockRDSClient) RemoveTagsFromResource(ctx context.Context, i *rds.RemoveTagsFromResourceInput, opts ...func(*rds.Options)) (*rds.RemoveTagsFromResourceOutput, error) {
+	return m.MockRemoveTags(ctx, i, opts)
 }

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -148,75 +148,6 @@ func TestCreatePatch(t *testing.T) {
 				},
 			},
 		},
-		"DifferentTags": {
-			args: args{
-				db: &rdstypes.DBInstance{
-					TagList: []rdstypes.Tag{
-						{Key: ptr.To("tag1")},
-						{Key: ptr.To("tag2")},
-						{Key: ptr.To("tag3")},
-					},
-				},
-				p: &v1beta1.RDSInstanceParameters{
-					Tags: []v1beta1.Tag{
-						{Key: "tag1"},
-						{Key: "tag5"},
-						{Key: "tag6"},
-					},
-				},
-			},
-			want: want{
-				patch: &v1beta1.RDSInstanceParameters{
-					Tags: []v1beta1.Tag{
-						{Key: "tag1"},
-						{Key: "tag5"},
-						{Key: "tag6"},
-					},
-				},
-			},
-		},
-		"SameTags": {
-			args: args{
-				db: &rdstypes.DBInstance{
-					TagList: []rdstypes.Tag{
-						{Key: ptr.To("tag1")},
-						{Key: ptr.To("tag2")},
-						{Key: ptr.To("tag3")},
-					},
-				},
-				p: &v1beta1.RDSInstanceParameters{
-					Tags: []v1beta1.Tag{
-						{Key: "tag1"},
-						{Key: "tag2"},
-						{Key: "tag3"},
-					},
-				},
-			},
-			want: want{
-				patch: &v1beta1.RDSInstanceParameters{},
-			},
-		},
-		"SameTagsDifferentOrder": {
-			args: args{
-				db: &rdstypes.DBInstance{
-					TagList: []rdstypes.Tag{
-						{Key: ptr.To("tag1"), Value: ptr.To("val")},
-						{Key: ptr.To("tag2"), Value: ptr.To("val")},
-						{Key: ptr.To("tag3"), Value: ptr.To("val")},
-					},
-				},
-				p: &v1beta1.RDSInstanceParameters{
-					Tags: []v1beta1.Tag{
-						{Key: "tag3", Value: "val"},
-						{Key: "tag2", Value: "val"},
-						{Key: "tag1", Value: "val"},
-					},
-				},
-			},
-			want: want{
-				patch: &v1beta1.RDSInstanceParameters{},
-			},
-		},
 		"IgnoreDifferentAvailabilityZoneForMultiAZ": {
 			args: args{
 				db: &rdstypes.DBInstance{
@@ -527,12 +458,81 @@ func TestIsUpToDate(t *testing.T) {
 			},
 			want: true,
 		},
+		"SameTags": {
+			args: args{
+				db: rdstypes.DBInstance{
+					TagList: []rdstypes.Tag{
+						{Key: ptr.To("tag1")},
+						{Key: ptr.To("tag2")},
+						{Key: ptr.To("tag3")},
+					},
+				},
+				r: v1beta1.RDSInstance{
+					Spec: v1beta1.RDSInstanceSpec{
+						ForProvider: v1beta1.RDSInstanceParameters{
+							Tags: []v1beta1.Tag{
+								{Key: "tag1"},
+								{Key: "tag2"},
+								{Key: "tag3"},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"SameTagsDifferentOrder": {
+			args: args{
+				db: rdstypes.DBInstance{
+					TagList: []rdstypes.Tag{
+						{Key: ptr.To("tag1"), Value: ptr.To("val")},
+						{Key: ptr.To("tag2"), Value: ptr.To("val")},
+						{Key: ptr.To("tag3"), Value: ptr.To("val")},
+					},
+				},
+				r: v1beta1.RDSInstance{
+					Spec: v1beta1.RDSInstanceSpec{
+						ForProvider: v1beta1.RDSInstanceParameters{
+							Tags: []v1beta1.Tag{
+								{Key: "tag3", Value: "val"},
+								{Key: "tag2", Value: "val"},
+								{Key: "tag1", Value: "val"},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		"DifferentTags": {
+			args: args{
+				db: rdstypes.DBInstance{
+					TagList: []rdstypes.Tag{
+						{Key: ptr.To("tag1")},
+						{Key: ptr.To("tag2")},
+						{Key: ptr.To("tag3")},
+					},
+				},
+				r: v1beta1.RDSInstance{
+					Spec: v1beta1.RDSInstanceSpec{
+						ForProvider: v1beta1.RDSInstanceParameters{
+							Tags: []v1beta1.Tag{
+								{Key: "tag1"},
+								{Key: "tag5"},
+								{Key: "tag6"},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			got, _, _ := IsUpToDate(ctx, tc.args.kube, &tc.args.r, tc.args.db)
+			got, _, _, _ := IsUpToDate(ctx, tc.args.kube, &tc.args.r, tc.args.db)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -532,7 +532,7 @@ func TestIsUpToDate(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
-			got, _, _, _ := IsUpToDate(ctx, tc.args.kube, &tc.args.r, tc.args.db)
+			got, _, _, _, _ := IsUpToDate(ctx, tc.args.kube, &tc.args.r, tc.args.db)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}

--- a/pkg/controller/database/rdsinstance/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
-	awsrdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
@@ -55,6 +54,7 @@ const (
 	errUnknownRestoreSource               = "unknown RDS restore source"
 	errModifyFailed                       = "cannot modify RDS instance"
 	errAddTagsFailed                      = "cannot add tags to RDS instance"
+	errRemoveTagsFailed                   = "cannot remove tags from  RDS instance"
 	errDeleteFailed                       = "cannot delete RDS instance"
 	errDescribeFailed                     = "cannot describe RDS instance"
 	errPatchCreationFailed                = "cannot create a patch object"
@@ -112,12 +112,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	return &external{c.newClientFn(cfg), c.kube}, nil
+	return &external{c.newClientFn(cfg), c.kube, rds.Cache{}}, nil
 }
 
 type external struct {
 	client rds.Client
 	kube   client.Client
+
+	cache rds.Cache
 }
 
 func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -152,7 +154,13 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	default:
 		cr.Status.SetConditions(xpv1.Unavailable())
 	}
-	upToDate, diff, err := rds.IsUpToDate(ctx, e.kube, cr, instance)
+
+	var cachecache rds.Cache
+
+	upToDate, diff, cachecache, err := rds.IsUpToDate(ctx, e.kube, cr, instance)
+
+	e.cache = cachecache
+
 	if err != nil {
 		return managed.ExternalObservation{}, errorutils.Wrap(err, errUpToDateFailed)
 	}
@@ -273,14 +281,22 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if _, err = e.client.ModifyDBInstance(ctx, modify); err != nil {
 		return managed.ExternalUpdate{}, errorutils.Wrap(err, errModifyFailed)
 	}
-	if len(patch.Tags) > 0 {
-		tags := make([]awsrdstypes.Tag, len(patch.Tags))
-		for i, t := range patch.Tags {
-			tags[i] = awsrdstypes.Tag{Key: aws.String(t.Key), Value: aws.String(t.Value)}
-		}
-		_, err = e.client.AddTagsToResource(ctx, &awsrds.AddTagsToResourceInput{
+
+	// Update tags if necessary
+	if len(e.cache.RemoveTags) > 0 {
+		_, err := e.client.RemoveTagsFromResource(ctx, &awsrds.RemoveTagsFromResourceInput{
 			ResourceName: aws.String(cr.Status.AtProvider.DBInstanceArn),
-			Tags:         tags,
+			TagKeys:      e.cache.RemoveTags,
+		})
+		if err != nil {
+			return managed.ExternalUpdate{}, errorutils.Wrap(err, errRemoveTagsFailed)
+		}
+	}
+	// remove before add for case where we just simply update a tag value
+	if len(e.cache.AddTags) > 0 {
+		_, err := e.client.AddTagsToResource(ctx, &awsrds.AddTagsToResourceInput{
+			ResourceName: aws.String(cr.Status.AtProvider.DBInstanceArn),
+			Tags:         e.cache.AddTags,
 		})
 		if err != nil {
 			return managed.ExternalUpdate{}, errorutils.Wrap(err, errAddTagsFailed)

--- a/pkg/controller/database/rdsinstance/rdsinstance_test.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance_test.go
@@ -100,7 +100,7 @@ func FromTimePtr(t *time.Time) *metav1.Time {
 type args struct {
 	rds   rds.Client
 	kube  client.Client
-	cache rds.Cache
+	cache Cache
 	cr    *v1beta1.RDSInstance
 }
 
@@ -194,8 +194,8 @@ func instance(m ...rdsModifier) *v1beta1.RDSInstance {
 	return cr
 }
 
-func cache(addTagsMap map[string]string, removeTagsMap map[string]string) rds.Cache {
-	c := rds.Cache{}
+func cache(addTagsMap map[string]string, removeTagsMap map[string]string) Cache {
+	c := Cache{}
 	for k, v := range addTagsMap {
 		c.AddTags = append(c.AddTags, awsrdstypes.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
 	}

--- a/pkg/controller/database/rdsinstance/rdsinstance_test.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance_test.go
@@ -37,6 +37,7 @@ import (
 	rds "github.com/crossplane-contrib/provider-aws/pkg/clients/database"
 	"github.com/crossplane-contrib/provider-aws/pkg/clients/database/fake"
 	errorutils "github.com/crossplane-contrib/provider-aws/pkg/utils/errors"
+	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
 )
 
 const (
@@ -97,9 +98,10 @@ func FromTimePtr(t *time.Time) *metav1.Time {
 }
 
 type args struct {
-	rds  rds.Client
-	kube client.Client
-	cr   *v1beta1.RDSInstance
+	rds   rds.Client
+	kube  client.Client
+	cache rds.Cache
+	cr    *v1beta1.RDSInstance
 }
 
 type rdsModifier func(*v1beta1.RDSInstance)
@@ -190,6 +192,17 @@ func instance(m ...rdsModifier) *v1beta1.RDSInstance {
 		f(cr)
 	}
 	return cr
+}
+
+func cache(addTagsMap map[string]string, removeTagsMap map[string]string) rds.Cache {
+	c := rds.Cache{}
+	for k, v := range addTagsMap {
+		c.AddTags = append(c.AddTags, awsrdstypes.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
+	}
+	for k := range removeTagsMap {
+		c.RemoveTags = append(c.RemoveTags, k)
+	}
+	return c
 }
 
 var _ managed.ExternalClient = &external{}
@@ -841,18 +854,42 @@ func TestUpdate(t *testing.T) {
 						return nil, errBoom
 					},
 				},
-				cr: instance(withTags(map[string]string{"foo": "bar"})),
+				cr:    instance(withTags(map[string]string{"foo": "bar"})),
+				cache: cache(map[string]string{"foo": "bar"}, map[string]string{}),
 			},
 			want: want{
 				cr:  instance(withTags(map[string]string{"foo": "bar"})),
 				err: errorutils.Wrap(errBoom, errAddTagsFailed),
 			},
 		},
+		"FailedRemoveTags": {
+			args: args{
+				rds: &fake.MockRDSClient{
+					MockModify: func(ctx context.Context, input *awsrds.ModifyDBInstanceInput, opts []func(*awsrds.Options)) (*awsrds.ModifyDBInstanceOutput, error) {
+						return &awsrds.ModifyDBInstanceOutput{}, nil
+					},
+					MockDescribe: func(ctx context.Context, input *awsrds.DescribeDBInstancesInput, opts []func(*awsrds.Options)) (*awsrds.DescribeDBInstancesOutput, error) {
+						return &awsrds.DescribeDBInstancesOutput{
+							DBInstances: []awsrdstypes.DBInstance{{}},
+						}, nil
+					},
+					MockRemoveTags: func(ctx context.Context, input *awsrds.RemoveTagsFromResourceInput, opts []func(*awsrds.Options)) (*awsrds.RemoveTagsFromResourceOutput, error) {
+						return nil, errBoom
+					},
+				},
+				cr:    instance(withTags(map[string]string{"foo": "bar"})),
+				cache: cache(map[string]string{}, map[string]string{"foo": "bar"}),
+			},
+			want: want{
+				cr:  instance(withTags(map[string]string{"foo": "bar"})),
+				err: errorutils.Wrap(errBoom, errRemoveTagsFailed),
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			e := &external{kube: tc.kube, client: tc.rds}
+			e := &external{kube: tc.kube, client: tc.rds, cache: tc.cache}
 			u, err := e.Update(context.Background(), tc.args.cr)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {


### PR DESCRIPTION
### Description of your changes

for `database.RDSInstance`:

- fix `isUpToDate()` logic to trigger update on tag-only-change (used cache scheme/solution from `rds.DBInstance`)
- add `RemoveTagsFromResource()` from AWS API to `update()` (removing tags was apparently not possible before...)
- adapt unit-tests

Fixes #1962

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually (update tag-only, update other db parameter)
