### PR TITLE
fix(ec2): Partial revert of 138b8cf to fix issue crossplane-contrib#2196

### DIFF
--- a/pkg/clients/ec2/routetable.go
+++ b/pkg/clients/ec2/routetable.go
@@ -160,7 +160,7 @@ func CreateRTPatch(in ec2types.RouteTable, target v1beta1.RouteTableParameters) 
 	targetCopy := target.DeepCopy()
 	currentParams := &v1beta1.RouteTableParameters{}
 
-	CompareTags(target.Tags, in.Tags)
+	SortTagsV1Beta1(targetCopy.Tags, in.Tags)
 
 	if !pointer.BoolValue(target.IgnoreRoutes) {
 		// Add the default route for fair comparison.

--- a/pkg/clients/ec2/routetable_test.go
+++ b/pkg/clients/ec2/routetable_test.go
@@ -12,11 +12,15 @@ import (
 )
 
 var (
-	rtVPC      = "some vpc"
-	otherRtVPC = "some other vpc"
-	rtID       = "some RT Id"
-	rtSubnetID = "some subnet"
-	rtOwner    = "some owner"
+	rtVPC           = "some vpc"
+	otherRtVPC      = "some other vpc"
+	rtID            = "some RT Id"
+	rtSubnetID      = "some subnet"
+	rtOwner         = "some owner"
+	rtTagName       = "tag1"
+	rtTagValue      = "value1"
+	otherRtTagName  = "tag2"
+	otherRtTagValue = "value2"
 )
 
 func specAssociations() []v1beta1.Association {
@@ -158,6 +162,23 @@ func TestCreateRTPatch(t *testing.T) {
 				patch: &v1beta1.RouteTableParameters{
 					VPCID: aws.String(otherRtVPC),
 				},
+			},
+		},
+		"DifferentTagOrder": {
+			args: args{
+				rt: ec2types.RouteTable{
+					Tags:         []ec2types.Tag{{Key: &rtTagName, Value: &rtTagValue}, {Key: &otherRtTagName, Value: &otherRtTagValue}},
+					Associations: rtAssociations(),
+					VpcId:        aws.String(rtVPC),
+				},
+				p: &v1beta1.RouteTableParameters{
+					Tags:         []v1beta1.Tag{{Key: otherRtTagName, Value: otherRtTagValue}, {Key: rtTagName, Value: rtTagValue}},
+					Associations: specAssociations(),
+					VPCID:        aws.String(vpcID),
+				},
+			},
+			want: want{
+				patch: &v1beta1.RouteTableParameters{},
 			},
 		},
 	}

--- a/pkg/clients/ec2/tags_v1beta1.go
+++ b/pkg/clients/ec2/tags_v1beta1.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ec2
 
 import (
+	"sort"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
@@ -52,4 +54,15 @@ func CompareTags(spec []svcapitypes.Tag, current []ec2types.Tag) bool {
 	}
 	toAdd, toRemove := DiffEC2Tags(GenerateEC2TagsV1Beta1(spec), current)
 	return len(toAdd) == 0 && len(toRemove) == 0
+}
+
+// SortTags sorts array of v1beta1.Tag and ec2type.Tag on 'Key'
+func SortTagsV1Beta1(tags []svcapitypes.Tag, ec2Tags []ec2types.Tag) {
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i].Key < tags[j].Key
+	})
+
+	sort.Slice(ec2Tags, func(i, j int) bool {
+		return *ec2Tags[i].Key < *ec2Tags[j].Key
+	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR reverts partially reverts the changes of 138b8cf to not detect changes when only the order of the tags change between what is returned by AWS and what is being submitted on the `RouteTable` CR.

The revert of this change will avoid detecting order-related differences because the `SortTagsV1Beta1(targetCopy.Tags, in.Tags)` function changes the order of `targetCopy.Tags` and `in.Tags` by reference which enables a proper comparison afterwards in:
`jsonPatch, err := jsonpatch.CreateJSONPatch(*currentParams, targetCopy)`

The `currentParams.Tags` will have the same tag order of `in.Tags` from the `LateInitializeRT(currentParams, &in)`.

Note: the `CompareTags` added in 138b8cf is effectively doing nothing as the result is not being used and nothing is changed by reference.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2196

I have:

- [X] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Added new unit test that validates the different order of the tags will still return an empty patch result (test fails with current code).

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
