### PR TITLE
fix: take into consideration the DesiredCount/RunningCount for resource readiness

### DIFF
--- a/pkg/controller/ecs/service/setup.go
+++ b/pkg/controller/ecs/service/setup.go
@@ -82,7 +82,11 @@ func postObserve(_ context.Context, cr *svcapitypes.Service, resp *svcsdk.Descri
 
 	switch aws.StringValue(resp.Services[0].Status) {
 	case "ACTIVE":
-		cr.SetConditions(xpv1.Available())
+		if resp.Services[0].DesiredCount != resp.Services[0].RunningCount {
+			cr.SetConditions(xpv1.Creating())
+		} else {
+			cr.SetConditions(xpv1.Available())
+		}
 	case "DRAINING":
 		cr.SetConditions(xpv1.Deleting())
 	case "INACTIVE":


### PR DESCRIPTION
Currently, ECS Service resource is only taken into consideration the `.Status` field to decide on the readiness of the Crossplane resource.

I think this is an overlook, and Crossplane should also take into consideration the `DesiredCount/RunningCount`, since it is part of the input Spec. Returning _ready_ based only on the `.Status` might result in returning to the client a _ready_ state when in fact, no tasks are running yet.

Before wrapping up the PR with tests, I would like to get some feedback from you to undertstand if you agree with this change or not. 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

Thanks.
