### PR TITLE
Ignore principals order when comparing policies

### DIFF
--- a/pkg/utils/policy/compare_test.go
+++ b/pkg/utils/policy/compare_test.go
@@ -19,6 +19,15 @@ var (
 
 	//go:embed testdata/Issue1892_b_min.json
 	policyIssue1892bMin string
+
+	//go:embed testdata/PrincipalsOrder_a.json
+	policyPrincipalsOrderA string
+
+	//go:embed testdata/PrincipalsOrder_b.json
+	policyPrincipalsOrderB string
+
+	//go:embed testdata/PrincipalsOrder_c.json
+	policyPrincipalsOrderC string
 )
 
 func TestCompareRawPolicies(t *testing.T) {
@@ -49,6 +58,24 @@ func TestCompareRawPolicies(t *testing.T) {
 			},
 			want: want{
 				equals: true,
+			},
+		},
+		"PrincipalsOrder Equal": {
+			args: args{
+				policyA: policyPrincipalsOrderA,
+				policyB: policyPrincipalsOrderB,
+			},
+			want: want{
+				equals: true,
+			},
+		},
+		"PrincipalsOrder NotEqual": {
+			args: args{
+				policyA: policyPrincipalsOrderA,
+				policyB: policyPrincipalsOrderC,
+			},
+			want: want{
+				equals: false,
 			},
 		},
 	}

--- a/pkg/utils/policy/convert.go
+++ b/pkg/utils/policy/convert.go
@@ -82,16 +82,16 @@ func convertResourcePolicyPrincipal(p *common.ResourcePrincipal) *Principal {
 	res := Principal{
 		AllowAnon: p.AllowAnon,
 		Federated: p.Federated,
-		Service:   p.Service,
+		Service:   NewStringOrSet(p.Service...),
 	}
 	for _, pr := range p.AWSPrincipals {
 		switch {
 		case pr.AWSAccountID != nil:
-			res.AWSPrincipals = append(res.AWSPrincipals, *pr.AWSAccountID)
+			res.AWSPrincipals = res.AWSPrincipals.Add(*pr.AWSAccountID)
 		case pr.IAMRoleARN != nil:
-			res.AWSPrincipals = append(res.AWSPrincipals, *pr.IAMRoleARN)
+			res.AWSPrincipals = res.AWSPrincipals.Add(*pr.IAMRoleARN)
 		case pr.UserARN != nil:
-			res.AWSPrincipals = append(res.AWSPrincipals, *pr.UserARN)
+			res.AWSPrincipals = res.AWSPrincipals.Add(*pr.UserARN)
 		}
 	}
 	return &res

--- a/pkg/utils/policy/parse_test.go
+++ b/pkg/utils/policy/parse_test.go
@@ -39,13 +39,13 @@ func TestParsePolicy(t *testing.T) {
 						{
 							SID: ptr.To("AllowPutObjectS3ServerAccessLogsPolicy"),
 							Principal: &Principal{
-								Service: StringOrArray{
+								Service: NewStringOrSet(
 									"logging.s3.amazonaws.com",
-								},
+								),
 								Federated: ptr.To("cognito-identity.amazonaws.com"),
-								AWSPrincipals: StringOrArray{
+								AWSPrincipals: NewStringOrSet(
 									"123456789012",
-								},
+								),
 							},
 							Effect: "Allow",
 							Action: StringOrArray{
@@ -78,15 +78,15 @@ func TestParsePolicy(t *testing.T) {
 						{
 							SID: ptr.To("AllowPutObjectS3ServerAccessLogsPolicy"),
 							Principal: &Principal{
-								Service: StringOrArray{
+								Service: NewStringOrSet(
 									"logging.s3.amazonaws.com",
 									"s3.amazonaws.com",
-								},
+								),
 								Federated: ptr.To("cognito-identity.amazonaws.com"),
-								AWSPrincipals: StringOrArray{
+								AWSPrincipals: NewStringOrSet(
 									"123456789012",
 									"452356421222",
-								},
+								),
 							},
 							Effect: "Allow",
 							Action: StringOrArray{

--- a/pkg/utils/policy/testdata/PrincipalsOrder_a.json
+++ b/pkg/utils/policy/testdata/PrincipalsOrder_a.json
@@ -1,0 +1,27 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": [
+        "eks.amazonaws.com",
+        "sqs.amazonaws.com"
+      ],
+      "AWS": [
+        "arn:aws:iam::123456789012:bbb",
+        "arn:aws:iam::123456789012:aaa"
+      ]
+    },
+    "NotPrincipal": {
+      "Service": [
+        "s3.amazonaws.com",
+        "ec2.amazonaws.com"
+      ],
+      "AWS": [
+        "arn:aws:iam::123456789012:ddd",
+        "arn:aws:iam::123456789012:ccc"
+      ]
+    },
+    "Action": ["sts:AssumeRole"]
+  }]
+}

--- a/pkg/utils/policy/testdata/PrincipalsOrder_b.json
+++ b/pkg/utils/policy/testdata/PrincipalsOrder_b.json
@@ -1,0 +1,27 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": [
+        "sqs.amazonaws.com",
+        "eks.amazonaws.com"
+      ],
+      "AWS": [
+        "arn:aws:iam::123456789012:aaa",
+        "arn:aws:iam::123456789012:bbb"
+      ]
+    },
+    "NotPrincipal": {
+      "Service": [
+        "ec2.amazonaws.com",
+        "s3.amazonaws.com"
+      ],
+      "AWS": [
+        "arn:aws:iam::123456789012:ccc",
+        "arn:aws:iam::123456789012:ddd"
+      ]
+    },
+    "Action": ["sts:AssumeRole"]
+  }]
+}

