### PR TITLE
fix(ec2): Call describe-instance API concurrently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	go.uber.org/zap v1.26.0
+	golang.org/x/sync v0.7.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.28.3
 	k8s.io/apiextensions-apiserver v0.28.3
@@ -125,7 +126,6 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/pkg/controller/ec2/instance/controller.go
+++ b/pkg/controller/ec2/instance/controller.go
@@ -18,6 +18,8 @@ package instance
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -129,61 +131,14 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		}, nil
 	}
 
-	response, err := e.client.DescribeInstances(ctx,
-		&awsec2.DescribeInstancesInput{
-			InstanceIds: []string{meta.GetExternalName(cr)},
-		})
-
-	// deleted instances that have not yet been cleaned up from the cluster return a
-	// 200 OK with a nil response.Reservations slice
-	if err == nil && len(response.Reservations) == 0 {
-		return managed.ExternalObservation{}, nil
+	instancePtr, o, err := e.describeInstance(ctx, meta.GetExternalName(cr))
+	if err != nil || instancePtr == nil {
+		return managed.ExternalObservation{}, err
 	}
-
-	if err != nil {
-		return managed.ExternalObservation{},
-			errorutils.Wrap(resource.Ignore(ec2.IsInstanceNotFoundErr, err), errDescribe)
-	}
-
-	// in a successful response, there should be one and only one object
-	if len(response.Reservations[0].Instances) != 1 {
-		return managed.ExternalObservation{}, errors.New(errMultipleItems)
-	}
-
-	observed := response.Reservations[0].Instances[0]
+	observed := *instancePtr
 
 	// update the CRD spec for any new values from provider
 	current := cr.Spec.ForProvider.DeepCopy()
-
-	o := awsec2.DescribeInstanceAttributeOutput{}
-
-	for _, input := range []types.InstanceAttributeName{
-		types.InstanceAttributeNameDisableApiTermination,
-		types.InstanceAttributeNameInstanceInitiatedShutdownBehavior,
-		types.InstanceAttributeNameUserData,
-	} {
-		r, err := e.client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
-			InstanceId: aws.String(meta.GetExternalName(cr)),
-			Attribute:  input,
-		})
-
-		if err != nil {
-			return managed.ExternalObservation{}, errorutils.Wrap(err, errDescribe)
-		}
-
-		if r.DisableApiTermination != nil {
-			o.DisableApiTermination = r.DisableApiTermination
-		}
-
-		if r.InstanceInitiatedShutdownBehavior != nil {
-			o.InstanceInitiatedShutdownBehavior = r.InstanceInitiatedShutdownBehavior
-		}
-
-		if r.UserData != nil {
-			o.UserData = r.UserData
-		}
-	}
-
 	ec2.LateInitializeInstance(&cr.Spec.ForProvider, &observed, &o)
 
 	if !cmp.Equal(current, &cr.Spec.ForProvider) {
@@ -219,6 +174,86 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 		ResourceUpToDate:        ec2.IsInstanceUpToDate(cr.Spec.ForProvider, observed, o),
 		ResourceLateInitialized: !cmp.Equal(current, &cr.Spec.ForProvider),
 	}, nil
