### PR TITLE
fix(s3): Add missing GLACIER_IR storage type in replication and lifecycle Configuration types

### DIFF
--- a/apis/s3/v1beta1/lifecycleConfiguration_types.go
+++ b/apis/s3/v1beta1/lifecycleConfiguration_types.go
@@ -149,7 +149,7 @@ type NoncurrentVersionExpiration struct {
 }
 
 // NoncurrentVersionTransition contains the transition rule that describes when noncurrent objects
-// transition to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER,
+// transition to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, GLACIER_IR
 // or DEEP_ARCHIVE storage class. If your bucket is versioning-enabled (or versioning
 // is suspended), you can set this action to request that Amazon S3 transition
 // noncurrent object versions to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING,
@@ -164,8 +164,8 @@ type NoncurrentVersionTransition struct {
 	NoncurrentDays int32 `json:"noncurrentDays,omitempty"`
 
 	// The class of storage used to store the object.
-	// Valid values are: GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
-	// +kubebuilder:validation:Enum=GLACIER;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
+	// Valid values are: GLACIER, GLACIER_IR, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
+	// +kubebuilder:validation:Enum=GLACIER;GLACIER_IR;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
 	StorageClass string `json:"storageClass"`
 }
 
@@ -184,7 +184,7 @@ type Transition struct {
 	Days int32 `json:"days,omitempty"`
 
 	// The storage class to which you want the object to transition.
-	// Valid values are: GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
-	// +kubebuilder:validation:Enum=GLACIER;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
+	// Valid values are: GLACIER, GLACIER_IR, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
+	// +kubebuilder:validation:Enum=GLACIER;GLACIER_IR;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
 	StorageClass string `json:"storageClass"`
 }

--- a/apis/s3/v1beta1/replicationConfiguration_types.go
+++ b/apis/s3/v1beta1/replicationConfiguration_types.go
@@ -186,7 +186,7 @@ type Destination struct {
 	// For valid values, see the StorageClass element of the PUT Bucket replication
 	// (https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html)
 	// action in the Amazon Simple Storage Service API Reference.
-	// +kubebuilder:validation:Enum=STANDARD;GLACIER;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
+	// +kubebuilder:validation:Enum=STANDARD;GLACIER;GLACIER_IR;STANDARD_IA;ONEZONE_IA;INTELLIGENT_TIERING;DEEP_ARCHIVE
 	// +optional
 	StorageClass *string `json:"storageClass"`
 }

--- a/package/crds/s3.aws.crossplane.io_buckets.yaml
+++ b/package/crds/s3.aws.crossplane.io_buckets.yaml
@@ -333,7 +333,7 @@ spec:
                               items:
                                 description: |-
                                   NoncurrentVersionTransition contains the transition rule that describes when noncurrent objects
-                                  transition to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER,
+                                  transition to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, GLACIER, GLACIER_IR
                                   or DEEP_ARCHIVE storage class. If your bucket is versioning-enabled (or versioning
                                   is suspended), you can set this action to request that Amazon S3 transition
                                   noncurrent object versions to the STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING,
@@ -352,9 +352,10 @@ spec:
                                   storageClass:
                                     description: |-
                                       The class of storage used to store the object.
-                                      Valid values are: GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
+                                      Valid values are: GLACIER, GLACIER_IR, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
                                     enum:
                                     - GLACIER
+                                    - GLACIER_IR
                                     - STANDARD_IA
                                     - ONEZONE_IA
                                     - INTELLIGENT_TIERING
@@ -401,9 +402,10 @@ spec:
                                   storageClass:
                                     description: |-
                                       The storage class to which you want the object to transition.
-                                      Valid values are: GLACIER, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
+                                      Valid values are: GLACIER, GLACIER_IR, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING, DEEP_ARCHIVE
                                     enum:
                                     - GLACIER
+                                    - GLACIER_IR
                                     - STANDARD_IA
                                     - ONEZONE_IA
                                     - INTELLIGENT_TIERING
@@ -2046,6 +2048,7 @@ spec:
                                   enum:
                                   - STANDARD
                                   - GLACIER
+                                  - GLACIER_IR
                                   - STANDARD_IA
                                   - ONEZONE_IA
                                   - INTELLIGENT_TIERING


### PR DESCRIPTION
Hello,

It's currently not possible to create a bucket with `GLACIER_IR` as a replicationConfiguration storageClass:
```
The Bucket "my-test-bucket-mxapp-bucket" is invalid: spec.forProvider.replicationConfiguration.rules[0].destination.storageClass: Unsupported value: "GLACIER_IR": supported values: "STANDARD", "GLACIER", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "DEEP_ARCHIVE"
```
### Description of your changes
As per https://docs.aws.amazon.com/AmazonS3/latest/API/API_Transition.html and https://docs.aws.amazon.com/AmazonS3/latest/API/API_NoncurrentVersionTransition.html GLACIER_IR should be part of the NoncurrentVersionTransition and Transition types for the lifecycle and replication configurations.


I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

 - [X] make reviewable test 
 - [X] Applied generated CRD in a dedicated cluster, bucket created with GLACIER_IR as destination Storage Class. 

Thanks for reviewing, please let me know if something is missing for the MR.
