### PR TITLE
refactor(apis): Remove AWS imports

### DIFF
--- a/apis/acm/v1alpha1/certificate_types.go
+++ b/apis/acm/v1alpha1/certificate_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -56,15 +55,15 @@ type CertificateExternalStatus struct {
 
 	// Flag to check eligibility for renewal status
 	// +kubebuilder:validation:Enum=ELIGIBLE;INELIGIBLE
-	RenewalEligibility types.RenewalEligibility `json:"renewalEligibility,omitempty"`
+	RenewalEligibility string `json:"renewalEligibility,omitempty"`
 
 	// Status of the certificate
 	// +kubebuilder:validation:Enum=PENDING_VALIDATION;ISSUED;INACTIVE;EXPIRED;VALIDATION_TIMED_OUT;REVOKED;FAILED
-	Status types.CertificateStatus `json:"status,omitempty"`
+	Status string `json:"status,omitempty"`
 
 	// Type of the certificate
 	// +kubebuilder:validation:Enum=IMPORTED;AMAZON_ISSUED;PRIVATE
-	Type types.CertificateType `json:"type,omitempty"`
+	Type string `json:"type,omitempty"`
 
 	// Contains the CNAME record that you add to your DNS database for domain
 	// validation. For more information, see Use DNS to Validate Domain Ownership
@@ -127,7 +126,7 @@ type CertificateParameters struct {
 	// Parameter add the certificate to a certificate transparency log.
 	// +optional
 	// +kubebuilder:validation:Enum=ENABLED;DISABLED
-	CertificateTransparencyLoggingPreference *types.CertificateTransparencyLoggingPreference `json:"certificateTransparencyLoggingPreference,omitempty"`
+	CertificateTransparencyLoggingPreference *string `json:"certificateTransparencyLoggingPreference,omitempty"`
 
 	// Subject Alternative Name extension of the ACM certificate.
 	// +optional
@@ -140,7 +139,7 @@ type CertificateParameters struct {
 	// Method to validate certificate.
 	// +optional
 	// +kubebuilder:validation:Enum=DNS;EMAIL
-	ValidationMethod *types.ValidationMethod `json:"validationMethod,omitempty"`
+	ValidationMethod *string `json:"validationMethod,omitempty"`
 
 	// Flag to renew the certificate
 	// +optional

--- a/apis/acm/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/acm/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/aws/aws-sdk-go-v2/service/acm/types"
 	"github.com/crossplane/crossplane-runtime/apis/common/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -136,7 +135,7 @@ func (in *CertificateParameters) DeepCopyInto(out *CertificateParameters) {
 	}
 	if in.CertificateTransparencyLoggingPreference != nil {
 		in, out := &in.CertificateTransparencyLoggingPreference, &out.CertificateTransparencyLoggingPreference
-		*out = new(types.CertificateTransparencyLoggingPreference)
+		*out = new(string)
 		**out = **in
 	}
 	if in.SubjectAlternativeNames != nil {
@@ -157,7 +156,7 @@ func (in *CertificateParameters) DeepCopyInto(out *CertificateParameters) {
 	}
 	if in.ValidationMethod != nil {
 		in, out := &in.ValidationMethod, &out.ValidationMethod
-		*out = new(types.ValidationMethod)
+		*out = new(string)
 		**out = **in
 	}
 	if in.RenewCertificate != nil {

--- a/apis/acmpca/v1alpha1/certificateauthority_types.go
+++ b/apis/acmpca/v1alpha1/certificateauthority_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,7 +28,7 @@ type CertificateAuthorityParameters struct {
 
 	// Type of the certificate authority
 	// +kubebuilder:validation:Enum=ROOT;SUBORDINATE
-	Type types.CertificateAuthorityType `json:"type"`
+	Type string `json:"type"`
 
 	// RevocationConfiguration to associate with the certificateAuthority.
 	// +optional
@@ -87,11 +86,11 @@ type CertificateAuthorityConfiguration struct {
 
 	// Type of the public key algorithm
 	// +kubebuilder:validation:Enum=RSA_2048;EC_secp384r1;EC_prime256v1;RSA_4096
-	KeyAlgorithm types.KeyAlgorithm `json:"keyAlgorithm"`
+	KeyAlgorithm string `json:"keyAlgorithm"`
 
 	// Algorithm that private CA uses to sign certificate requests
 	// +kubebuilder:validation:Enum=SHA512WITHECDSA;SHA256WITHECDSA;SHA384WITHECDSA;SHA512WITHRSA;SHA256WITHRSA;SHA384WITHRSA
-	SigningAlgorithm types.SigningAlgorithm `json:"signingAlgorithm"`
+	SigningAlgorithm string `json:"signingAlgorithm"`
 
 	// Subject is information of Certificate Authority
 	Subject Subject `json:"subject"`

--- a/apis/acmpca/v1beta1/certificateauthority_types.go
+++ b/apis/acmpca/v1beta1/certificateauthority_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,7 +28,7 @@ type CertificateAuthorityParameters struct {
 
 	// Type of the certificate authority
 	// +kubebuilder:validation:Enum=ROOT;SUBORDINATE
-	Type types.CertificateAuthorityType `json:"type"`
+	Type string `json:"type"`
 
 	// RevocationConfiguration to associate with the certificateAuthority.
 	// +optional
@@ -87,11 +86,11 @@ type CertificateAuthorityConfiguration struct {
 
 	// Type of the public key algorithm
 	// +kubebuilder:validation:Enum=RSA_2048;EC_secp384r1;EC_prime256v1;RSA_4096
-	KeyAlgorithm types.KeyAlgorithm `json:"keyAlgorithm"`
+	KeyAlgorithm string `json:"keyAlgorithm"`
 
 	// Algorithm that private CA uses to sign certificate requests
 	// +kubebuilder:validation:Enum=SHA512WITHECDSA;SHA256WITHECDSA;SHA384WITHECDSA;SHA512WITHRSA;SHA256WITHRSA;SHA384WITHRSA
-	SigningAlgorithm types.SigningAlgorithm `json:"signingAlgorithm"`
+	SigningAlgorithm string `json:"signingAlgorithm"`
 
 	// Subject is information of Certificate Authority
 	Subject Subject `json:"subject"`

--- a/apis/apigatewayv2/v1alpha1/referencers.go
+++ b/apis/apigatewayv2/v1alpha1/referencers.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 	resource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ec2 "github.com/crossplane-contrib/provider-aws/apis/ec2/v1beta1"
@@ -304,7 +304,7 @@ func IntegrationID() reference.ExtractValueFn {
 			return ""
 		}
 
-		id := aws.ToString(r.Status.AtProvider.IntegrationID)
+		id := ptr.Deref(r.Status.AtProvider.IntegrationID, "")
 
 		// The Integration ID target requires the integrations/ prefix
 		if id == "" || strings.HasPrefix(id, "integrations/") {

--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,7 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
-golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/clients/acmpca/certificateauthority.go
+++ b/pkg/clients/acmpca/certificateauthority.go
@@ -48,7 +48,7 @@ func NewClient(conf *aws.Config) Client {
 // GenerateCreateCertificateAuthorityInput from certificateAuthorityParameters
 func GenerateCreateCertificateAuthorityInput(p *v1beta1.CertificateAuthorityParameters) *acmpca.CreateCertificateAuthorityInput {
 	m := &acmpca.CreateCertificateAuthorityInput{
-		CertificateAuthorityType:          p.Type,
+		CertificateAuthorityType:          types.CertificateAuthorityType(p.Type),
 		CertificateAuthorityConfiguration: GenerateCertificateAuthorityConfiguration(p.CertificateAuthorityConfiguration),
 		RevocationConfiguration:           GenerateRevocationConfiguration(p.RevocationConfiguration),
 	}
@@ -84,8 +84,8 @@ func GenerateCertificateAuthorityConfiguration(p v1beta1.CertificateAuthorityCon
 			Surname:                    p.Subject.Surname,
 			Title:                      p.Subject.Title,
 		},
-		SigningAlgorithm: p.SigningAlgorithm,
-		KeyAlgorithm:     p.KeyAlgorithm,
+		SigningAlgorithm: types.SigningAlgorithm(p.SigningAlgorithm),
+		KeyAlgorithm:     types.KeyAlgorithm(p.KeyAlgorithm),
 	}
 	return m
 
@@ -116,8 +116,8 @@ func LateInitializeCertificateAuthority(in *v1beta1.CertificateAuthorityParamete
 		return
 	}
 
-	if string(in.Type) == "" && string(certificateAuthority.Type) != "" {
-		in.Type = certificateAuthority.Type
+	if in.Type == "" && string(certificateAuthority.Type) != "" {
+		in.Type = string(certificateAuthority.Type)
 	}
 
 	// NOTE(muvaf): Only ACTIVE and DISABLED statuses can be assigned by the user

--- a/pkg/clients/acmpca/certificateauthority_test.go
+++ b/pkg/clients/acmpca/certificateauthority_test.go
@@ -56,10 +56,10 @@ func TestGenerateCreateCertificateAuthorityInput(t *testing.T) {
 	}{
 		"Filled_Input": {
 			in: &v1beta1.CertificateAuthorityParameters{
-				Type: types.CertificateAuthorityTypeRoot,
+				Type: string(types.CertificateAuthorityTypeRoot),
 				CertificateAuthorityConfiguration: v1beta1.CertificateAuthorityConfiguration{
-					SigningAlgorithm: types.SigningAlgorithmSha256withecdsa,
-					KeyAlgorithm:     types.KeyAlgorithmRsa2048,
+					SigningAlgorithm: string(types.SigningAlgorithmSha256withecdsa),
+					KeyAlgorithm:     string(types.KeyAlgorithmRsa2048),
 					Subject: v1beta1.Subject{
 						CommonName:                 commonName,
 						Country:                    country,
@@ -129,8 +129,8 @@ func TestGenerateCertificateAuthorityConfiguration(t *testing.T) {
 	}{
 		"Filled_Input": {
 			in: v1beta1.CertificateAuthorityConfiguration{
-				SigningAlgorithm: types.SigningAlgorithmSha256withecdsa,
-				KeyAlgorithm:     types.KeyAlgorithmRsa2048,
+				SigningAlgorithm: string(types.SigningAlgorithmSha256withecdsa),
+				KeyAlgorithm:     string(types.KeyAlgorithmRsa2048),
 				Subject: v1beta1.Subject{
 					CommonName:                 commonName,
 					Country:                    country,
@@ -227,7 +227,7 @@ func TestLateInitializeCertificateAuthority(t *testing.T) {
 		"AllFilledNoDiff": {
 			args: args{
 				spec: &v1beta1.CertificateAuthorityParameters{
-					Type: types.CertificateAuthorityTypeRoot,
+					Type: string(types.CertificateAuthorityTypeRoot),
 				},
 				in: &types.CertificateAuthority{
 					Type:   types.CertificateAuthorityTypeRoot,
@@ -245,7 +245,7 @@ func TestLateInitializeCertificateAuthority(t *testing.T) {
 				},
 			},
 			want: &v1beta1.CertificateAuthorityParameters{
-				Type:   types.CertificateAuthorityTypeRoot,
+				Type:   string(types.CertificateAuthorityTypeRoot),
 				Status: &status,
 				CertificateAuthorityConfiguration: v1beta1.CertificateAuthorityConfiguration{
 					Subject: v1beta1.Subject{

--- a/pkg/controller/acmpca/certificateauthority/controller_test.go
+++ b/pkg/controller/acmpca/certificateauthority/controller_test.go
@@ -79,7 +79,7 @@ func withCertificateAuthorityArn() certificateAuthorityModifier {
 
 func withCertificateAuthorityType() certificateAuthorityModifier {
 	return func(r *v1beta1.CertificateAuthority) {
-		r.Spec.ForProvider.Type = awsacmpcatypes.CertificateAuthorityTypeRoot
+		r.Spec.ForProvider.Type = string(awsacmpcatypes.CertificateAuthorityTypeRoot)
 		r.Status.AtProvider.CertificateAuthorityARN = certificateAuthorityArn
 		meta.SetExternalName(r, certificateAuthorityArn)
 	}


### PR DESCRIPTION
### Description of your changes

This removes the import statements in `apis` for `github.com/aws/*` and replaces all imported types with plain strings.

It allows importing `apis` in other Go modules without the necessity to import AWS SDK dependencies.

It makes no breaking changes since the imported types where only just string type aliases.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

n.a.

[contribution process]: https://git.io/fj2m9
