### PR TITLE
fix(ec2.instance): permit to create instance with no tags

### DIFF
--- a/pkg/controller/ec2/instance/controller.go
+++ b/pkg/controller/ec2/instance/controller.go
@@ -265,14 +265,16 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.Ex
 
 	instance := result.Instances[0]
 
-	if _, err := e.client.CreateTags(ctx, &awsec2.CreateTagsInput{
-		Resources: []string{pointer.StringValue(instance.InstanceId)},
-		Tags:      ec2.GenerateEC2TagsManualV1alpha1(cr.Spec.ForProvider.Tags),
-	}); err != nil {
-		return managed.ExternalCreation{}, errorutils.Wrap(err, errCreateTags)
-	}
-
 	meta.SetExternalName(cr, pointer.StringValue(instance.InstanceId))
+
+	if len(cr.Spec.ForProvider.Tags) > 0 {
+		if _, err := e.client.CreateTags(ctx, &awsec2.CreateTagsInput{
+			Resources: []string{pointer.StringValue(instance.InstanceId)},
+			Tags:      ec2.GenerateEC2TagsManualV1alpha1(cr.Spec.ForProvider.Tags),
+		}); err != nil {
+			return managed.ExternalCreation{}, errorutils.Wrap(err, errCreateTags)
+		}
+	}
 
 	return managed.ExternalCreation{}, nil
 }

--- a/pkg/controller/ec2/instance/controller_test.go
+++ b/pkg/controller/ec2/instance/controller_test.go
@@ -259,6 +259,31 @@ func TestCreate(t *testing.T) {
 				result: managed.ExternalCreation{},
 			},
 		},
+		"SuccessfulWithNoTags": {
+			args: args{
+				instance: &fake.MockInstanceClient{
+					MockRunInstances: func(ctx context.Context, input *awsec2.RunInstancesInput, opts []func(*awsec2.Options)) (*awsec2.RunInstancesOutput, error) {
+						return &awsec2.RunInstancesOutput{
+							Instances: []types.Instance{
+								{
+									InstanceId: &instanceID,
+								},
+							},
+						}, nil
+					},
+					MockCreateTags: func(ctx context.Context, input *awsec2.CreateTagsInput, opts []func(*awsec2.Options)) (*awsec2.CreateTagsOutput, error) {
+						// This function should NOT be called if no tags are provided
+						t.Errorf("CreateTags was called but should not have been")
+						return nil, errors.New("CreateTags should not be called")
+					},
+				},
+				cr: instance(withSpec(manualv1alpha1.InstanceParameters{})),
+			},
+			want: want{
+				cr:     instance(withExternalName(instanceID), withSpec(manualv1alpha1.InstanceParameters{})),
+				result: managed.ExternalCreation{},
+			},
+		},
 		"CreateFail": {
 			args: args{
 				instance: &fake.MockInstanceClient{


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue in the EC2 instance controller where an empty tag list causes the `CreateTags` API call to fail, preventing the instance’s external name from being set. 

Currently, `Create` always attempts to call `CreateTags`, even when no tags are provided. However, AWS rejects `CreateTags` with an empty tag list, returning an `InvalidParameterValue`.
Since this error occurs before `SetExternalName` is called, the Crossplane reconciliation loop fails to detect that the instance was already created and keeps creating new instances in an infinite loop.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have added a SuccessfulWithNoTags test to explicitly check that CreateTags is not called when no tags are provided.
