### PR TITLE
Fix changes detection for route53.ResourceRecordSet

### DIFF
--- a/pkg/clients/resourcerecordset/resourcerecordset.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset.go
@@ -175,6 +175,8 @@ func LateInitialize(in *v1alpha1.ResourceRecordSetParameters, rrSet *route53type
 	rrType := string(rrSet.Type)
 	in.Type = pointer.LateInitializeValueFromPtr(in.Type, &rrType)
 	in.TTL = pointer.LateInitialize(in.TTL, rrSet.TTL)
+	in.MultiValueAnswer = pointer.LateInitialize(in.MultiValueAnswer, rrSet.MultiValueAnswer)
+	in.SetIdentifier = pointer.LateInitialize(in.SetIdentifier, rrSet.SetIdentifier)
 	if len(in.ResourceRecords) == 0 && len(rrSet.ResourceRecords) != 0 {
 		in.ResourceRecords = make([]v1alpha1.ResourceRecord, len(rrSet.ResourceRecords))
 		for i, val := range rrSet.ResourceRecords {

--- a/pkg/clients/resourcerecordset/resourcerecordset_test.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset_test.go
@@ -59,19 +59,43 @@ func TestCreatePatch(t *testing.T) {
 				patch: &v1alpha1.ResourceRecordSetParameters{},
 			},
 		},
+		"SameFieldsWithMultiValueAnswer": {
+			args: args{
+				rrSet: route53types.ResourceRecordSet{
+					Name:             &resourceRecordSetName,
+					TTL:              &ttl,
+					MultiValueAnswer: aws.Bool(true),
+					SetIdentifier:    aws.String("id"),
+				},
+				p: v1alpha1.ResourceRecordSetParameters{
+					TTL:              &ttl,
+					MultiValueAnswer: aws.Bool(true),
+					SetIdentifier:    aws.String("id"),
+				},
+			},
+			want: want{
+				patch: &v1alpha1.ResourceRecordSetParameters{},
+			},
+		},
 		"DifferentFields": {
 			args: args{
 				rrSet: route53types.ResourceRecordSet{
-					Name: &resourceRecordSetName,
-					TTL:  &ttl,
+					Name:             &resourceRecordSetName,
+					TTL:              &ttl,
+					MultiValueAnswer: aws.Bool(true),
+					SetIdentifier:    aws.String("id"),
 				},
 				p: v1alpha1.ResourceRecordSetParameters{
-					TTL: &ttl2,
+					TTL:              &ttl2,
+					MultiValueAnswer: aws.Bool(false),
+					SetIdentifier:    aws.String("id2"),
 				},
 			},
 			want: want{
 				patch: &v1alpha1.ResourceRecordSetParameters{
-					TTL: &ttl2,
+					TTL:              &ttl2,
+					MultiValueAnswer: aws.Bool(false),
+					SetIdentifier:    aws.String("id2"),
 				},
 			},
 		},


### PR DESCRIPTION
For records that have MultiValueAnswer and SetIdentifier fields.

### Description of your changes

ResourceRecordSets with MultiValueAnswer and SetIdentifier fields
were always considered out of date and were upserted on every reconciliation.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Additional test case
- Manual integration testing

[contribution process]: https://git.io/fj2m9
