### PR TITLE
fix(eks): Update NodeGroup taints

### DIFF
--- a/pkg/clients/eks/nodegroup_test.go
+++ b/pkg/clients/eks/nodegroup_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/crossplane-contrib/provider-aws/apis/eks/manualv1alpha1"
 	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
@@ -640,6 +641,77 @@ func TestGenerateUpdateNodeGroupInput(t *testing.T) {
 				UpdateConfig: &ekstypes.NodegroupUpdateConfig{
 					MaxUnavailable:           &maxUnavailablePercentage,
 					MaxUnavailablePercentage: &maxUnavailable,
+				},
+			},
+		},
+		"DiffTaints": {
+			args: args{
+				name: ngName,
+				p: &manualv1alpha1.NodeGroupParameters{
+					ClusterName: clusterName,
+					Taints: []manualv1alpha1.Taint{
+						{
+							Effect: "effect",
+							Key:    ptr.To("toAdd"),
+							Value:  ptr.To("value"),
+						},
+						{
+							Effect: "effect",
+							Key:    ptr.To("toChange"),
+							Value:  ptr.To("newValue"),
+						},
+						{
+							Effect: "effect",
+							Key:    ptr.To("toKeep"),
+							Value:  ptr.To("value"),
+						},
+					},
+				},
+				n: &ekstypes.Nodegroup{
+					NodegroupName: &ngName,
+					ClusterName:   &clusterName,
+					Taints: []ekstypes.Taint{
+						{
+							Effect: "effect",
+							Key:    ptr.To("toKeep"),
+							Value:  ptr.To("value"),
+						},
+						{
+							Effect: "effect",
+							Key:    ptr.To("toRemove"),
+							Value:  ptr.To("value"),
+						},
+						{
+							Effect: "effect",
+							Key:    ptr.To("toChange"),
+							Value:  ptr.To("oldValue"),
+						},
+					},
+				},
+			},
+			want: &eks.UpdateNodegroupConfigInput{
+				NodegroupName: &ngName,
+				ClusterName:   &clusterName,
+				Taints: &ekstypes.UpdateTaintsPayload{
+					AddOrUpdateTaints: []ekstypes.Taint{
+						{
+							Effect: "effect",
+							Key:    ptr.To("toAdd"),
+							Value:  ptr.To("value"),
+						},
+						{
+							Effect: "effect",
+							Key:    ptr.To("toChange"),
+							Value:  ptr.To("newValue"),
+						},
+					},
+					RemoveTaints: []ekstypes.Taint{
+						{
+							Effect: "effect",
+							Key:    ptr.To("toRemove"),
+							Value:  ptr.To("value"),
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### Description of your changes

Adds a check and update mechanic for EKS nodegroup taints to the controller that works similar to tags adding / removal.

Fixes https://github.com/crossplane-contrib/provider-aws/issues/1952

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests

[contribution process]: https://git.io/fj2m9
