### PR TITLE
fix(sdk-config): drop web identity usage from v1 default config

### DIFF
--- a/pkg/utils/connect/aws/config.go
+++ b/pkg/utils/connect/aws/config.go
@@ -32,7 +32,7 @@ import (
 	stscredstypesv2 "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	awsv1 "github.com/aws/aws-sdk-go/aws"
 	credentialsv1 "github.com/aws/aws-sdk-go/aws/credentials"
-	stscredsv1 "github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	defaultsv1 "github.com/aws/aws-sdk-go/aws/defaults"
 	endpointsv1 "github.com/aws/aws-sdk-go/aws/endpoints"
 	requestv1 "github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -672,17 +672,8 @@ func GetDefaultConfigV1() (*awsv1.Config, error) {
 	muV1.Lock()
 	defer muV1.Unlock()
 	if defaultConfigV1 == nil {
-		cfg := awsv1.NewConfig()
-		sess, err := GetSessionV1(cfg)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to load default AWS config")
-		}
-		envCfg, err := config.NewEnvConfig()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to load default AWS env config")
-		}
-		creds := stscredsv1.NewWebIdentityCredentials(sess, envCfg.RoleARN, envCfg.RoleSessionName, envCfg.WebIdentityTokenFilePath) //nolint:staticcheck
-		defaultConfigV1 = cfg.WithCredentials(creds)
+		// use the sdk's default config
+		defaultConfigV1 = defaultsv1.Get().Config
 	}
 	return defaultConfigV1.Copy(), nil
 }


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes web identity usage when using providerconfig.spec.credentials.source InjectedIdentity.

Sample config:
```
apiVersion: aws.crossplane.io/v1beta1
kind: ProviderConfig
metadata:
  name: default
spec:
  credentials:
    source: InjectedIdentity
```

Sample error message when not providing a web identity token file, e.g. via AWS_WEB_IDENTITY_TOKEN_FILE, in the provider-aws pod with InjectedIdentity:
```
failed to describe DBParameterGroup: WebIdentityErr: failed fetching WebIdentity token: 
caused by: WebIdentityErr: unable to read file at 
caused by: open : no such file or directory
```

This fix enables (config v1) services to use any credential provider via the default credential provider chain.
As a result v1 services can be used with container credential providers like pod identity.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make test` to ensure this PR is ready for review.

### How has this code been tested

make test

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
