### PR TITLE
fix(s3): dont set ExpiredObjectDeleteMarker in lifecycle policy if da…

### DIFF
--- a/pkg/controller/s3/bucket/lifecycleConfig.go
+++ b/pkg/controller/s3/bucket/lifecycleConfig.go
@@ -161,12 +161,18 @@ func GenerateLifecycleRules(in []v1beta1.LifecycleRule) []types.LifecycleRule { 
 			}
 		}
 		if local.Expiration != nil {
-			rule.Expiration = &types.LifecycleExpiration{
-				Days:                      ptr.To(local.Expiration.Days),
-				ExpiredObjectDeleteMarker: ptr.To(local.Expiration.ExpiredObjectDeleteMarker),
+			rule.Expiration = &types.LifecycleExpiration{}
+			if local.Expiration.Days > 0 {
+				rule.Expiration.Days = ptr.To(local.Expiration.Days)
 			}
 			if local.Expiration.Date != nil {
 				rule.Expiration.Date = ptr.To(local.Expiration.Date.Time)
+			}
+			// NOTE(kkendzia): ExpiredObjectDeleteMarker must not be set when Days or Date is specified
+			// This behaviour is in line with terraform provider aws and avoids a MalformedXML Error
+			// When both is set, ExpiredObjectDeleteMarker will be ignored.
+			if local.Expiration.Date == nil && local.Expiration.Days == 0 {
+				rule.Expiration.ExpiredObjectDeleteMarker = ptr.To(local.Expiration.ExpiredObjectDeleteMarker)
 			}
 		}
 		if local.NoncurrentVersionExpiration != nil {


### PR DESCRIPTION
This PR solved the issue with a parameter collision in S3 Bucket Lifecycle Configurations.

According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex7 you cannot specify both `Days` / `Date` and `ExpiredObjectDeleteMarker`, resulting in a MalformedXML Error otherwise.

### Description of your changes

This change is adapted to the behaviour of terraform provider aws: https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/s3/bucket_lifecycle_configuration.go#L664

When Date or Days is set, don't set ExpiredObjectDeleteMarker at all.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

tested by @simwak 
* Built
* Tested with example MRs

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
