### PR TITLE
fix(ecs): issue with empty network configuration parameter

### DIFF
--- a/examples/ecs/service.yaml
+++ b/examples/ecs/service.yaml
@@ -37,3 +37,41 @@ spec:
       name: example
   providerConfigRef:
     name: example
+---
+apiVersion: ecs.aws.crossplane.io/v1alpha1
+kind: Service
+metadata:
+  name: nginx-test-ecs
+  annotations:
+    task-definition-network-mode: awsvpc
+spec:
+  forProvider:
+    cluster: arn:aws:ecs:us-east-1:123456789:cluster/crossplane-ecs-controller-test
+    launchType: EC2
+    region: us-east-1
+    schedulingStrategy: DAEMON
+    networkConfiguration:
+      awsvpcConfiguration:
+        assignPublicIP: DISABLED
+        subnets: 
+        - subnet-06338caec7dcf
+        - subnet-02a8df89fdafa
+    taskDefinition: arn:aws:ecs:us-east-1:123456789:task-definition/nginx:3
+  providerConfigRef:
+    name: providerconfig-aws
+---
+apiVersion: ecs.aws.crossplane.io/v1alpha1
+kind: Service
+metadata:
+  name: filebeat-test
+  annotations:
+    task-definition-network-mode: host
+spec:
+  forProvider:
+    cluster: arn:aws:ecs:us-east-1:123456789:cluster/crossplane-ecs-controller-test
+    launchType: EC2
+    region: us-east-1
+    schedulingStrategy: DAEMON
+    taskDefinition: arn:aws:ecs:us-east-1:123456789:task-definition/pratyush-filebeat:1
+  providerConfigRef:
+    name: providerconfig-aws

--- a/pkg/controller/ecs/service/setup.go
+++ b/pkg/controller/ecs/service/setup.go
@@ -537,7 +537,7 @@ func generateNetworkConfiguration(cr *svcapitypes.Service) *svcsdk.NetworkConfig
 	networkConfiguration := &svcsdk.NetworkConfiguration{}
 
 	if cr.Spec.ForProvider.NetworkConfiguration == nil {
-		return networkConfiguration
+		return nil
 	}
 
 	if cr.Spec.ForProvider.NetworkConfiguration.AWSvpcConfiguration != nil {


### PR DESCRIPTION
### Description of your changes

When using host network mode users do not need to pass the network config , but the codes passes and empty object thus having issues creating a service with no network configuration , So when user is not passing any network configuration I removed if it is an empty object


Fixes #
This fixes https://github.com/crossplane-contrib/provider-aws/issues/2233

### How has this code been tested
Added in the new examples I used to test the code , service are getting created without the network configuration now 

[contribution process]: https://git.io/fj2m9
