### PR TITLE
fix(rds/dbinstance): Ignore VPCSecurityGroupIDs for cluster instances

### DIFF
--- a/apis/rds/generator-config.yaml
+++ b/apis/rds/generator-config.yaml
@@ -13,6 +13,11 @@ resources:
         from:
           operation: ModifyDBInstance
           path: AllowMajorVersionUpgrade
+      DBClusterIdentifier:
+        is_read_only: true
+        from:
+          operation: DescribeDBInstances
+          path: DBInstances.DBClusterIdentifier
   DBCluster:
     fields:
       AllowMajorVersionUpgrade:

--- a/apis/rds/v1alpha1/zz_db_instance.go
+++ b/apis/rds/v1alpha1/zz_db_instance.go
@@ -954,6 +954,9 @@ type DBInstanceObservation struct {
 	// For more information about CoIPs, see Customer-owned IP addresses (https://docs.aws.amazon.com/outposts/latest/userguide/routing.html#ip-addressing)
 	// in the Amazon Web Services Outposts User Guide.
 	CustomerOwnedIPEnabled *bool `json:"customerOwnedIPEnabled,omitempty"`
+	// If the DB instance is a member of a DB cluster, indicates the name of the
+	// DB cluster that the DB instance is a member of.
+	DBClusterIdentifier *string `json:"dbClusterIdentifier,omitempty"`
 	// The Amazon Resource Name (ARN) for the DB instance.
 	DBInstanceARN *string `json:"dbInstanceARN,omitempty"`
 	// The list of replicated automated backups associated with the DB instance.

--- a/apis/rds/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/rds/v1alpha1/zz_generated.deepcopy.go
@@ -3146,6 +3146,11 @@ func (in *DBInstanceObservation) DeepCopyInto(out *DBInstanceObservation) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DBClusterIdentifier != nil {
+		in, out := &in.DBClusterIdentifier, &out.DBClusterIdentifier
+		*out = new(string)
+		**out = **in
+	}
 	if in.DBInstanceARN != nil {
 		in, out := &in.DBInstanceARN, &out.DBInstanceARN
 		*out = new(string)

--- a/package/crds/rds.aws.crossplane.io_dbinstances.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbinstances.yaml
@@ -1665,6 +1665,11 @@ spec:
                       CoIPs, see Customer-owned IP addresses (https://docs.aws.amazon.com/outposts/latest/userguide/routing.html#ip-addressing)
                       in the Amazon Web Services Outposts User Guide."
                     type: boolean
+                  dbClusterIdentifier:
+                    description: If the DB instance is a member of a DB cluster, indicates
+                      the name of the DB cluster that the DB instance is a member
+                      of.
+                    type: string
                   dbInstanceARN:
                     description: The Amazon Resource Name (ARN) for the DB instance.
                     type: string


### PR DESCRIPTION
### Description of your changes

This prevents the controller from sending `VPCSecurityGroupIDs` during update or create for DB instances that belong to a DB cluster.

Fixes https://github.com/crossplane-contrib/provider-aws/issues/1799

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually

[contribution process]: https://git.io/fj2m9