--- a/pkg/utils/policy/testdata/PrincipalsOrder_c.json
+++ b/pkg/utils/policy/testdata/PrincipalsOrder_c.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Service": [
+        "sqs.amazonaws.com",
+        "eks.amazonaws.com"
+      ],
+      "AWS": [
+        "arn:aws:iam::123456789012:aaa",
+        "arn:aws:iam::123456789012:bbb"
+      ]
+    },
+    "NotPrincipal": {
+      "Service": [
+        "ec2.amazonaws.com",
+        "s3.amazonaws.com"
+      ],
+      "AWS": [
+        "arn:aws:iam::123456789012:ccc",
+        "arn:aws:iam::123456789012:eee",
+        "arn:aws:iam::123456789012:ddd"
+      ]
+    },
+    "Action": ["sts:AssumeRole"]
+  }]
+}

--- a/pkg/utils/policy/types_test.go
+++ b/pkg/utils/policy/types_test.go
@@ -1,0 +1,79 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStringOrSet_Equal(t *testing.T) {
+	cases := map[string]struct {
+		a, b  StringOrSet
+		equal bool
+	}{
+		"BothNil": {
+			a:     nil,
+			b:     nil,
+			equal: true,
+		},
+		"BothEmpty": {
+			a:     NewStringOrSet(),
+			b:     NewStringOrSet(),
+			equal: true,
+		},
+		"EqualDifferentOrder": {
+			a:     NewStringOrSet("a", "b"),
+			b:     NewStringOrSet("b", "a"),
+			equal: true,
+		},
+		"NotEqual": {
+			a:     NewStringOrSet("a", "b"),
+			b:     NewStringOrSet("a", "c"),
+			equal: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.a, tc.b); (diff == "") != tc.equal {
+				t.Errorf("diff: %s", diff)
+			}
+		})
+	}
+}
+
+func TestStringOrSet_MarshalJSON(t *testing.T) {
+	cases := map[string]struct {
+		set  StringOrSet
+		want string
+	}{
+		"nil": {
+			set:  nil,
+			want: "null",
+		},
+		"Empty": {
+			set:  NewStringOrSet(),
+			want: "[]",
+		},
+		"Single": {
+			set:  NewStringOrSet("a"),
+			want: `["a"]`,
+		},
+		"Multiple": {
+			set:  NewStringOrSet("a", "c", "b"),
+			want: `["a","b","c"]`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			b, err := tc.set.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(b) != tc.want {
+				t.Errorf("got %s, want %s", b, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

AWS returns principals items in a random order so provider-aws should ignore it to not consider policies changed.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Existing and new tests

[contribution process]: https://git.io/fj2m9
