### PR TITLE
fix: add engine version for dbinstance update

### DIFF
--- a/pkg/clients/rds/common.go
+++ b/pkg/clients/rds/common.go
@@ -46,6 +46,7 @@ const (
 	ErrNoPasswordUpToDate                                    = "cannot determine password up to date status"
 	ErrGetCachedPassword                                     = "cannot get cached password"
 	ErrRetrievePasswordForUpdate                             = "cannot retrieve password for update"
+	ErrDescribe                                              = "cannot describe dbinstance"
 )
 
 const (

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -269,6 +269,16 @@ func (e *custom) preUpdate(ctx context.Context, cr *svcapitypes.DBInstance, obj 
 		obj.StorageThroughput = nil
 	}
 
+	input := GenerateDescribeDBInstancesInput(cr)
+
+	out, err := e.client.DescribeDBInstancesWithContext(ctx, input)
+	if err != nil {
+		return errors.Wrap(err, dbinstance.ErrDescribe)
+	}
+	if !isEngineVersionUpToDate(cr, out) && cr.Spec.ForProvider.EngineVersion != nil {
+		obj.EngineVersion = cr.Spec.ForProvider.EngineVersion // add EngineVersion if changed and no downgrade
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Currently, when changing the engine version of a rds db instance, the new version is not send to aws. This leads to a) the database does not get updated and b) an update loop, as the isUpToDate call always returns false.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
