### PR TITLE
fix(glue/crawler): lateinit lakeFormationConfiguration

### DIFF
--- a/pkg/controller/glue/crawler/setup.go
+++ b/pkg/controller/glue/crawler/setup.go
@@ -162,6 +162,12 @@ func lateInitialize(spec *svcapitypes.CrawlerParameters, resp *svcsdk.GetCrawler
 
 	spec.Configuration = pointer.LateInitialize(spec.Configuration, resp.Crawler.Configuration)
 
+	if spec.LakeFormationConfiguration == nil {
+		spec.LakeFormationConfiguration = &svcapitypes.LakeFormationConfiguration{}
+	}
+	spec.LakeFormationConfiguration.AccountID = pointer.LateInitialize(spec.LakeFormationConfiguration.AccountID, resp.Crawler.LakeFormationConfiguration.AccountId)
+	spec.LakeFormationConfiguration.UseLakeFormationCredentials = pointer.LateInitialize(spec.LakeFormationConfiguration.UseLakeFormationCredentials, resp.Crawler.LakeFormationConfiguration.UseLakeFormationCredentials)
+
 	if spec.LineageConfiguration == nil {
 		spec.LineageConfiguration = &svcapitypes.LineageConfiguration{}
 	}


### PR DESCRIPTION
### Description of your changes

With the aws sdk bump from  https://github.com/crossplane-contrib/provider-aws/pull/1523 `glue.Crawler` got a new parameter/field `lakeFormationConfiguration`, which needs to be lateinit to avoid an update-loop.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually 
