### PR TITLE
fix(iam): Add schema type to RolePolicy document

### DIFF
--- a/apis/iam/v1beta1/rolepolicy_types.go
+++ b/apis/iam/v1beta1/rolepolicy_types.go
@@ -26,6 +26,7 @@ import (
 type RolePolicyParameters struct {
 
 	// The JSON policy document that is the content for the policy.
+	// +kubebuilder:validation:Type=object
 	Document extv1.JSON `json:"document"`
 
 	// RoleName presents the name of the IAM role.

--- a/package/crds/iam.aws.crossplane.io_rolepolicies.yaml
+++ b/package/crds/iam.aws.crossplane.io_rolepolicies.yaml
@@ -72,6 +72,7 @@ spec:
                   document:
                     description: The JSON policy document that is the content for
                       the policy.
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   roleName:
                     description: RoleName presents the name of the IAM role.


### PR DESCRIPTION
### Description of your changes

Explicitly sets the type for `spec.forProvider.document` in `iam.RolePolicy`.

Fixes https://github.com/crossplane-contrib/provider-aws/issues/1990

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