+}
+
+func (e *external) describeInstance(ctx context.Context, instanceId string) (
+	*types.Instance,
+	awsec2.DescribeInstanceAttributeOutput,
+	error,
+) {
+	wg := sync.WaitGroup{}
+
+	var describeOutput *awsec2.DescribeInstancesOutput
+	var describeError error
+	wg.Add(1)
+	go func() {
+		describeOutput, describeError = e.client.DescribeInstances(ctx, &awsec2.DescribeInstancesInput{
+			InstanceIds: []string{instanceId},
+		})
+		wg.Done()
+	}()
+
+	attrs := awsec2.DescribeInstanceAttributeOutput{}
+	attrsErr := atomic.Pointer[error]{}
+	descAttr := func(attr types.InstanceAttributeName) (*awsec2.DescribeInstanceAttributeOutput, error) {
+		return e.client.DescribeInstanceAttribute(ctx, &awsec2.DescribeInstanceAttributeInput{
+			InstanceId: &instanceId,
+			Attribute:  attr,
+		})
+	}
+
+	wg.Add(1)
+	go func() {
+		if r, err := descAttr(types.InstanceAttributeNameDisableApiTermination); err != nil {
+			attrsErr.Store(&err)
+		} else {
+			attrs.DisableApiTermination = r.DisableApiTermination
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		if r, err := descAttr(types.InstanceAttributeNameInstanceInitiatedShutdownBehavior); err != nil {
+			attrsErr.Store(&err)
+		} else {
+			attrs.InstanceInitiatedShutdownBehavior = r.InstanceInitiatedShutdownBehavior
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		if r, err := descAttr(types.InstanceAttributeNameUserData); err != nil {
+			attrsErr.Store(&err)
+		} else {
+			attrs.UserData = r.UserData
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	if describeError != nil {
+		return nil, attrs,
+			errorutils.Wrap(resource.Ignore(ec2.IsInstanceNotFoundErr, describeError), errDescribe)
+	}
+
+	// deleted instances that have not yet been cleaned up from the cluster return a
+	// 200 OK with a nil response.Reservations slice
+	if len(describeOutput.Reservations) == 0 {
+		return nil, attrs, nil
+	}
+
+	// in a successful response, there should be one and only one object
+	if len(describeOutput.Reservations[0].Instances) != 1 {
+		return nil, attrs, errors.New(errMultipleItems)
+	}
+
+	if err := attrsErr.Load(); err != nil {
+		return nil, attrs, errorutils.Wrap(*err, errDescribe)
+	}
+	return &describeOutput.Reservations[0].Instances[0], attrs, nil
 }
 
 func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.ExternalCreation, error) {

--- a/pkg/controller/ec2/instance/controller_test.go
+++ b/pkg/controller/ec2/instance/controller_test.go
@@ -166,6 +166,9 @@ func TestObserve(t *testing.T) {
 							}},
 						}, nil
 					},
+					MockDescribeInstanceAttribute: func(ctx context.Context, input *awsec2.DescribeInstanceAttributeInput, opts []func(*awsec2.Options)) (*awsec2.DescribeInstanceAttributeOutput, error) {
+						return &awsec2.DescribeInstanceAttributeOutput{}, nil
+					},
 				},
 				cr: instance(withSpec(manualv1alpha1.InstanceParameters{
 					InstanceType: string(types.InstanceTypeM1Small),
@@ -186,6 +189,9 @@ func TestObserve(t *testing.T) {
 				instance: &fake.MockInstanceClient{
 					MockDescribeInstances: func(ctx context.Context, input *awsec2.DescribeInstancesInput, opts []func(*awsec2.Options)) (*awsec2.DescribeInstancesOutput, error) {
 						return &awsec2.DescribeInstancesOutput{}, errBoom
+					},
+					MockDescribeInstanceAttribute: func(ctx context.Context, input *awsec2.DescribeInstanceAttributeInput, opts []func(*awsec2.Options)) (*awsec2.DescribeInstanceAttributeOutput, error) {
+						return &awsec2.DescribeInstanceAttributeOutput{}, nil
 					},
 				},
 				cr: instance(withSpec(manualv1alpha1.InstanceParameters{


### PR DESCRIPTION
### Description of your changes

Instance observation makes 4 AWS API calls. Running this calls concurrently reduces reconciliation time. Here is 0.99 quantile of reconciliation duration

<img width="752" alt="image" src="https://github.com/crossplane-contrib/provider-aws/assets/119438383/01d34549-d70d-4a1e-bdd3-6fe9e732ee3e">

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

with existing unit tests

[contribution process]: https://git.io/fj2m9
