### PR TITLE
Use new policy checker for iam.roles

### DIFF
--- a/pkg/controller/iam/role/controller_test.go
+++ b/pkg/controller/iam/role/controller_test.go
@@ -18,6 +18,7 @@ package role
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -36,7 +37,6 @@ import (
 	"github.com/crossplane-contrib/provider-aws/pkg/clients/iam/fake"
 	errorutils "github.com/crossplane-contrib/provider-aws/pkg/utils/errors"
 	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
-	legacypolicy "github.com/crossplane-contrib/provider-aws/pkg/utils/policy/old"
 )
 
 var (
@@ -82,11 +82,7 @@ func withArn(s string) roleModifier {
 
 func withPolicy() roleModifier {
 	return func(r *v1beta1.Role) {
-		p, err := legacypolicy.CompactAndEscapeJSON(policy)
-		if err != nil {
-			return
-		}
-		r.Spec.ForProvider.AssumeRolePolicyDocument = p
+		r.Spec.ForProvider.AssumeRolePolicyDocument = url.QueryEscape(policy)
 	}
 }
 

--- a/pkg/utils/policy/compare.go
+++ b/pkg/utils/policy/compare.go
@@ -10,3 +10,17 @@ func ArePoliciesEqal(a, b *Policy) (equal bool, diff string) {
 	diff = cmp.Diff(a, b)
 	return diff == "", diff
 }
+
+// ArePolicyDocumentsEqual determines if the two policy documents can be considered equal.
+func ArePolicyDocumentsEqual(a, b string) bool {
+	policyA, err := ParsePolicyString(a)
+	if err != nil {
+		return a == b
+	}
+	policyB, err := ParsePolicyString(b)
+	if err != nil {
+		return false
+	}
+	eq, _ := ArePoliciesEqal(&policyA, &policyB)
+	return eq
+}


### PR DESCRIPTION
To not trigger update event and update role in AWS when AWS changes formatting in policy document.

### Description of your changes

Policy checker in `pkg/utils/policy/old` considers that policies are different if one of them has `"Action": "x"` and another one has `"Action": ["x"]`. This PR fixes it.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- existing and new test cases

[contribution process]: https://git.io/fj2m9
