### PR TITLE
Reduce ec2 instance controller API calls for an observation

### DIFF
--- a/pkg/clients/ec2/instance.go
+++ b/pkg/clients/ec2/instance.go
@@ -190,8 +190,8 @@ func LateInitializeInstance(in *manualv1alpha1.InstanceParameters, instance *typ
 		in.InstanceInitiatedShutdownBehavior = pointer.LateInitializeValueFromPtr(in.InstanceInitiatedShutdownBehavior, attributes.InstanceInitiatedShutdownBehavior.Value)
 	}
 
-	if attributes.InstanceType != nil {
-		in.InstanceType = pointer.LateInitializeValueFromPtr(in.InstanceType, attributes.InstanceType.Value)
+	if in.InstanceType == "" {
+		in.InstanceType = string(instance.InstanceType)
 	}
 
 	if attributes.UserData != nil {

--- a/pkg/controller/ec2/instance/controller.go
+++ b/pkg/controller/ec2/instance/controller.go
@@ -158,11 +158,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 
 	for _, input := range []types.InstanceAttributeName{
 		types.InstanceAttributeNameDisableApiTermination,
-		types.InstanceAttributeNameEbsOptimized,
 		types.InstanceAttributeNameInstanceInitiatedShutdownBehavior,
-		types.InstanceAttributeNameInstanceType,
-		types.InstanceAttributeNameKernel,
-		types.InstanceAttributeNameRamdisk,
 		types.InstanceAttributeNameUserData,
 	} {
 		r, err := e.client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
@@ -178,24 +174,8 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 			o.DisableApiTermination = r.DisableApiTermination
 		}
 
-		if r.EbsOptimized != nil {
-			o.EbsOptimized = r.EbsOptimized
-		}
-
 		if r.InstanceInitiatedShutdownBehavior != nil {
 			o.InstanceInitiatedShutdownBehavior = r.InstanceInitiatedShutdownBehavior
-		}
-
-		if r.InstanceType != nil {
-			o.InstanceType = r.InstanceType
-		}
-
-		if r.KernelId != nil {
-			o.KernelId = r.KernelId
-		}
-
-		if r.RamdiskId != nil {
-			o.RamdiskId = r.RamdiskId
 		}
 
 		if r.UserData != nil {


### PR DESCRIPTION
### Description of your changes

The EC2 instance controller synchronously makes several DescribeInstanceAttribut calls to the EC2 API and does not use the results. This slows down the reconcile time for a single observation.

This removes the API calls for attributes that are returned in `RunInstances`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in staging/production in our fork. See drastic decrease in reconcile time for the ec2 instance resource.
![image](https://github.com/crossplane-contrib/provider-aws/assets/8886628/8fc285fb-414f-40d1-873a-62dc346f7f3b)

[contribution process]: https://git.io/fj2m9

Related to #2029
