### PR TITLE
fix(S3): Add check for S3 tagging api error code when empty TagSet

### DIFF
--- a/pkg/controller/s3/bucket/taggingConfig.go
+++ b/pkg/controller/s3/bucket/taggingConfig.go
@@ -62,6 +62,9 @@ func (in *TaggingConfigurationClient) CacheBucketTaggingOutput(ctx context.Conte
 	if in.cache.getBucketTaggingOutput == nil {
 		external, err := in.client.GetBucketTagging(ctx, &awss3.GetBucketTaggingInput{Bucket: bucketName})
 		if err != nil {
+			if s3.TaggingNotFound(err) {
+				return &awss3.GetBucketTaggingOutput{TagSet: nil}, nil
+			}
 			return external, err
 		}
 		in.cache.getBucketTaggingOutput = external

--- a/pkg/controller/s3/bucket/taggingConfig_test.go
+++ b/pkg/controller/s3/bucket/taggingConfig_test.go
@@ -298,6 +298,22 @@ func TestTaggingCreateOrUpdate(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessfulCreateNoExistingTags": {
+			args: args{
+				b: s3testing.Bucket(s3testing.WithTaggingConfig(generateTaggingConfig())),
+				cl: NewTaggingConfigurationClient(fake.MockBucketClient{
+					MockPutBucketTagging: func(ctx context.Context, input *s3.PutBucketTaggingInput, opts []func(*s3.Options)) (*s3.PutBucketTaggingOutput, error) {
+						return &s3.PutBucketTaggingOutput{}, nil
+					},
+					MockGetBucketTagging: func(ctx context.Context, input *s3.GetBucketTaggingInput, opts []func(*s3.Options)) (*s3.GetBucketTaggingOutput, error) {
+						return nil, &smithy.GenericAPIError{Code: clientss3.TaggingNotFoundErrCode}
+					},
+				}),
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Adds check to catch when the AWS S3 API throws a `NoSuchTagSet` error code if a bucket has no tag set associated with the bucket, and return a nil TagSet.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2052

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

minor change, passed all existing and new tests. 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
