### PR TITLE
chore: Update OWNERS.md with correct christophrj

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -15,4 +15,4 @@ guidelines and responsibilities for the steering committee and maintainers.
 * Carl Henrik Lunde <chlunde@gmail.com> ([chlunde](https://github.com/chlunde))
 * Maximilian Blatt ([MisterMX](https://github.com/MisterMX))
 * Ana Garlau ([anagarlau](https://github.com/anagarlau))
-* Christopher Junk ([christopherj](https://github.com/christopherj))
+* Christopher Junk ([christophrj](https://github.com/christophrj))


### PR DESCRIPTION
### Description of your changes

This PR is just a small update from #2138 to correct a typo in the github user name for https://github.com/christophrj 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable test` to ensure this PR is ready for review.~

### How has this code been tested

I've verified the link goes to https://github.com/christophrj 😇 

[contribution process]: https://git.io/fj2m9
