### PR TITLE
fix(database): skip isUpToDate on deletion

### DIFF
--- a/pkg/controller/database/rdsinstance/rdsinstance.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance.go
@@ -161,11 +161,16 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		cr.Status.SetConditions(xpv1.Unavailable())
 	}
 
+	if meta.WasDeleted(cr) { // There is no need to run isUpToDate if the resource is deleted
+		return managed.ExternalObservation{
+			ResourceExists: true,
+		}, nil
+	}
+
 	var upToDate bool
 	var diff string
 
 	upToDate, diff, e.cache.AddTags, e.cache.RemoveTags, err = rds.IsUpToDate(ctx, e.kube, cr, instance)
-
 	if err != nil {
 		return managed.ExternalObservation{}, errorutils.Wrap(err, errUpToDateFailed)
 	}


### PR DESCRIPTION
### Description of your changes

for `database.rdsinstance`:
- implement the same logic to skip the isUpToDate()-check on deletion as https://github.com/crossplane-contrib/provider-aws/pull/1979 did for the ACK controllers

This fixes e.g. a common case of a missing k8s secret blocking the deletion, if it was deleted from the cluster before the MR.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually
