### PR TITLE
ec2: include attributes in instance observation, fix reconciling tags

### DIFF
--- a/apis/ec2/manualv1alpha1/instances_types.go
+++ b/apis/ec2/manualv1alpha1/instances_types.go
@@ -312,6 +312,8 @@ type InstanceObservation struct {
 	// +optional
 	CPUOptons *CPUOptionsRequest `json:"cpuOptions,omitempty"`
 	// +optional
+	DisableAPITermination *bool `json:"disableAPITermination,omitempty"`
+	// +optional
 	EBSOptimized *bool `json:"ebsOptimized,omitempty"`
 	// +optional
 	ElasticGPUAssociations []ElasticGPUAssociation `json:"elasticGpuAssociation,omitempty"`
@@ -329,6 +331,8 @@ type InstanceObservation struct {
 	ImageID *string `json:"imageId,omitempty"`
 	// +optional
 	InstanceID *string `json:"instanceId,omitempty"`
+	// +optional
+	InstanceInitiatedShutdownBehavior *string `json:"instanceInitiatedShutdownBehavior,omitempty"`
 	// +optional
 	InstanceLifecycle string `json:"instanceLifecyle"`
 	// Supported instance family when set instanceInterruptionBehavior to hibernate
@@ -382,8 +386,10 @@ type InstanceObservation struct {
 	// +optional
 	SubnetID *string `json:"subnetId,omitempty"`
 	// +optional
-	Tags               []Tag  `json:"tags,omitempty"`
-	VirtualizationType string `json:"virualizationType"`
+	Tags []Tag `json:"tags,omitempty"`
+	// +optional
+	UserData           *string `json:"userData,omitempty"`
+	VirtualizationType string  `json:"virualizationType"`
 	// +optional
 	VPCID *string `json:"vpcId,omitempty"`
 }

--- a/apis/ec2/manualv1alpha1/zz_generated.deepcopy.go
+++ b/apis/ec2/manualv1alpha1/zz_generated.deepcopy.go
@@ -884,6 +884,11 @@ func (in *InstanceObservation) DeepCopyInto(out *InstanceObservation) {
 		*out = new(CPUOptionsRequest)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DisableAPITermination != nil {
+		in, out := &in.DisableAPITermination, &out.DisableAPITermination
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EBSOptimized != nil {
 		in, out := &in.EBSOptimized, &out.EBSOptimized
 		*out = new(bool)
@@ -925,6 +930,11 @@ func (in *InstanceObservation) DeepCopyInto(out *InstanceObservation) {
 	}
 	if in.InstanceID != nil {
 		in, out := &in.InstanceID, &out.InstanceID
+		*out = new(string)
+		**out = **in
+	}
+	if in.InstanceInitiatedShutdownBehavior != nil {
+		in, out := &in.InstanceInitiatedShutdownBehavior, &out.InstanceInitiatedShutdownBehavior
 		*out = new(string)
 		**out = **in
 	}
@@ -1047,6 +1057,11 @@ func (in *InstanceObservation) DeepCopyInto(out *InstanceObservation) {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]Tag, len(*in))
 		copy(*out, *in)
+	}
+	if in.UserData != nil {
+		in, out := &in.UserData, &out.UserData
+		*out = new(string)
+		**out = **in
 	}
 	if in.VPCID != nil {
 		in, out := &in.VPCID, &out.VPCID

--- a/package/crds/ec2.aws.crossplane.io_instances.yaml
+++ b/package/crds/ec2.aws.crossplane.io_instances.yaml
@@ -1399,6 +1399,8 @@ spec:
                     - coreCount
                     - threadsPerCore
                     type: object
+                  disableAPITermination:
+                    type: boolean
                   ebs:
                     type: string
                   ebsOptimized:
@@ -1490,6 +1492,8 @@ spec:
                   imageId:
                     type: string
                   instanceId:
+                    type: string
+                  instanceInitiatedShutdownBehavior:
                     type: string
                   instanceLifecyle:
                     type: string
@@ -1886,6 +1890,8 @@ spec:
                       - value
                       type: object
                     type: array
+                  userData:
+                    type: string
                   virualizationType:
                     type: string
                   vpcId:

--- a/pkg/clients/ec2/instance_test.go
+++ b/pkg/clients/ec2/instance_test.go
@@ -32,58 +32,59 @@ const (
 	managedKind           = "instance.ec2.aws.crossplane.io"
 	managedProviderConfig = "example"
 
-	arch                  = "x86_64"
-	assocID               = "assocId"
-	assocState            = "assocState"
-	attachmentID          = "attachId"
-	blockDeviceName       = "/dev/xvda"
-	capacityReservationID = "capResId"
-	clientToken           = "clientToken"
-	cpuCredits            = "cpuCredits"
-	description           = "desc"
-	elasticInferAccARN    = "inferArn"
-	elasticInferAccID     = "inferId"
-	elasticInferAccState  = "inferState"
-	gpuID                 = "gpuId"
-	gpuType               = "gpuType"
-	groupID               = "groupId"
-	groupName             = "groupName"
-	hostID                = "hostId"
-	hostGroupARN          = "hostGroupArn"
-	iamARN                = "iamArn"
-	iamID                 = "iamId"
-	imageID               = "imageId"
-	interfaceType         = "intType"
-	ipOwnerID             = "ipOwnerId"
-	ipv6Address           = "ipv6Address"
-	ipv6Prefix            = "ipv6Prefix"
-	kernelID              = "kernelId"
-	keyName               = "keyName"
-	launchTemplateID      = "launchTemplateId"
-	launchTemplateName    = "launchTemplateName"
-	licenseConfig         = "licenseConfig"
-	macAddress            = "macAddress"
-	outpostARN            = "outpostArn"
-	placementAff          = "affinity"
-	privateDNSName        = "privDnsName"
-	privateIPAddress      = "privIpAddress"
-	productCodeID         = "productCodeId"
-	publicDNSName         = "publicDnsName"
-	publicIPAddress       = "publicIp"
-	ramDiskID             = "ramDiskId"
-	rootDeviceName        = "rootDeviceName"
-	snapshotID            = "snapshotId"
-	spotInstanceReqID     = "spotInstacneId"
-	spotMarketType        = "spotMarketType"
-	spreadDomain          = "spreadDomain"
-	sriovNetSupport       = "sriovNetSupport"
-	stateReason           = "stateReason"
-	tagResourceType       = "instance"
-	tagsKey               = "key"
-	tagsVal               = "value"
-	userData              = "userData"
-	volumeID              = "volId"
-	volumeType            = "gp2"
+	arch                              = "x86_64"
+	assocID                           = "assocId"
+	assocState                        = "assocState"
+	attachmentID                      = "attachId"
+	blockDeviceName                   = "/dev/xvda"
+	capacityReservationID             = "capResId"
+	clientToken                       = "clientToken"
+	cpuCredits                        = "cpuCredits"
+	description                       = "desc"
+	elasticInferAccARN                = "inferArn"
+	elasticInferAccID                 = "inferId"
+	elasticInferAccState              = "inferState"
+	gpuID                             = "gpuId"
+	gpuType                           = "gpuType"
+	groupID                           = "groupId"
+	groupName                         = "groupName"
+	hostID                            = "hostId"
+	hostGroupARN                      = "hostGroupArn"
+	iamARN                            = "iamArn"
+	iamID                             = "iamId"
+	imageID                           = "imageId"
+	instanceInitiatedShutdownBehavior = "stop"
+	interfaceType                     = "intType"
+	ipOwnerID                         = "ipOwnerId"
+	ipv6Address                       = "ipv6Address"
+	ipv6Prefix                        = "ipv6Prefix"
+	kernelID                          = "kernelId"
+	keyName                           = "keyName"
+	launchTemplateID                  = "launchTemplateId"
+	launchTemplateName                = "launchTemplateName"
+	licenseConfig                     = "licenseConfig"
+	macAddress                        = "macAddress"
+	outpostARN                        = "outpostArn"
+	placementAff                      = "affinity"
+	privateDNSName                    = "privDnsName"
+	privateIPAddress                  = "privIpAddress"
+	productCodeID                     = "productCodeId"
+	publicDNSName                     = "publicDnsName"
+	publicIPAddress                   = "publicIp"
+	ramDiskID                         = "ramDiskId"
+	rootDeviceName                    = "rootDeviceName"
+	snapshotID                        = "snapshotId"
+	spotInstanceReqID                 = "spotInstacneId"
+	spotMarketType                    = "spotMarketType"
+	spreadDomain                      = "spreadDomain"
+	sriovNetSupport                   = "sriovNetSupport"
+	stateReason                       = "stateReason"
+	tagResourceType                   = "instance"
+	tagsKey                           = "key"
+	tagsVal                           = "value"
+	userData                          = "userData"
+	volumeID                          = "volId"
+	volumeType                        = "gp2"
 )
 
 func TestGenerateInstanceConditions(t *testing.T) {
@@ -195,8 +196,9 @@ func TestGenerateDescribeInstancesByExternalTags(t *testing.T) {
 
 func TestGenerateInstanceObservation(t *testing.T) {
 	cases := map[string]struct {
-		in  types.Instance
-		out manualv1alpha1.InstanceObservation
+		in         types.Instance
+		attributes ec2.DescribeInstanceAttributeOutput
+		out        manualv1alpha1.InstanceObservation
 	}{
 		"AllFilled": {
 			in: types.Instance{
@@ -368,6 +370,13 @@ func TestGenerateInstanceObservation(t *testing.T) {
 				VirtualizationType: types.VirtualizationTypeHvm,
 				VpcId:              aws.String(vpcID),
 			},
+			attributes: ec2.DescribeInstanceAttributeOutput{
+				DisableApiTermination:             &types.AttributeBooleanValue{Value: aws.Bool(true)},
+				InstanceInitiatedShutdownBehavior: &types.AttributeValue{Value: aws.String(instanceInitiatedShutdownBehavior)},
+				KernelId:                          &types.AttributeValue{Value: aws.String(kernelID)},
+				RamdiskId:                         &types.AttributeValue{Value: aws.String(ramDiskID)},
+				UserData:                          &types.AttributeValue{Value: aws.String(userData)},
+			},
 			out: manualv1alpha1.InstanceObservation{
 				AmiLaunchIndex: aws.Int32(0),
 				Architecture:   arch,
@@ -394,8 +403,9 @@ func TestGenerateInstanceObservation(t *testing.T) {
 					CoreCount:      aws.Int32(1),
 					ThreadsPerCore: aws.Int32(1),
 				},
-				EBSOptimized: aws.Bool(false),
-				EnaSupport:   aws.Bool(false),
+				DisableAPITermination: aws.Bool(true),
+				EBSOptimized:          aws.Bool(false),
+				EnaSupport:            aws.Bool(false),
 				ElasticGPUAssociations: []manualv1alpha1.ElasticGPUAssociation{
 					{
 						ElasticGPUAssociationID:    aws.String(assocID),
@@ -420,11 +430,12 @@ func TestGenerateInstanceObservation(t *testing.T) {
 					ARN: aws.String(iamARN),
 					ID:  aws.String(iamID),
 				},
-				ImageID:           aws.String(imageID),
-				InstanceID:        aws.String(instanceID),
-				InstanceLifecycle: string(types.InstanceLifecycleTypeScheduled),
-				InstanceType:      string(types.InstanceTypeM1Small),
-				KernelID:          aws.String(kernelID),
+				ImageID:                           aws.String(imageID),
+				InstanceID:                        aws.String(instanceID),
+				InstanceInitiatedShutdownBehavior: aws.String(instanceInitiatedShutdownBehavior),
+				InstanceLifecycle:                 string(types.InstanceLifecycleTypeScheduled),
+				InstanceType:                      string(types.InstanceTypeM1Small),
+				KernelID:                          aws.String(kernelID),
 				Licenses: []manualv1alpha1.LicenseConfigurationRequest{
 					{
 						LicenseConfigurationARN: aws.String(licenseConfig),
@@ -530,6 +541,7 @@ func TestGenerateInstanceObservation(t *testing.T) {
 						Value: tagsVal,
 					},
 				},
+				UserData:           aws.String(userData),
 				VirtualizationType: string(types.VirtualizationTypeHvm),
 				VPCID:              aws.String(vpcID),
 			},
@@ -538,7 +550,7 @@ func TestGenerateInstanceObservation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			r := GenerateInstanceObservation(tc.in)
+			r := GenerateInstanceObservation(tc.in, &tc.attributes)
 			if diff := cmp.Diff(tc.out, r); diff != "" {
 				t.Errorf("GenerateInstanceObservation(...): -want, +got:\n%s", diff)
 			}

--- a/pkg/controller/ec2/instance/controller.go
+++ b/pkg/controller/ec2/instance/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -211,7 +212,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		}
 	}
 
-	observation := ec2.GenerateInstanceObservation(observed)
+	observation := ec2.GenerateInstanceObservation(observed, &o)
 	condition := ec2.GenerateInstanceCondition(observation)
 
 	switch condition {
@@ -273,7 +274,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		return managed.ExternalUpdate{}, errors.New(errUnexpectedObject)
 	}
 
-	if cr.Spec.ForProvider.DisableAPITermination != nil {
+	if !ptr.Equal(cr.Spec.ForProvider.DisableAPITermination, cr.Status.AtProvider.DisableAPITermination) {
 		modifyInput := &awsec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(meta.GetExternalName(cr)),
 			DisableApiTermination: &types.AttributeBooleanValue{
@@ -287,7 +288,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	if cr.Spec.ForProvider.InstanceInitiatedShutdownBehavior != "" {
+	if cr.Spec.ForProvider.InstanceInitiatedShutdownBehavior != pointer.StringValue(cr.Status.AtProvider.InstanceInitiatedShutdownBehavior) {
 		modifyInput := &awsec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(meta.GetExternalName(cr)),
 			InstanceInitiatedShutdownBehavior: &types.AttributeValue{
@@ -301,7 +302,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	if cr.Spec.ForProvider.KernelID != nil {
+	if !ptr.Equal(cr.Spec.ForProvider.KernelID, cr.Status.AtProvider.KernelID) {
 		modifyInput := &awsec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(meta.GetExternalName(cr)),
 			Kernel: &types.AttributeValue{
@@ -315,7 +316,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	if cr.Spec.ForProvider.RAMDiskID != nil {
+	if !ptr.Equal(cr.Spec.ForProvider.RAMDiskID, cr.Status.AtProvider.RAMDiskID) {
 		modifyInput := &awsec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(meta.GetExternalName(cr)),
 			Ramdisk: &types.AttributeValue{
@@ -329,7 +330,7 @@ func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.Ex
 		}
 	}
 
-	if cr.Spec.ForProvider.UserData != nil {
+	if !ptr.Equal(cr.Spec.ForProvider.UserData, cr.Status.AtProvider.UserData) {
 		modifyInput := &awsec2.ModifyInstanceAttributeInput{
 			InstanceId: aws.String(meta.GetExternalName(cr)),
 			UserData: &types.BlobAttributeValue{


### PR DESCRIPTION
### Description of your changes

This ensures that when tags change, the EC2 instance reconciles the update. Previously the ec2 instance controller supported updating tags via `CreateTags` but did not perform reconciliation when tags changed as it was not included in the check for if the EC2 instance was up to date.

However, the way `Update` is currently implemented had the implicit assumption that the EC2 instance must be stopped for all updates, which is true for all the ModifyInstanceAttribute calls, however, tags can be applied at runtime. This changes the logic of the controller to (1) include the instance attributes in the instance observations, (2) only attempt to modify instance attributes if the observation does not match the spec.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
This code has been tested on and deployed in our own fork used in production.

Unit tests are updated to include instance attributes.

[contribution process]: https://git.io/fj2m9
