### PR TITLE
fix(database): allow empty array as value in enableCloudwatchLogsExports + fix isuptodate check

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -414,7 +414,7 @@ type RDSInstanceParameters struct {
 	// information, see Publishing Database Logs to Amazon CloudWatch Logs  (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
 	// in the Amazon Relational Database Service User Guide.
 	// +optional
-	EnableCloudwatchLogsExports []string `json:"enableCloudwatchLogsExports,omitempty"`
+	EnableCloudwatchLogsExports []string `json:"enableCloudwatchLogsExports"`
 
 	// EnableIAMDatabaseAuthentication should be true to enable mapping of AWS Identity and Access Management (IAM) accounts
 	// to database accounts, and otherwise false.

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -549,6 +549,21 @@ func TestIsUpToDate(t *testing.T) {
 			},
 			want: false,
 		},
+		"EnableCloudwatchLogExportsEmptyAndNil": {
+			args: args{
+				db: rdstypes.DBInstance{
+					EnabledCloudwatchLogsExports: nil,
+				},
+				r: v1beta1.RDSInstance{
+					Spec: v1beta1.RDSInstanceSpec{
+						ForProvider: v1beta1.RDSInstanceParameters{
+							EnableCloudwatchLogsExports: []string{},
+						},
+					},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for name, tc := range cases {
@@ -1130,7 +1145,7 @@ func TestLateInitialize(t *testing.T) {
 				Timezone:                           &zone,
 				DBSecurityGroups:                   []string{name},
 				DBSubnetGroupName:                  subnetGroup.DBSubnetGroupName,
-				EnableCloudwatchLogsExports:        nil,
+				EnableCloudwatchLogsExports:        enabledCloudwatchExports,
 				ProcessorFeatures: []v1beta1.ProcessorFeature{{
 					Name:  name,
 					Value: value,


### PR DESCRIPTION
### Description of your changes

for `RDSInstance.database`:

- allow empty array as value in `spec.paramaters.enableCloudwatchLogsExports`
- fix isUpTodate-check for `EnableCloudwatchLogsExports`


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
na
