### PR TITLE
fix(ack): controllers only skip isUpToDate on deletion

### DIFF
--- a/pkg/controller/apigateway/apikey/zz_controller.go
+++ b/pkg/controller/apigateway/apikey/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAPIKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/authorizer/zz_controller.go
+++ b/pkg/controller/apigateway/authorizer/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAuthorizer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/basepathmapping/zz_controller.go
+++ b/pkg/controller/apigateway/basepathmapping/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateBasePathMapping(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/deployment/zz_controller.go
+++ b/pkg/controller/apigateway/deployment/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDeployment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/documentationpart/zz_controller.go
+++ b/pkg/controller/apigateway/documentationpart/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDocumentationPart(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/documentationversion/zz_controller.go
+++ b/pkg/controller/apigateway/documentationversion/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDocumentationVersion(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/domainname/zz_controller.go
+++ b/pkg/controller/apigateway/domainname/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomainName(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/gatewayresponse/zz_controller.go
+++ b/pkg/controller/apigateway/gatewayresponse/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGatewayResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/integration/zz_controller.go
+++ b/pkg/controller/apigateway/integration/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/integrationresponse/zz_controller.go
+++ b/pkg/controller/apigateway/integrationresponse/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegrationResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/method/zz_controller.go
+++ b/pkg/controller/apigateway/method/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateMethod(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/methodresponse/zz_controller.go
+++ b/pkg/controller/apigateway/methodresponse/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateMethodResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/model/zz_controller.go
+++ b/pkg/controller/apigateway/model/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateModel(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/requestvalidator/zz_controller.go
+++ b/pkg/controller/apigateway/requestvalidator/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRequestValidator(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/resource/zz_controller.go
+++ b/pkg/controller/apigateway/resource/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResource(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/restapi/zz_controller.go
+++ b/pkg/controller/apigateway/restapi/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRestAPI(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/stage/zz_controller.go
+++ b/pkg/controller/apigateway/stage/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStage(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/usageplan/zz_controller.go
+++ b/pkg/controller/apigateway/usageplan/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUsagePlan(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/usageplankey/zz_controller.go
+++ b/pkg/controller/apigateway/usageplankey/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUsagePlanKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigateway/vpclink/zz_controller.go
+++ b/pkg/controller/apigateway/vpclink/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCLink(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/api/zz_controller.go
+++ b/pkg/controller/apigatewayv2/api/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAPI(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/apimapping/zz_controller.go
+++ b/pkg/controller/apigatewayv2/apimapping/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAPIMapping(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/authorizer/zz_controller.go
+++ b/pkg/controller/apigatewayv2/authorizer/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAuthorizer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/deployment/zz_controller.go
+++ b/pkg/controller/apigatewayv2/deployment/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDeployment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/domainname/zz_controller.go
+++ b/pkg/controller/apigatewayv2/domainname/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomainName(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/integration/zz_controller.go
+++ b/pkg/controller/apigatewayv2/integration/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/integrationresponse/zz_controller.go
+++ b/pkg/controller/apigatewayv2/integrationresponse/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIntegrationResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/model/zz_controller.go
+++ b/pkg/controller/apigatewayv2/model/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateModel(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/route/zz_controller.go
+++ b/pkg/controller/apigatewayv2/route/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRoute(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/routeresponse/zz_controller.go
+++ b/pkg/controller/apigatewayv2/routeresponse/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRouteResponse(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/stage/zz_controller.go
+++ b/pkg/controller/apigatewayv2/stage/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStage(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/apigatewayv2/vpclink/zz_controller.go
+++ b/pkg/controller/apigatewayv2/vpclink/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCLink(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/athena/workgroup/zz_controller.go
+++ b/pkg/controller/athena/workgroup/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateWorkGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/autoscaling/autoscalinggroup/zz_controller.go
+++ b/pkg/controller/autoscaling/autoscalinggroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAutoScalingGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/batch/computeenvironment/zz_controller.go
+++ b/pkg/controller/batch/computeenvironment/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateComputeEnvironment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/batch/jobqueue/zz_controller.go
+++ b/pkg/controller/batch/jobqueue/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateJobQueue(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cloudfront/cachepolicy/zz_controller.go
+++ b/pkg/controller/cloudfront/cachepolicy/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCachePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/zz_controller.go
+++ b/pkg/controller/cloudfront/cloudfrontoriginaccessidentity/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCloudFrontOriginAccessIdentity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cloudfront/distribution/zz_controller.go
+++ b/pkg/controller/cloudfront/distribution/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDistribution(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cloudfront/responseheaderspolicy/zz_controller.go
+++ b/pkg/controller/cloudfront/responseheaderspolicy/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResponseHeadersPolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cloudsearch/domain/zz_controller.go
+++ b/pkg/controller/cloudsearch/domain/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomain(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cloudwatchlogs/loggroup/zz_controller.go
+++ b/pkg/controller/cloudwatchlogs/loggroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLogGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cognitoidentityprovider/group/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/group/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cognitoidentityprovider/identityprovider/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/identityprovider/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateIdentityProvider(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cognitoidentityprovider/resourceserver/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/resourceserver/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResourceServer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cognitoidentityprovider/userpool/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/userpool/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUserPool(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cognitoidentityprovider/userpoolclient/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/userpoolclient/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUserPoolClient(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/cognitoidentityprovider/userpooldomain/zz_controller.go
+++ b/pkg/controller/cognitoidentityprovider/userpooldomain/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUserPoolDomain(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/dax/cluster/zz_controller.go
+++ b/pkg/controller/dax/cluster/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/dax/parametergroup/zz_controller.go
+++ b/pkg/controller/dax/parametergroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/dax/subnetgroup/zz_controller.go
+++ b/pkg/controller/dax/subnetgroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateSubnetGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/docdb/dbcluster/setup_test.go
+++ b/pkg/controller/docdb/dbcluster/setup_test.go
@@ -1747,12 +1747,14 @@ func TestObserve(t *testing.T) {
 					withDeletionTimestamp(&metav1.Time{Time: timeNow}),
 					withPreferredMaintenanceWindow(testOtherPreferredMaintenanceWindow),
 					withExternalName(testDBClusterIdentifier),
+					withConditions(xpv1.Available()),
 					withStatus(svcapitypes.DocDBInstanceStateAvailable),
 					withVpcSecurityGroupIds(),
 				),
 				result: managed.ExternalObservation{
-					ResourceExists:   true,
-					ResourceUpToDate: true,
+					ResourceExists:    true,
+					ResourceUpToDate:  true,
+					ConnectionDetails: generateConnectionDetails("", "", "", "", 0),
 				},
 				docdb: fake.MockDocDBClientCall{
 					DescribeDBClustersWithContext: []*fake.CallDescribeDBClustersWithContext{

--- a/pkg/controller/docdb/dbcluster/zz_controller.go
+++ b/pkg/controller/docdb/dbcluster/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/docdb/dbclusterparametergroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBClusterParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/docdb/dbinstance/zz_controller.go
+++ b/pkg/controller/docdb/dbinstance/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBInstance(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/docdb/dbsubnetgroup/zz_controller.go
+++ b/pkg/controller/docdb/dbsubnetgroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBSubnetGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/dynamodb/backup/zz_controller.go
+++ b/pkg/controller/dynamodb/backup/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateBackup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/dynamodb/globaltable/zz_controller.go
+++ b/pkg/controller/dynamodb/globaltable/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGlobalTable(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/dynamodb/table/zz_controller.go
+++ b/pkg/controller/dynamodb/table/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTable(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/flowlog/zz_controller.go
+++ b/pkg/controller/ec2/flowlog/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFlowLog(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/launchtemplate/zz_controller.go
+++ b/pkg/controller/ec2/launchtemplate/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLaunchTemplate(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/launchtemplateversion/zz_controller.go
+++ b/pkg/controller/ec2/launchtemplateversion/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLaunchTemplateVersion(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/transitgateway/zz_controller.go
+++ b/pkg/controller/ec2/transitgateway/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTransitGateway(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/transitgatewayroutetable/zz_controller.go
+++ b/pkg/controller/ec2/transitgatewayroutetable/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTransitGatewayRouteTable(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/transitgatewayvpcattachment/zz_controller.go
+++ b/pkg/controller/ec2/transitgatewayvpcattachment/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTransitGatewayVPCAttachment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/volume/zz_controller.go
+++ b/pkg/controller/ec2/volume/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVolume(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/vpcendpoint/zz_controller.go
+++ b/pkg/controller/ec2/vpcendpoint/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCEndpoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/vpcendpointserviceconfiguration/zz_controller.go
+++ b/pkg/controller/ec2/vpcendpointserviceconfiguration/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCEndpointServiceConfiguration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ec2/vpcpeeringconnection/zz_controller.go
+++ b/pkg/controller/ec2/vpcpeeringconnection/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVPCPeeringConnection(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ecr/lifecyclepolicy/zz_controller.go
+++ b/pkg/controller/ecr/lifecyclepolicy/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLifecyclePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ecs/cluster/zz_controller.go
+++ b/pkg/controller/ecs/cluster/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ecs/service/zz_controller.go
+++ b/pkg/controller/ecs/service/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateService(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ecs/taskdefinition/zz_controller.go
+++ b/pkg/controller/ecs/taskdefinition/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTaskDefinition(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/efs/accesspoint/zz_controller.go
+++ b/pkg/controller/efs/accesspoint/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAccessPoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/efs/filesystem/zz_controller.go
+++ b/pkg/controller/efs/filesystem/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFileSystem(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/efs/mounttarget/zz_controller.go
+++ b/pkg/controller/efs/mounttarget/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateMountTarget(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/eks/addon/zz_controller.go
+++ b/pkg/controller/eks/addon/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAddon(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/elasticache/cacheparametergroup/zz_controller.go
+++ b/pkg/controller/elasticache/cacheparametergroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCacheParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/elbv2/listener/zz_controller.go
+++ b/pkg/controller/elbv2/listener/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateListener(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/elbv2/loadbalancer/zz_controller.go
+++ b/pkg/controller/elbv2/loadbalancer/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateLoadBalancer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/elbv2/targetgroup/zz_controller.go
+++ b/pkg/controller/elbv2/targetgroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateTargetGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/emrcontainers/jobrun/zz_controller.go
+++ b/pkg/controller/emrcontainers/jobrun/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateJobRun(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/emrcontainers/virtualcluster/zz_controller.go
+++ b/pkg/controller/emrcontainers/virtualcluster/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateVirtualCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/firehose/deliverystream/zz_controller.go
+++ b/pkg/controller/firehose/deliverystream/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDeliveryStream(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/globalaccelerator/accelerator/zz_controller.go
+++ b/pkg/controller/globalaccelerator/accelerator/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAccelerator(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/globalaccelerator/endpointgroup/zz_controller.go
+++ b/pkg/controller/globalaccelerator/endpointgroup/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEndpointGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/globalaccelerator/listener/zz_controller.go
+++ b/pkg/controller/globalaccelerator/listener/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateListener(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/glue/classifier/zz_controller.go
+++ b/pkg/controller/glue/classifier/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateClassifier(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/glue/connection/setup.go
+++ b/pkg/controller/glue/connection/setup.go
@@ -127,13 +127,6 @@ func postObserve(ctx context.Context, cr *svcapitypes.Connection, obj *svcsdk.Ge
 }
 
 func (h *hooks) isUpToDate(_ context.Context, cr *svcapitypes.Connection, resp *svcsdk.GetConnectionOutput) (bool, string, error) {
-
-	// no checks needed if user deletes the resource
-	// ensures that an error (e.g. missing ARN) here does not prevent deletion
-	if meta.WasDeleted(cr) {
-		return true, "", nil
-	}
-
 	currentParams := customGenerateConnection(resp).Spec.ForProvider
 
 	if diff := cmp.Diff(cr.Spec.ForProvider, currentParams, cmpopts.EquateEmpty(),

--- a/pkg/controller/glue/connection/zz_controller.go
+++ b/pkg/controller/glue/connection/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateConnection(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/glue/crawler/setup.go
+++ b/pkg/controller/glue/crawler/setup.go
@@ -206,12 +206,6 @@ func lateInitialize(spec *svcapitypes.CrawlerParameters, resp *svcsdk.GetCrawler
 }
 
 func (h *hooks) isUpToDate(_ context.Context, cr *svcapitypes.Crawler, resp *svcsdk.GetCrawlerOutput) (bool, string, error) {
-	// no checks needed if user deletes the resource
-	// ensures that an error (e.g. missing ARN) here does not prevent deletion
-	if meta.WasDeleted(cr) {
-		return true, "", nil
-	}
-
 	currentParams := customGenerateCrawler(resp).Spec.ForProvider
 
 	// separate check bc: 1.lowercase handling 2.field Schedule has different input/output shapes (see generator-config.yaml)

--- a/pkg/controller/glue/crawler/zz_controller.go
+++ b/pkg/controller/glue/crawler/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCrawler(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/glue/database/zz_controller.go
+++ b/pkg/controller/glue/database/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDatabase(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/glue/job/setup.go
+++ b/pkg/controller/glue/job/setup.go
@@ -154,12 +154,6 @@ func lateInitialize(spec *svcapitypes.JobParameters, resp *svcsdk.GetJobOutput) 
 }
 
 func (h *hooks) isUpToDate(_ context.Context, cr *svcapitypes.Job, resp *svcsdk.GetJobOutput) (bool, string, error) {
-	// no checks needed if user deletes the resource
-	// ensures that an error (e.g. missing ARN) here does not prevent deletion
-	if meta.WasDeleted(cr) {
-		return true, "", nil
-	}
-
 	currentParams := customGenerateJob(resp).Spec.ForProvider
 
 	if diff := cmp.Diff(cr.Spec.ForProvider, currentParams, cmpopts.EquateEmpty(),

--- a/pkg/controller/glue/job/zz_controller.go
+++ b/pkg/controller/glue/job/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateJob(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/glue/securityconfiguration/zz_controller.go
+++ b/pkg/controller/glue/securityconfiguration/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateSecurityConfiguration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/iam/instanceprofile/zz_controller.go
+++ b/pkg/controller/iam/instanceprofile/zz_controller.go
@@ -85,15 +85,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateInstanceProfile(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/iot/policy/zz_controller.go
+++ b/pkg/controller/iot/policy/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GeneratePolicy(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/iot/thing/zz_controller.go
+++ b/pkg/controller/iot/thing/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateThing(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/kafka/cluster/zz_controller.go
+++ b/pkg/controller/kafka/cluster/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/kafka/configuration/zz_controller.go
+++ b/pkg/controller/kafka/configuration/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateConfiguration(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/kinesis/stream/zz_controller.go
+++ b/pkg/controller/kinesis/stream/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStream(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/kms/grant/zz_controller.go
+++ b/pkg/controller/kms/grant/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGrant(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/kms/key/zz_controller.go
+++ b/pkg/controller/kms/key/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateKey(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/lambda/function/zz_controller.go
+++ b/pkg/controller/lambda/function/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFunction(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/lambda/functionurlconfig/zz_controller.go
+++ b/pkg/controller/lambda/functionurlconfig/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateFunctionURLConfig(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/mq/broker/zz_controller.go
+++ b/pkg/controller/mq/broker/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateBroker(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/mq/user/zz_controller.go
+++ b/pkg/controller/mq/user/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUser(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/mwaa/environment/zz_controller.go
+++ b/pkg/controller/mwaa/environment/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEnvironment(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/neptune/dbcluster/zz_controller.go
+++ b/pkg/controller/neptune/dbcluster/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/opensearchservice/domain/zz_controller.go
+++ b/pkg/controller/opensearchservice/domain/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDomain(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/prometheusservice/alertmanagerdefinition/zz_controller.go
+++ b/pkg/controller/prometheusservice/alertmanagerdefinition/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAlertManagerDefinition(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/prometheusservice/rulegroupsnamespace/zz_controller.go
+++ b/pkg/controller/prometheusservice/rulegroupsnamespace/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateRuleGroupsNamespace(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/prometheusservice/workspace/zz_controller.go
+++ b/pkg/controller/prometheusservice/workspace/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateWorkspace(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/ram/resourceshare/zz_controller.go
+++ b/pkg/controller/ram/resourceshare/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResourceShare(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -781,12 +781,6 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj 
 		return upd, err
 	}
 
-	if meta.WasDeleted(cr) {
-		// (schroeder-paul): if we are in the deleting state (which can take a while) we do not need to do
-		// any of the following, so we return here.
-		return upd, nil
-	}
-
 	desiredPassword, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
 	if err != nil {
 		return upd, errors.Wrap(err, dbinstance.ErrRetrievePasswordForUpdate)

--- a/pkg/controller/rds/dbcluster/zz_controller.go
+++ b/pkg/controller/rds/dbcluster/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/rds/dbclusterparametergroup/zz_controller.go
+++ b/pkg/controller/rds/dbclusterparametergroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBClusterParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -261,12 +261,6 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBInstance, out
 		return upd, err
 	}
 
-	if meta.WasDeleted(cr) {
-		// (schroeder-paul): if we are in the deleting state (which can take a while) we do not need to do
-		// any of the following, so we return here.
-		return upd, nil
-	}
-
 	desiredPassword, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
 	if err != nil {
 		return upd, errors.Wrap(err, dbinstance.ErrRetrievePasswordForUpdate)

--- a/pkg/controller/rds/dbinstance/zz_controller.go
+++ b/pkg/controller/rds/dbinstance/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBInstance(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/rds/dbparametergroup/zz_controller.go
+++ b/pkg/controller/rds/dbparametergroup/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateDBParameterGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/rds/globalcluster/zz_controller.go
+++ b/pkg/controller/rds/globalcluster/zz_controller.go
@@ -92,15 +92,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateGlobalCluster(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/rds/optiongroup/zz_controller.go
+++ b/pkg/controller/rds/optiongroup/zz_controller.go
@@ -93,15 +93,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateOptionGroup(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/route53resolver/resolverendpoint/zz_controller.go
+++ b/pkg/controller/route53resolver/resolverendpoint/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResolverEndpoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/route53resolver/resolverrule/zz_controller.go
+++ b/pkg/controller/route53resolver/resolverrule/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateResolverRule(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/s3control/accesspoint/zz_controller.go
+++ b/pkg/controller/s3control/accesspoint/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateAccessPoint(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/secretsmanager/secret/setup.go
+++ b/pkg/controller/secretsmanager/secret/setup.go
@@ -237,10 +237,6 @@ func getAWSSecretData(ref *svcapitypes.SecretReference, s *svcsdk.GetSecretValue
 }
 
 func (e *hooks) isUpToDate(ctx context.Context, cr *svcapitypes.Secret, resp *svcsdk.DescribeSecretOutput) (bool, string, error) {
-	if meta.WasDeleted(cr) {
-		return false, "", nil
-	}
-
 	// NOTE(muvaf): No operation can be done on secrets that are marked for deletion.
 	if resp.DeletedDate != nil {
 		return true, "", nil

--- a/pkg/controller/secretsmanager/secret/zz_controller.go
+++ b/pkg/controller/secretsmanager/secret/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateSecret(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/servicecatalog/provisionedproduct/zz_controller.go
+++ b/pkg/controller/servicecatalog/provisionedproduct/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateProvisionedProduct(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/servicediscovery/service/zz_controller.go
+++ b/pkg/controller/servicediscovery/service/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateService(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/sesv2/configurationset/setup.go
+++ b/pkg/controller/sesv2/configurationset/setup.go
@@ -77,10 +77,6 @@ type hooks struct {
 }
 
 func isUpToDate(_ context.Context, cr *svcapitypes.ConfigurationSet, resp *svcsdk.GetConfigurationSetOutput) (bool, string, error) {
-	if meta.WasDeleted(cr) {
-		return true, "", nil // There is no need to check for updates when we want to delete.
-	}
-
 	if !isUpToDateDeliveryOptions(cr, resp) {
 		return false, "", nil
 	}

--- a/pkg/controller/sesv2/configurationset/zz_controller.go
+++ b/pkg/controller/sesv2/configurationset/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateConfigurationSet(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/sesv2/emailidentity/setup.go
+++ b/pkg/controller/sesv2/emailidentity/setup.go
@@ -25,7 +25,6 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
@@ -81,10 +80,6 @@ type hooks struct {
 }
 
 func (e *hooks) isUpToDate(_ context.Context, cr *svcapitypes.EmailIdentity, resp *svcsdk.GetEmailIdentityOutput) (bool, string, error) { //nolint:gocyclo
-	if meta.WasDeleted(cr) {
-		return true, "", nil // There is no need to check for updates when we want to delete.
-	}
-
 	if pointer.StringValue(cr.Spec.ForProvider.ConfigurationSetName) != pointer.StringValue(resp.ConfigurationSetName) {
 		return false, "", nil
 	}

--- a/pkg/controller/sesv2/emailidentity/zz_controller.go
+++ b/pkg/controller/sesv2/emailidentity/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEmailIdentity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/sesv2/emailtemplate/setup.go
+++ b/pkg/controller/sesv2/emailtemplate/setup.go
@@ -62,10 +62,6 @@ func SetupEmailTemplate(mgr ctrl.Manager, o controller.Options) error {
 }
 
 func isUpToDate(_ context.Context, cr *svcapitypes.EmailTemplate, resp *svcsdk.GetEmailTemplateOutput) (bool, string, error) {
-	if meta.WasDeleted(cr) {
-		return true, "", nil // There is no need to check for updates when we want to delete.
-	}
-
 	if cr.Spec.ForProvider.TemplateContent != nil && resp.TemplateContent != nil {
 		if pointer.StringValue(cr.Spec.ForProvider.TemplateContent.HTML) != pointer.StringValue(resp.TemplateContent.Html) {
 			return false, "", nil

--- a/pkg/controller/sesv2/emailtemplate/zz_controller.go
+++ b/pkg/controller/sesv2/emailtemplate/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateEmailTemplate(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/sfn/activity/zz_controller.go
+++ b/pkg/controller/sfn/activity/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateActivity(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/sfn/statemachine/zz_controller.go
+++ b/pkg/controller/sfn/statemachine/zz_controller.go
@@ -89,15 +89,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateStateMachine(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/transfer/server/zz_controller.go
+++ b/pkg/controller/transfer/server/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateServer(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/transfer/user/zz_controller.go
+++ b/pkg/controller/transfer/user/zz_controller.go
@@ -88,15 +88,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	GenerateUser(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:          true,

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -104,15 +104,13 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "late-init failed")
 	}
 	Generate{{ .CRD.Names.Camel }}(resp).Status.AtProvider.DeepCopyInto(&cr.Status.AtProvider)
-	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
-		return managed.ExternalObservation{
-			ResourceExists:   true,
-			ResourceUpToDate: true,
-		}, nil
-	}
-	upToDate, diff, err := e.isUpToDate(ctx, cr, resp)
-	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+	upToDate := true
+	diff := ""
+	if !meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		upToDate, diff, err = e.isUpToDate(ctx, cr, resp)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "isUpToDate check failed")
+		}
 	}
 	return e.postObserve(ctx, cr, resp, managed.ExternalObservation{
 		ResourceExists:   true,


### PR DESCRIPTION
### Description of your changes

- adapts the ACK controller template to only skip `isUpToDate()` on resource deletion (and not also `postObserve()`)
- for `docdb.Cluster` 
  - adapt unit-test
  - in `postObserve()` add `if meta.WasDeleted(cr) {...}` around secretRef accessing to avoid MR deletion stuck on missing secret
- also cleaned-up the no longer needed `if meta.WasDeleted(cr) {return}` in some `isUpToDate()` 

Fixes #1978

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
unit-tests, manually (`secretsmanager.Secret` + `docdb.Cluster`)
