### PR TITLE
fix(eks): SubnetIds diff

### DIFF
--- a/pkg/clients/eks/eks.go
+++ b/pkg/clients/eks/eks.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -180,6 +181,9 @@ func GenerateEncryptionConfig(parameters *v1beta1.ClusterParameters) []ekstypes.
 func CreatePatch(in *ekstypes.Cluster, target *v1beta1.ClusterParameters) (*v1beta1.ClusterParameters, error) {
 	currentParams := &v1beta1.ClusterParameters{}
 	LateInitialize(currentParams, in)
+
+	slices.Sort(currentParams.ResourcesVpcConfig.SubnetIDs)
+	slices.Sort(target.ResourcesVpcConfig.SubnetIDs)
 
 	jsonPatch, err := jsonpatch.CreateJSONPatch(currentParams, target)
 	if err != nil {


### PR DESCRIPTION
Fixes the diff of subnetIds.

Fixes:
```
cannot update EKS cluster configuration: InvalidParameterException:
      No changes needed for the provided vpc config.
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Reordered the subnetIds to create the mentioned error, tested if it appears with the fix