### PR TITLE
fix: Explicitly provide no-op logger by default

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -66,6 +67,9 @@ func main() {
 		// *very* verbose even at info level, so we only provide it a real
 		// logger when we're running in debug mode.
 		ctrl.SetLogger(zl)
+	} else {
+		// explicitly provide a no-op logger by default, otherwise controller-runtime gives a warning
+		ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 	}
 
 	log.Debug("Starting", "sync-period", syncInterval.String())


### PR DESCRIPTION
### Description of your changes

Closes https://github.com/crossplane-contrib/provider-aws/issues/2081

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
