### PR TITLE
fix(rdsinstance.database): do not overwrite engineVersion if only major was set + add engineVersion to observe

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -1261,7 +1261,7 @@ type RDSInstanceStatus struct {
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.dbInstanceStatus"
 // +kubebuilder:printcolumn:name="ENGINE",type="string",JSONPath=".spec.forProvider.engine"
-// +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".spec.forProvider.engineVersion"
+// +kubebuilder:printcolumn:name="VERSION",type="string",JSONPath=".status.atProvider.engineVersion"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,aws}

--- a/package/crds/database.aws.crossplane.io_rdsinstances.yaml
+++ b/package/crds/database.aws.crossplane.io_rdsinstances.yaml
@@ -31,7 +31,7 @@ spec:
     - jsonPath: .spec.forProvider.engine
       name: ENGINE
       type: string
-    - jsonPath: .spec.forProvider.engineVersion
+    - jsonPath: .status.atProvider.engineVersion
       name: VERSION
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/pkg/clients/database/rds.go
+++ b/pkg/clients/database/rds.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -463,6 +462,7 @@ func GenerateObservation(db rdstypes.DBInstance) v1beta1.RDSInstanceObservation 
 		DBInstancePort:                        int(ptr.Deref(db.DbInstancePort, 0)),
 		DBResourceID:                          aws.ToString(db.DbiResourceId),
 		EnabledCloudwatchLogsExports:          db.EnabledCloudwatchLogsExports,
+		EngineVersion:                         db.EngineVersion,
 		EnhancedMonitoringResourceArn:         aws.ToString(db.EnhancedMonitoringResourceArn),
 		PerformanceInsightsEnabled:            aws.ToBool(db.PerformanceInsightsEnabled),
 		ReadReplicaDBClusterIdentifiers:       db.ReadReplicaDBClusterIdentifiers,
@@ -671,12 +671,6 @@ func LateInitialize(in *v1beta1.RDSInstanceParameters, db *rdstypes.DBInstance) 
 		}
 	}
 	in.EngineVersion = pointer.LateInitialize(in.EngineVersion, db.EngineVersion)
-	// When version 5.6 is chosen, AWS creates 5.6.41 and that's totally valid.
-	// But we detect as if we need to update it all the time. Here, we assign
-	// the actual full version to our spec to avoid unnecessary update signals.
-	if strings.HasPrefix(aws.ToString(db.EngineVersion), aws.ToString(in.EngineVersion)) {
-		in.EngineVersion = db.EngineVersion
-	}
 	if in.DBParameterGroupName == nil {
 		for i := range db.DBParameterGroups {
 			if db.DBParameterGroups[i].DBParameterGroupName != nil {

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -78,7 +78,6 @@ var (
 	tier                               = 4
 	tier32                             = int32(tier)
 	trueFlag                           = true
-	truncEngine                        = "5.6"
 	username                           = "username"
 	value                              = "testValue"
 	vpc                                = "vpc"
@@ -836,6 +835,7 @@ func TestGenerateObservation(t *testing.T) {
 				DbiResourceId:                         &resourceID,
 				BackupRetentionPeriod:                 &retention32,
 				EnabledCloudwatchLogsExports:          enabledCloudwatchExports,
+				EngineVersion:                         &engine,
 				EnhancedMonitoringResourceArn:         &arn,
 				PerformanceInsightsEnabled:            &trueFlag,
 				ReadReplicaDBClusterIdentifiers:       replicaClusters,
@@ -893,6 +893,7 @@ func TestGenerateObservation(t *testing.T) {
 				InstanceCreateTime:            &metav1.Time{Time: createTime},
 				Endpoint:                      v1beta1.Endpoint{Port: port, HostedZoneID: zone, Address: address},
 				EnabledCloudwatchLogsExports:  enabledCloudwatchExports,
+				EngineVersion:                 &engine,
 				EnhancedMonitoringResourceArn: arn,
 				LatestRestorableTime:          &metav1.Time{Time: lastRestoreTime},
 				OptionGroupMemberships:        []v1beta1.OptionGroupMembership{{OptionGroupName: name, Status: status}},
@@ -1230,7 +1231,7 @@ func TestLateInitialize(t *testing.T) {
 				EngineVersion: &engine,
 			},
 			params: v1beta1.RDSInstanceParameters{
-				EngineVersion: &truncEngine,
+				EngineVersion: &engine,
 			},
 			want: v1beta1.RDSInstanceParameters{
 				EngineVersion: &engine,

--- a/pkg/controller/database/rdsinstance/rdsinstance_test.go
+++ b/pkg/controller/database/rdsinstance/rdsinstance_test.go
@@ -173,6 +173,10 @@ func withStatusAWSBackupRecoveryPointARN(s string) rdsModifier {
 	return func(r *v1beta1.RDSInstance) { r.Status.AtProvider.AWSBackupRecoveryPointARN = s }
 }
 
+func withStatusEngineVersion(s *string) rdsModifier {
+	return func(r *v1beta1.RDSInstance) { r.Status.AtProvider.EngineVersion = s }
+}
+
 func instance(m ...rdsModifier) *v1beta1.RDSInstance {
 	cr := &v1beta1.RDSInstance{}
 	for _, f := range m {
@@ -421,6 +425,7 @@ func TestObserve(t *testing.T) {
 			want: want{
 				cr: instance(
 					withEngineVersion(&engineVersion),
+					withStatusEngineVersion(&engineVersion),
 					withDBInstanceStatus(string(v1beta1.RDSInstanceStateCreating)),
 					withConditions(xpv1.Creating()),
 				),


### PR DESCRIPTION
### Description of your changes

for `RDSInstance.database`:
- remove lateinit overwrite of `engineVersion` when only major is set
  - this is no longer needed since we check in isUpToDate the `engineVersion` in detail (considering major and minor)
- now fill  - already existing status field... - with observed `engineVersion` in AWS
- change printcolumn to `.status.atProvider.engineVersion`

Fixes:

for setups where MRs were applied automatically (e.g. via Composition/XR) the `spec.forProvider.engineVersion` would constantly flicker due to this lateinit part, when user set only the major version (which is valid by AWS; and makes sense in combination with `autoMinorVersionUpgrade`)


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually
