### PR TITLE
feat: Do not set Status.AtProvider.LastUsedAt for IAM roles by default

### DIFF
--- a/apis/iam/v1beta1/role_types.go
+++ b/apis/iam/v1beta1/role_types.go
@@ -21,6 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// Set this annotation to update Status.AtProvider.LastUsedAt.
+	// Note that this may trigger frequent updates and reconciliation of
+	// dependent resources.
+	TRACK_LAST_USED_AT = "roles.iam.crossplane.io/track-last-used-at"
+)
+
 // Tag represents user-provided metadata that can be associated
 // with a IAM role. For more information about tagging,
 // see Tagging IAM Identities (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html)
@@ -134,6 +141,8 @@ type RoleExternalStatus struct {
 	// where data is tracked
 	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period)
 	// in the IAM User Guide.
+	//
+	// This field is not updated by default (see TRACK_LAST_USED_AT).
 	RoleLastUsed *RoleLastUsed `json:"roleLastUsed,omitempty"`
 }
 

--- a/package/crds/iam.aws.crossplane.io_roles.yaml
+++ b/package/crds/iam.aws.crossplane.io_roles.yaml
@@ -311,14 +311,15 @@ spec:
                       in the Using IAM guide.
                     type: string
                   roleLastUsed:
-                    description: Contains information about the last time that an
+                    description: "Contains information about the last time that an
                       IAM role was used. This includes the date and time and the Region
                       in which the role was last used. Activity is only reported for
                       the trailing 400 days. This period can be shorter if your Region
                       began supporting these features within the last year. The role
                       might have been used more than 400 days ago. For more information,
                       see Regions where data is tracked (https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period)
-                      in the IAM User Guide.
+                      in the IAM User Guide. \n This field is not updated by default
+                      (see TRACK_LAST_USED_AT)."
                     properties:
                       lastUsedDate:
                         description: The date and time, in ISO 8601 date-time format

--- a/pkg/controller/iam/role/controller.go
+++ b/pkg/controller/iam/role/controller.go
@@ -140,6 +140,9 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	cr.SetConditions(xpv1.Available())
 
 	cr.Status.AtProvider = iam.GenerateRoleObservation(*observed.Role)
+	if _, ok := cr.Annotations[v1beta1.TRACK_LAST_USED_AT]; !ok {
+		cr.Status.AtProvider.RoleLastUsed = nil
+	}
 
 	upToDate, diff, err := iam.IsRoleUpToDate(cr.Spec.ForProvider, role)
 	if err != nil {


### PR DESCRIPTION
Because it can call frequent unnecessary reconciliations of dependent resources.

### Description of your changes

`LastUsedAt` is updated frequently and triggers unnecessary reconciliations of dependent resources.

I presumed that this field is used rarely and reasonable default would be not to update it on every reconciliation, even though this will be a breaking change.

Please let me know if you think it's better to use `IGNORE_LAST_USED_AT` annotation instead.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

new test case

[contribution process]: https://git.io/fj2m9
