### PR TITLE
Cache secret info

### DIFF
--- a/pkg/controller/cache/cluster/controller.go
+++ b/pkg/controller/cache/cluster/controller.go
@@ -162,7 +162,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	return obs, nil
-	}, nil
 }
 
 func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {

--- a/pkg/controller/cache/cluster/controller.go
+++ b/pkg/controller/cache/cluster/controller.go
@@ -147,9 +147,15 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, err
 	}
 
+	obs.ConnectionDetails = managed.ConnectionDetails{
+		xpv1.ResourceCredentialsSecretEndpointKey: []byte(pointer.StringValue(cr.Status.AtProvider.Endpoint.Address)),
+		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.FormatInt(int64(pointer.Int64Value(cr.Status.AtProvider.Endpoint.Port)), 10)),
+	}
+
 	return managed.ExternalObservation{
-		ResourceExists:   true,
-		ResourceUpToDate: upToDate,
+		ResourceExists:          true,
+		ResourceUpToDate:        upToDate,
+		ConnectionDetails:       obs.ConnectionDetails,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
As best I can tell, we're not actually storing anything relevant in the ExternalObservation struct, so we end up with a secret with zero bytes.

I didn't actually see Endpoint in the underlying observer object. There were a list of cache nodes. I don't think this is a solution to all of the problems, but I hope this is a step in the right direction.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Refs #2167 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

That ^^ isn't a valid command

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I've not tested this. I'm not clear how. I'm actively seeking help and understanding here. I'm even open to running this in my dev cluster if there's a reasonable process to do that.

[contribution process]: https://git.io/fj2m9
