### PR TITLE
chores: Update build submodule and up up cli version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   # Common versions
   GO_VERSION: '1.21.2'
   GOLANGCI_VERSION: 'v1.54.2'
-  DOCKER_BUILDX_VERSION: 'v0.10.0'
+  DOCKER_BUILDX_VERSION: 'v0.14.1'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
@@ -35,6 +35,9 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports
 
       - name: Find the Go Build Cache
         id: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
-        run: make vendor vendor.check
+        run: make modules.download modules.check
 
       - name: Check Diff
         run: make check-diff
@@ -132,7 +132,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
-        run: make vendor vendor.check
+        run: make modules.download modules.check
 
       # We could run 'make lint' to ensure our desired Go version, but we prefer
       # this action because it leaves 'annotations' (i.e. it comments on PRs to
@@ -248,7 +248,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
-        run: make vendor vendor.check
+        run: make modules.download modules.check
 
       - name: Run Unit Tests
         run: make -j2 test
@@ -308,7 +308,7 @@ jobs:
             ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
-        run: make vendor vendor.check
+        run: make modules.download modules.check
 
       - name: Build Helm Chart
         run: make -j2 build
@@ -379,7 +379,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pkg-
 
       - name: Vendor Dependencies
-        run: make vendor vendor.check
+        run: make modules.download modules.check
 
       - name: Build Artifacts
         run: make -j2 build.all

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ GOLANGCILINT_VERSION = 1.54.2
 # ====================================================================================
 # Setup Kubernetes tools
 
-UP_VERSION = v0.18.0
+UP_VERSION = v0.27.0
 UP_CHANNEL = stable
-UPTEST_VERSION = v0.5.0
+UPTEST_VERSION = v0.12.0
 
 -include build/makelib/k8s_tools.mk
 

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ manifests:
 e2e.run: test-integration
 
 # Run integration tests.
-test-integration: $(KIND) $(KUBECTL) $(UP) $(HELM3)
+test-integration: $(KIND) $(KUBECTL) $(UP) $(HELM)
 	@$(INFO) running integration tests using kind $(KIND_VERSION)
 	@KIND_NODE_IMAGE_TAG=${KIND_NODE_IMAGE_TAG} $(ROOT_DIR)/cluster/local/integration_tests.sh || $(FAIL)
 	@$(OK) integration tests passed

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -131,13 +131,13 @@ echo "${PVC_YAML}" | "${KUBECTL}" create -f -
 
 # install crossplane from stable channel
 echo_step "installing crossplane from stable channel"
-"${HELM3}" repo add crossplane-stable https://charts.crossplane.io/stable/
+"${HELM}" repo add crossplane-stable https://charts.crossplane.io/stable/
 chart_version="1.14.5"
 echo_info "using crossplane version ${chart_version}"
 echo
 # we replace empty dir with our PVC so that the /cache dir in the kind node
 # container is exposed to the crossplane pod
-"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
+"${HELM}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --wait --set packageCache.pvc=package-cache
 
 # ----------- integration tests
 echo_step "--- INTEGRATION TESTS ---"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
Fixes #
-->
- Update build module to use the latest supported version and change the up version that is compatible with docker > 1.25
- `vendor` and ` vendor.check` were deprecated, updated the CI to use the new version `modules.download` and ` modules.check` 

```sh
Go Targets:
    modules.download Download Go modules.
    modules.check    Fail the build if Go modules have changed.
``` 



I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Build in MacOS with Docker 
- Run actions 
<img width="920" alt="image" src="https://github.com/crossplane-contrib/provider-aws/assets/3131280/38f477a1-73fd-4990-9693-2ac148e982f6">


[contribution process]: https://git.io/fj2m9
