### PR TITLE
chore(secretmanager): add versionids to status

### DIFF
--- a/apis/secretsmanager/generator-config.yaml
+++ b/apis/secretsmanager/generator-config.yaml
@@ -25,6 +25,11 @@ resources:
     fields:
       KmsKeyId:
         referenced_type: "kms/v1alpha1.Key"
+      VersionIdsToStages:
+        is_read_only: true
+        from:
+          operation: DescribeSecret
+          path: VersionIdsToStages
     exceptions:
       errors:
         404:

--- a/apis/secretsmanager/v1beta1/zz_generated.deepcopy.go
+++ b/apis/secretsmanager/v1beta1/zz_generated.deepcopy.go
@@ -410,6 +410,28 @@ func (in *SecretObservation) DeepCopyInto(out *SecretObservation) {
 			}
 		}
 	}
+	if in.VersionIDsToStages != nil {
+		in, out := &in.VersionIDsToStages, &out.VersionIDsToStages
+		*out = make(map[string][]*string, len(*in))
+		for key, val := range *in {
+			var outVal []*string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				inVal := (*in)[key]
+				in, out := &inVal, &outVal
+				*out = make([]*string, len(*in))
+				for i := range *in {
+					if (*in)[i] != nil {
+						in, out := &(*in)[i], &(*out)[i]
+						*out = new(string)
+						**out = **in
+					}
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	out.CustomSecretObservation = in.CustomSecretObservation
 }
 

--- a/apis/secretsmanager/v1beta1/zz_secret.go
+++ b/apis/secretsmanager/v1beta1/zz_secret.go
@@ -100,6 +100,27 @@ type SecretObservation struct {
 	//
 	//    * InSync, which indicates that the replica was created.
 	ReplicationStatus []*ReplicationStatusType `json:"replicationStatus,omitempty"`
+	// A list of the versions of the secret that have staging labels attached. Versions
+	// that don't have staging labels are considered deprecated and Secrets Manager
+	// can delete them.
+	//
+	// Secrets Manager uses staging labels to indicate the status of a secret version
+	// during rotation. The three staging labels for rotation are:
+	//
+	//    * AWSCURRENT, which indicates the current version of the secret.
+	//
+	//    * AWSPENDING, which indicates the version of the secret that contains
+	//    new secret information that will become the next current version when
+	//    rotation finishes. During rotation, Secrets Manager creates an AWSPENDING
+	//    version ID before creating the new secret version. To check if a secret
+	//    version exists, call GetSecretValue.
+	//
+	//    * AWSPREVIOUS, which indicates the previous current version of the secret.
+	//    You can use this as the last known good version.
+	//
+	// For more information about rotation and staging labels, see How rotation
+	// works (https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotate-secrets_how.html).
+	VersionIDsToStages map[string][]*string `json:"versionIDsToStages,omitempty"`
 
 	CustomSecretObservation `json:",inline"`
 }

--- a/package/crds/secretsmanager.aws.crossplane.io_secrets.yaml
+++ b/package/crds/secretsmanager.aws.crossplane.io_secrets.yaml
@@ -1103,6 +1103,38 @@ spec:
                           type: string
                       type: object
                     type: array
+                  versionIDsToStages:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      A list of the versions of the secret that have staging labels attached. Versions
+                      that don't have staging labels are considered deprecated and Secrets Manager
+                      can delete them.
+
+
+                      Secrets Manager uses staging labels to indicate the status of a secret version
+                      during rotation. The three staging labels for rotation are:
+
+
+                         * AWSCURRENT, which indicates the current version of the secret.
+
+
+                         * AWSPENDING, which indicates the version of the secret that contains
+                         new secret information that will become the next current version when
+                         rotation finishes. During rotation, Secrets Manager creates an AWSPENDING
+                         version ID before creating the new secret version. To check if a secret
+                         version exists, call GetSecretValue.
+
+
+                         * AWSPREVIOUS, which indicates the previous current version of the secret.
+                         You can use this as the last known good version.
+
+
+                      For more information about rotation and staging labels, see How rotation
+                      works (https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotate-secrets_how.html).
+                    type: object
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/pkg/controller/secretsmanager/secret/zz_conversions.go
+++ b/pkg/controller/secretsmanager/secret/zz_conversions.go
@@ -97,6 +97,21 @@ func GenerateSecret(resp *svcsdk.DescribeSecretOutput) *svcapitypes.Secret {
 	} else {
 		cr.Spec.ForProvider.Tags = nil
 	}
+	if resp.VersionIdsToStages != nil {
+		f16 := map[string][]*string{}
+		for f16key, f16valiter := range resp.VersionIdsToStages {
+			f16val := []*string{}
+			for _, f16valiter := range f16valiter {
+				var f16valelem string
+				f16valelem = *f16valiter
+				f16val = append(f16val, &f16valelem)
+			}
+			f16[f16key] = f16val
+		}
+		cr.Status.AtProvider.VersionIDsToStages = f16
+	} else {
+		cr.Status.AtProvider.VersionIDsToStages = nil
+	}
 
 	return cr
 }


### PR DESCRIPTION
### Description of your changes

- added versionids to secretsmanager.secret in order to facilitate migration cases


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- built new version, manually tested that status is showing

[contribution process]: https://git.io/fj2m9
