### PR TITLE
fix(lambda): Push empty environment of vpc config if nil

### DIFF
--- a/pkg/controller/lambda/function/setup.go
+++ b/pkg/controller/lambda/function/setup.go
@@ -476,14 +476,12 @@ func GenerateUpdateFunctionConfigurationInput(cr *svcapitypes.Function) *svcsdk.
 	}
 	if cr.Spec.ForProvider.Environment != nil {
 		f4 := &svcsdk.Environment{}
-		if cr.Spec.ForProvider.Environment.Variables != nil {
-			f4f0 := map[string]*string{}
-			for f4f0key, f4f0valiter := range cr.Spec.ForProvider.Environment.Variables {
-				var f4f0val = *f4f0valiter
-				f4f0[f4f0key] = &f4f0val
-			}
-			f4.SetVariables(f4f0)
+		f4f0 := map[string]*string{}
+		for f4f0key, f4f0valiter := range cr.Spec.ForProvider.Environment.Variables {
+			var f4f0val = *f4f0valiter
+			f4f0[f4f0key] = &f4f0val
 		}
+		f4.SetVariables(f4f0)
 		res.SetEnvironment(f4)
 	}
 	if cr.Spec.ForProvider.FileSystemConfigs != nil {
@@ -558,22 +556,21 @@ func GenerateUpdateFunctionConfigurationInput(cr *svcapitypes.Function) *svcsdk.
 	}
 	if cr.Spec.ForProvider.CustomFunctionVPCConfigParameters != nil {
 		f19 := &svcsdk.VpcConfig{}
-		if cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SecurityGroupIDs != nil {
-			f19f0 := []*string{}
-			for _, f19f0iter := range cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SecurityGroupIDs {
-				var f19f0elem = *f19f0iter
-				f19f0 = append(f19f0, &f19f0elem)
-			}
-			f19.SetSecurityGroupIds(f19f0)
+
+		f19f0 := []*string{}
+		for _, f19f0iter := range cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SecurityGroupIDs {
+			var f19f0elem = *f19f0iter
+			f19f0 = append(f19f0, &f19f0elem)
 		}
-		if cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SubnetIDs != nil {
-			f19f1 := []*string{}
-			for _, f19f1iter := range cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SubnetIDs {
-				var f19f1elem = *f19f1iter
-				f19f1 = append(f19f1, &f19f1elem)
-			}
-			f19.SetSubnetIds(f19f1)
+		f19.SetSecurityGroupIds(f19f0)
+
+		f19f1 := []*string{}
+		for _, f19f1iter := range cr.Spec.ForProvider.CustomFunctionVPCConfigParameters.SubnetIDs {
+			var f19f1elem = *f19f1iter
+			f19f1 = append(f19f1, &f19f1elem)
 		}
+		f19.SetSubnetIds(f19f1)
+
 		res.SetVpcConfig(f19)
 	}
 	return res

--- a/pkg/controller/lambda/function/setup_test.go
+++ b/pkg/controller/lambda/function/setup_test.go
@@ -621,7 +621,10 @@ func TestGenerateUpdateFunctionConfigurationInput(t *testing.T) {
 					Runtime:           aws.String("test_runtime"),
 					Timeout:           aws.Int64(128),
 					TracingConfig:     &svcsdk.TracingConfig{Mode: aws.String(svcsdk.TracingModeActive)},
-					VpcConfig:         &svcsdk.VpcConfig{SecurityGroupIds: []*string{aws.String("id1")}},
+					VpcConfig: &svcsdk.VpcConfig{
+						SecurityGroupIds: []*string{aws.String("id1")},
+						SubnetIds:        []*string{},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### Description of your changes

This removes the nil check in the function controller to send an empty array for VPC config and environment if the properties are nil.

Fixes https://github.com/crossplane-contrib/provider-aws/issues/1872

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually and unit tests.

[contribution process]: https://git.io/fj2m9
