### PR TITLE
fix(rds): add port to status and connection details from either spec or aws default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   timeout: 30m
 
-  skip-files:
+  exclude-files:
   - "zz_generated\\..+\\.go$"
 
 output:
@@ -21,11 +21,14 @@ linters-settings:
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    #ignore: fmt:.*,io/ioutil:^Read.*
+    exclude-functions:
+    - fmt.*
+    - io/ioutil:^Read.*
 
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    shadow: false
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
@@ -112,7 +115,6 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
     - govet
     - gocyclo
     - gocritic
@@ -125,15 +127,14 @@ linters:
     - misspell
     - nakedret
     - nolintlint
+    - gosimple
+    - staticcheck
+    - unused
 
   disable:
     # These linters are all deprecated as of golangci-lint v1.49.0. We disable
     # them explicitly to avoid the linter logging deprecation warnings.
-    - deadcode
-    - varcheck
-    - scopelint
-    - structcheck
-    - interfacer
+    - megacheck
 
   presets:
     - bugs

--- a/apis/rds/generator-config.yaml
+++ b/apis/rds/generator-config.yaml
@@ -34,6 +34,11 @@ resources:
         from:
           operation: DescribeDBClusters
           path: DBClusters.KmsKeyId
+      Port:
+        is_read_only: true
+        from:
+          operation: DescribeDBClusters
+          path: DBClusters.Port    
   DBInstanceRoleAssociation:
     exceptions:
       errors:

--- a/apis/rds/v1alpha1/zz_db_cluster.go
+++ b/apis/rds/v1alpha1/zz_db_cluster.go
@@ -749,6 +749,8 @@ type DBClusterObservation struct {
 	//
 	// This setting is only for non-Aurora Multi-AZ DB clusters.
 	PerformanceInsightsEnabled *bool `json:"performanceInsightsEnabled,omitempty"`
+	// The port that the database engine is listening on.
+	Port *int64 `json:"port,omitempty"`
 	// Contains one or more identifiers of the read replicas associated with this
 	// DB cluster.
 	ReadReplicaIdentifiers []*string `json:"readReplicaIdentifiers,omitempty"`

--- a/apis/rds/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/rds/v1alpha1/zz_generated.deepcopy.go
@@ -1585,6 +1585,11 @@ func (in *DBClusterObservation) DeepCopyInto(out *DBClusterObservation) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Port != nil {
+		in, out := &in.Port, &out.Port
+		*out = new(int64)
+		**out = **in
+	}
 	if in.ReadReplicaIdentifiers != nil {
 		in, out := &in.ReadReplicaIdentifiers, &out.ReadReplicaIdentifiers
 		*out = make([]*string, len(*in))

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -1885,6 +1885,10 @@ spec:
 
                       This setting is only for non-Aurora Multi-AZ DB clusters.
                     type: boolean
+                  port:
+                    description: The port that the database engine is listening on.
+                    format: int64
+                    type: integer
                   readReplicaIdentifiers:
                     description: |-
                       Contains one or more identifiers of the read replicas associated with this

--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -108,6 +108,7 @@ func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, res
 	}
 
 	cr.Status.AtProvider.KMSKeyID = resp.DBClusters[0].KmsKeyId
+	cr.Status.AtProvider.Port = resp.DBClusters[0].Port
 
 	switch pointer.StringValue(resp.DBClusters[0].Status) {
 	case "available", "storage-optimization", "backing-up":
@@ -125,12 +126,8 @@ func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, res
 	obs.ConnectionDetails = managed.ConnectionDetails{
 		xpv1.ResourceCredentialsSecretEndpointKey: []byte(pointer.StringValue(cr.Status.AtProvider.Endpoint)),
 		xpv1.ResourceCredentialsSecretUserKey:     []byte(pointer.StringValue(cr.Spec.ForProvider.MasterUsername)),
-		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.Port), 10)),
+		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.FormatInt(pointer.Int64Value(cr.Status.AtProvider.Port), 10)),
 		"readerEndpoint":                          []byte(pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint)),
-	}
-
-	if pointer.Int64Value(cr.Spec.ForProvider.Port) > 0 {
-		obs.ConnectionDetails[xpv1.ResourceCredentialsSecretPortKey] = []byte(strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.Port), 10))
 	}
 
 	pw, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2175 

- writes the port to status and connection details, including when spec.forProvider.port is unset
- updates linter configuration for less warnings

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- new provider image -> dbclusters.rds with and without spec.forProvider.port

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
