### PR TITLE
Remove default instance options that cause problems when using launch…

### DIFF
--- a/package/crds/ec2.aws.crossplane.io_instances.yaml
+++ b/package/crds/ec2.aws.crossplane.io_instances.yaml
@@ -604,9 +604,6 @@ spec:
 
                           Default: The default version for the launch template.
                         type: string
-                    required:
-                    - launchTemplateId
-                    - launchTemplateName
                     type: object
                   licenseSpecifications:
                     description: The Amazon Resource Name (ARN) of the license configuration
@@ -1221,7 +1218,6 @@ spec:
                     pattern: ^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
                     type: string
                 required:
-                - imageId
                 - region
                 type: object
               managementPolicies:


### PR DESCRIPTION
Fixes #1193 
1. When using launch template, the ImageId set in launchTemplate is ignored when setting the imageId required by the default instance resource. Therefore, the imageId needs to be removed from crd.
2. **crossplane can only use one of launchTemplateId and launchTemplateName,** but both are required in crd. Therefore, we need to remove the required of these two in crd to use it.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

# Example
```
---
apiVersion: ec2.aws.crossplane.io/v1beta1
kind: SecurityGroup
metadata:
  name: sample-cluster-sg
spec:
  deletionPolicy: Delete
  forProvider:
    region: ap-northeast-2
    vpcId: <change to Your VPC-ID>
    groupName: test-crossplane-security-group
    description: test-crossplane-security-group
    ingress:
    - ipProtocol: '-1'
      ipRanges:
      - cidrIp: 10.55.0.0/16
    egress:
    - ipProtocol: '-1'
      ipRanges:
      - cidrIp: 0.0.0.0/0
    tags:
    - key: managed-by
      value: crossplane
  providerConfigRef:
    name: default
---
apiVersion: ec2.aws.crossplane.io/v1alpha1
kind: LaunchTemplate
metadata:
  name: test-crossplane-obj
spec:
  deletionPolicy: Delete
  forProvider:
    launchTemplateName: test-crossplane-obj
    launchTemplateData:
      imageID: ami-0d5bb3742db8fc264
      instanceType: m7i-flex.large
      # echo 'Hello crossplane! > hello.txt'
      userData: SGVsbG8gY3Jvc3NwbGFuZSEgPiBoZWxsby50eHQK
    region: ap-northeast-2
    tags:
    - key: managed-by
      value: crossplane
  providerConfigRef:
    name: default
---
apiVersion: ec2.aws.crossplane.io/v1alpha1
kind: Instance
metadata:
  name: sample-instance
spec:
  deletionPolicy: Delete
  forProvider:
    region: ap-northeast-2
    securityGroupRefs:
    - name: sample-cluster-sg
    launchTemplate:
      launchTemplateName: test-crossplane-obj
    subnetId: subnet-02ccc64296fccbad7
  providerConfigRef:
    name: default
```

[contribution process]: https://git.io/fj2m9
