### PR TITLE
ec2: Create security group with tags in the spec

### DIFF
--- a/pkg/controller/ec2/securitygroup/controller.go
+++ b/pkg/controller/ec2/securitygroup/controller.go
@@ -189,6 +189,12 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 		GroupName:   aws.String(cr.Spec.ForProvider.GroupName),
 		VpcId:       cr.Spec.ForProvider.VPCID,
 		Description: aws.String(cr.Spec.ForProvider.Description),
+		TagSpecifications: []awsec2types.TagSpecification{
+			{
+				ResourceType: awsec2types.ResourceTypeSecurityGroup,
+				Tags:         ec2.GenerateEC2TagsV1Beta1(cr.Spec.ForProvider.Tags),
+			},
+		},
 	})
 	if err != nil {
 		return managed.ExternalCreation{}, errorutils.Wrap(err, errCreate)


### PR DESCRIPTION
### Description of your changes

Resource tags are used to ensure that only IAM roles with the right access can modify the resources. This ensures that the security groups will have the right tags from creation time. Without this change, IAM policy based on tags may fail to run subsequent steps of security group creation.

This change makes security groups created with the tags rather than waiting for the first observation / update to add tags.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested on our own internal production fork and staging environments.

[contribution process]: https://git.io/fj2m9
