### PR TITLE
fix(rdsinstance.database): do not send empty modify-calls

### DIFF
--- a/pkg/clients/database/rds.go
+++ b/pkg/clients/database/rds.go
@@ -887,6 +887,10 @@ func generateCloudWatchExportConfiguration(spec, current []string) *rdstypes.Clo
 		}
 	}
 
+	if len(toEnable) == 0 && len(toDisable) == 0 {
+		return nil
+	}
+
 	return &rdstypes.CloudwatchLogsExportConfiguration{
 		EnableLogTypes:  toEnable,
 		DisableLogTypes: toDisable,

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -1368,10 +1368,6 @@ func TestGenerateModifyDBInstanceInput(t *testing.T) {
 			params: v1beta1.RDSInstanceParameters{},
 			want: rds.ModifyDBInstanceInput{
 				DBInstanceIdentifier: &emptyName,
-				CloudwatchLogsExportConfiguration: &rdstypes.CloudwatchLogsExportConfiguration{
-					DisableLogTypes: []string{},
-					EnableLogTypes:  []string{},
-				},
 			},
 		},
 	}

--- a/pkg/controller/database/rdsinstance/rdsinstance_test.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance_test.go
@@ -857,10 +857,12 @@ func TestUpdate(t *testing.T) {
 						}, nil
 					},
 				},
-				cr: instance(),
+				cr: instance(
+					withEngineVersion(&engineVersion)),
 			},
 			want: want{
-				cr:  instance(),
+				cr: instance(
+					withEngineVersion(&engineVersion)),
 				err: errorutils.Wrap(errBoom, errModifyFailed),
 			},
 		},


### PR DESCRIPTION
### Description of your changes

for RDSInstance.database:
- do not request Modify, when ModifyDBInstanceInput only includes `DBInstanceIdentifier` and the Modify-Flags(`AllowMajorVersionUpgrade`, `ApplyImmediately`)

When user only changed Tags, this could lead to getting the MR stuck, if `ApplyImmediately: false` was set.
AWS then blocks the request and the whole update-fails:

> "update failed: cannot modify RDS instance: api error InvalidParameterCombination: No modifications were requested"

This rarely happened, due to AWS curiously not rejecting empty Modify-Calls with `ApplyImmediately: true`.



I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually 
