### PR TITLE
fix(ecs): Fix LateInitialize & Slice diffs

### DIFF
--- a/pkg/controller/ecs/service/setup.go
+++ b/pkg/controller/ecs/service/setup.go
@@ -77,11 +77,13 @@ func isUpToDate(context context.Context, service *svcapitypes.Service, output *s
 
 	tags := func(a, b *svcapitypes.Tag) bool { return aws.StringValue(a.Key) < aws.StringValue(b.Key) }
 	stringpointer := func(a, b *string) bool { return aws.StringValue(a) < aws.StringValue(b) }
+	keyValuePair := func(a, b *svcsdk.KeyValuePair) bool { return aws.StringValue(a.Name) < aws.StringValue(b.Name) }
 
 	diff := cmp.Diff(c, t,
 		cmpopts.EquateEmpty(),
 		cmpopts.SortSlices(tags),
 		cmpopts.SortSlices(stringpointer),
+		cmpopts.SortSlices(keyValuePair),
 		// Not present in DescribeServicesOutput
 		cmpopts.IgnoreFields(svcapitypes.ServiceParameters{}, "Region"),
 		cmpopts.IgnoreFields(svcapitypes.CustomServiceParameters{}, "Cluster"),


### PR DESCRIPTION
Fixes:
- Updating Volumes in TaskDefinitionFamily (LateInit)
- Diffs on TaskDefinitionFamily/ECS Service

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- Updating Environment on TaskDefinitionFamily and check if update loop occurs
- Updating Volumes on TaskDefinitionFamily and check if update loop occurs