### PR TITLE
Call route53.ListResourceRecordSets with MaxItems = 1

### DIFF
--- a/pkg/clients/resourcerecordset/resourcerecordset.go
+++ b/pkg/clients/resourcerecordset/resourcerecordset.go
@@ -71,9 +71,11 @@ func NewClient(cfg aws.Config) Client {
 // GetResourceRecordSet returns recordSet if present or err
 func GetResourceRecordSet(ctx context.Context, name string, params v1alpha1.ResourceRecordSetParameters, c Client) (*route53types.ResourceRecordSet, error) {
 	res, err := c.ListResourceRecordSets(ctx, &route53.ListResourceRecordSetsInput{
-		HostedZoneId:    params.ZoneID,
-		StartRecordName: &name,
-		StartRecordType: route53types.RRType(params.Type),
+		HostedZoneId:          params.ZoneID,
+		StartRecordName:       &name,
+		StartRecordType:       route53types.RRType(params.Type),
+		StartRecordIdentifier: params.SetIdentifier,
+		MaxItems:              aws.Int32(1),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Otherwise AWS returns ALL routes with name >= requested one.

### Description of your changes

Fetching unnecessary records results in slow & inefficient reconciliations
when account has a lot or route53 resords.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Manual integration testing

[contribution process]: https://git.io/fj2m9
