### PR TITLE
fix(lambda): Policy parsing for permissions when using roles as principles

### DIFF
--- a/pkg/controller/lambda/permission/policy.go
+++ b/pkg/controller/lambda/permission/policy.go
@@ -35,6 +35,7 @@ func (p *policyPrincipal) UnmarshalJSON(data []byte) error {
 	}
 
 	p.Service = pp.Service
+	p.AWS = pp.AWS
 	return nil
 }
 
@@ -45,6 +46,7 @@ type policyCondition struct {
 
 type policyPrincipal struct {
 	Service *string `json:"Service,omitempty"`
+	AWS     *string `json:"AWS,omitempty"`
 }
 
 type _policyPrincipal policyPrincipal
@@ -61,6 +63,9 @@ type policyStatement struct {
 func (p *policyStatement) GetPrincipal() string {
 	if p.Principal.Service != nil {
 		return *p.Principal.Service
+	}
+	if p.Principal.AWS != nil {
+		return *p.Principal.AWS
 	}
 	return ""
 }

--- a/pkg/controller/lambda/permission/policy_test.go
+++ b/pkg/controller/lambda/permission/policy_test.go
@@ -58,6 +58,17 @@ func TestUnmarshalPolicyPrincipal(t *testing.T) {
 				err: nil,
 			},
 		},
+		"PrincipalObjectAWS": {
+			args: args{
+				rawPolicy: `{"AWS":"aws:arn:iam:::role/test"}`,
+			},
+			want: want{
+				result: policyPrincipal{
+					AWS: stringPtr("aws:arn:iam:::role/test"),
+				},
+				err: nil,
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -210,6 +221,58 @@ func TestUnmarshalPolicy(t *testing.T) {
 							Resource: "resource",
 							Principal: policyPrincipal{
 								Service: stringPtr("service"),
+							},
+							Condition: policyCondition{
+								ArnLike: map[string]string{
+									"like2": "bar",
+								},
+								StringEquals: map[string]string{
+									"equals1": "foo",
+								},
+							},
+						},
+					},
+				},
+				err: nil,
+			},
+		},
+		"UnmarshalPolicyWithAWSObjectAsPrincipal": {
+			args: args{
+				rawPolicy: `{
+					"Version":"version",
+					"Id":"default",
+					"Statement":[
+						{
+							"Sid": "sid",
+							"Effect": "effect",
+							"Principal": {
+								"AWS": "arn"
+							},
+							"Action": "action",
+							"Resource": "resource",
+							"Condition": {
+								"StringEquals": {
+									"equals1": "foo"
+								},
+								"ArnLike": {
+									"like2": "bar"
+								}
+							}
+						}
+					]
+				}`,
+			},
+			want: want{
+				result: &policyDocument{
+					Version: "version",
+					Statement: []policyStatement{
+						{
+							Sid:      "sid",
+							Effect:   "effect",
+							Action:   "action",
+							Resource: "resource",
+							Principal: policyPrincipal{
+								AWS: stringPtr("arn"),
 							},
 							Condition: policyCondition{
 								ArnLike: map[string]string{


### PR DESCRIPTION
### Description of your changes

When using roles as principle in permissions.lambda the key is "AWS", which got lost when unmarshaling the returned policy.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran provider locally against AWS and added unittest

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
