### PR TITLE
fix(rds): DBCluster update logic

### DIFF
--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -2,6 +2,9 @@ package dbcluster
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,7 +21,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,19 +45,32 @@ const (
 	errUnknownRestoreFromSource = "unknown restoreFrom source"
 )
 
-type custom struct {
+type shared struct {
 	kube   client.Client
 	client svcsdkapi.RDSAPI
+	cache  *cache
+}
+
+type cache struct {
+	addTags                            []*svcsdk.Tag
+	removeTags                         []*string
+	desiredPassword                    string
+	passwordChanged                    bool
+	engineVersionChanged               bool
+	dbClusterParameterGroupNameChanged bool
+	backupRetentionPeriodChanged       bool
+	backupWindowChanged                bool
 }
 
 func setupExternal(e *external) {
-	h := &custom{client: e.client, kube: e.kube}
+	s := &shared{client: e.client, kube: e.kube, cache: &cache{}}
 	e.preObserve = preObserve
-	e.postObserve = h.postObserve
-	e.isUpToDate = h.isUpToDate
-	e.preUpdate = h.preUpdate
-	e.postUpdate = h.postUpdate
-	e.preCreate = h.preCreate
+	e.postObserve = s.postObserve
+	e.isUpToDate = s.isUpToDate
+	e.preUpdate = s.preUpdate
+	e.postUpdate = s.postUpdate
+	e.preCreate = s.preCreate
+	e.postCreate = s.postCreate
 	e.preDelete = preDelete
 	e.filterList = filterList
 }
@@ -97,11 +115,11 @@ func preObserve(_ context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.Descri
 	return nil
 }
 
-// This probably requires custom Conditions to be defined for handling all statuses
+// This probably requires shared Conditions to be defined for handling all statuses
 // described here https://docs.pointer.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Status.html
 // Need to get help from community on how to deal with this. Ideally the status should reflect
 // the true status value as described by the provider.
-func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClustersOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
+func (s *shared) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClustersOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -121,24 +139,12 @@ func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, res
 	default:
 		cr.SetConditions(xpv1.Unavailable().WithMessage("DB Cluster is " + pointer.StringValue(resp.DBClusters[0].Status)))
 	}
+	obs.ConnectionDetails, err = s.updateConnectionDetails(ctx, cr, obs.ConnectionDetails)
 
-	obs.ConnectionDetails = managed.ConnectionDetails{
-		xpv1.ResourceCredentialsSecretEndpointKey: []byte(pointer.StringValue(cr.Status.AtProvider.Endpoint)),
-		xpv1.ResourceCredentialsSecretUserKey:     []byte(pointer.StringValue(cr.Spec.ForProvider.MasterUsername)),
-		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.FormatInt(pointer.Int64Value(cr.Status.AtProvider.Port), 10)),
-		"readerEndpoint":                          []byte(pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint)),
-	}
-
-	pw, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
-	if err != nil {
-		return obs, errors.Wrap(err, dbinstance.ErrGetCachedPassword)
-	}
-	obs.ConnectionDetails[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(pw)
-
-	return obs, nil
+	return obs, err
 }
 
-func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.CreateDBClusterInput) (err error) { //nolint:gocyclo
+func (s *shared) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.CreateDBClusterInput) (err error) { //nolint:gocyclo
 	restoreFrom := cr.Spec.ForProvider.RestoreFrom
 	autogenerate := cr.Spec.ForProvider.AutogeneratePassword
 	masterUserPasswordSecretRef := cr.Spec.ForProvider.MasterUserPasswordSecretRef
@@ -151,7 +157,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 		pw, err = password.Generate()
 	case masterUserPasswordSecretRef != nil && autogenerate,
 		masterUserPasswordSecretRef != nil && !autogenerate:
-		pw, err = dbinstance.GetSecretValue(ctx, e.kube, masterUserPasswordSecretRef)
+		pw, err = dbinstance.GetSecretValue(ctx, s.kube, masterUserPasswordSecretRef)
 	}
 	if err != nil {
 		return errors.Wrap(err, dbinstance.ErrNoRetrievePasswordOrGenerate)
@@ -175,7 +181,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 			input.DBClusterIdentifier = obj.DBClusterIdentifier
 			input.VpcSecurityGroupIds = obj.VpcSecurityGroupIds
 
-			if _, err = e.client.RestoreDBClusterFromS3WithContext(ctx, input); err != nil {
+			if _, err = s.client.RestoreDBClusterFromS3WithContext(ctx, input); err != nil {
 				return errors.Wrap(err, errRestore)
 			}
 		case "Snapshot":
@@ -183,7 +189,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 			input.DBClusterIdentifier = obj.DBClusterIdentifier
 			input.VpcSecurityGroupIds = obj.VpcSecurityGroupIds
 
-			if _, err = e.client.RestoreDBClusterFromSnapshotWithContext(ctx, input); err != nil {
+			if _, err = s.client.RestoreDBClusterFromSnapshotWithContext(ctx, input); err != nil {
 				return errors.Wrap(err, errRestore)
 			}
 		case "PointInTime":
@@ -191,7 +197,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 			input.DBClusterIdentifier = obj.DBClusterIdentifier
 			input.VpcSecurityGroupIds = obj.VpcSecurityGroupIds
 
-			if _, err = e.client.RestoreDBClusterToPointInTimeWithContext(ctx, input); err != nil {
+			if _, err = s.client.RestoreDBClusterToPointInTimeWithContext(ctx, input); err != nil {
 				return errors.Wrap(err, errRestore)
 			}
 		default:
@@ -201,10 +207,19 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 
 	obj.EngineVersion = cr.Spec.ForProvider.EngineVersion
 
-	if _, err = dbinstance.Cache(ctx, e.kube, cr, passwordRestoreInfo); err != nil {
+	if _, err = dbinstance.Cache(ctx, s.kube, cr, passwordRestoreInfo); err != nil {
 		return errors.Wrap(err, dbinstance.ErrCachePassword)
 	}
 	return nil
+}
+
+func (s *shared) postCreate(ctx context.Context, cr *svcapitypes.DBCluster, _ *svcsdk.CreateDBClusterOutput, extCreation managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+	cd, err := s.updateConnectionDetails(ctx, cr, managed.ConnectionDetails{})
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+	extCreation.ConnectionDetails = cd
+	return extCreation, nil
 }
 
 func generateRestoreDBClusterFromS3Input(cr *svcapitypes.DBCluster) *svcsdk.RestoreDBClusterFromS3Input { //nolint:gocyclo
@@ -557,32 +572,57 @@ func generateRestoreDBClusterToPointInTimeInput(cr *svcapitypes.DBCluster) *svcs
 	return res
 }
 
-func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out *svcsdk.DescribeDBClustersOutput) (bool, string, error) { //nolint:gocyclo
-	current := GenerateDBCluster(out)
+func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out *svcsdk.DescribeDBClustersOutput) (bool, string, error) { //nolint:gocyclo
+	// If ApplyImmediately is not true we update observed state of db cluster with pending modified values to prevent redundant updates
+	if !ptr.Deref(cr.Spec.ForProvider.ApplyImmediately, false) {
+		utils.SetPmvDBCluster(out)
+	}
+	observed := GenerateDBCluster(out)
 
 	status := pointer.StringValue(out.DBClusters[0].Status)
 	if status == "modifying" || status == "upgrading" || status == "configuring-iam-database-auth" || status == "migrating" || status == "prepairing-data-migration" || status == "creating" {
 		return true, "", nil
 	}
 
-	passwordUpToDate, _, err := dbinstance.PasswordUpToDate(ctx, e.kube, cr)
+	passwordUpToDate, desiredPassword, err := dbinstance.PasswordUpToDate(ctx, s.kube, cr)
 	if err != nil {
 		return false, "", errors.Wrap(err, dbinstance.ErrNoPasswordUpToDate)
 	}
-	if !passwordUpToDate {
-		return false, "", nil
+	s.cache.desiredPassword = desiredPassword
+	s.cache.passwordChanged = !passwordUpToDate
+
+	patch, err := createPatch(&observed.Spec.ForProvider, &cr.Spec.ForProvider)
+	if err != nil {
+		return false, "", err
+	}
+	diff := cmp.Diff(&svcapitypes.DBClusterParameters{}, patch, cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "AllowMajorVersionUpgrade"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "BacktrackWindow"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "BackupRetentionPeriod"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "DBSubnetGroupName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "DBClusterParameterGroupName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnableCloudwatchLogsExports"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EngineVersion"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "FinalDBSnapshotIdentifier"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "MasterUserPasswordSecretRef"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "ScalingConfiguration"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "SkipFinalSnapshot"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "StorageType"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "OptionGroupName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "PreferredBackupWindow"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "Region"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "Tags"),
+		cmpopts.IgnoreTypes(svcapitypes.CustomDBClusterParameters{}),
+	)
+
+	if s.cache.passwordChanged {
+		diff += "\nmaster user password changed"
 	}
 
-	if pointer.BoolValue(cr.Spec.ForProvider.EnableIAMDatabaseAuthentication) != pointer.BoolValue(out.DBClusters[0].IAMDatabaseAuthenticationEnabled) {
-		return false, "", nil
-	}
-
-	if !isPreferredMaintenanceWindowUpToDate(cr, out) {
-		return false, "", nil
-	}
-
-	if !isPreferredBackupWindowUpToDate(cr, out) {
-		return false, "", nil
+	s.cache.backupWindowChanged = !isPreferredBackupWindowUpToDate(cr, out)
+	if s.cache.backupWindowChanged {
+		diff += "\ndesired preferredBackupWindow: " + pointer.StringValue(cr.Spec.ForProvider.PreferredBackupWindow) +
+			", observed preferredBackupWindow: " + pointer.StringValue(out.DBClusters[0].PreferredBackupWindow)
 	}
 
 	if pointer.Int64Value(cr.Spec.ForProvider.BacktrackWindow) != pointer.Int64Value(out.DBClusters[0].BacktrackWindow) {
@@ -590,49 +630,55 @@ func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out 
 	}
 
 	if !isStorageTypeUpToDate(cr, out) {
-		return false, "", nil
+		diff += "\ndesired storageType: " + pointer.StringValue(cr.Spec.ForProvider.StorageType) +
+			", observed storageType: " + pointer.StringValue(out.DBClusters[0].StorageType)
 	}
 
-	if !isBackupRetentionPeriodUpToDate(cr, out) {
-		return false, "", nil
-	}
-
-	if pointer.BoolValue(cr.Spec.ForProvider.CopyTagsToSnapshot) != pointer.BoolValue(out.DBClusters[0].CopyTagsToSnapshot) {
-		return false, "", nil
-	}
-
-	if pointer.BoolValue(cr.Spec.ForProvider.DeletionProtection) != pointer.BoolValue(out.DBClusters[0].DeletionProtection) {
-		return false, "", nil
-	}
-
-	if !isEngineVersionUpToDate(cr, out) {
-		return false, "", nil
+	s.cache.backupRetentionPeriodChanged = !isBackupRetentionPeriodUpToDate(cr, out)
+	if s.cache.backupRetentionPeriodChanged {
+		diff += "\ndesired backupRetentionPeriod: " + strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.BackupRetentionPeriod), 10) +
+			", observed backupRetentionPeriod: " + strconv.FormatInt(pointer.Int64Value(out.DBClusters[0].BackupRetentionPeriod), 10)
 	}
 
 	if !isPortUpToDate(cr, out) {
-		return false, "", nil
+		diff += "\ndesired port: " + strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.Port), 10) +
+			", observed port: " + strconv.FormatInt(pointer.Int64Value(out.DBClusters[0].Port), 10)
+	}
+
+	s.cache.engineVersionChanged = !isEngineVersionUpToDate(cr, out)
+	if s.cache.engineVersionChanged {
+		if ptr.Deref(cr.Spec.ForProvider.EngineVersion, "") == ptr.Deref(out.DBClusters[0].EngineVersion, "") && out.DBClusters[0].PendingModifiedValues != nil && ptr.Deref(out.DBClusters[0].PendingModifiedValues.EngineVersion, "") != "" {
+			diff += fmt.Sprintf("\ndesired engineVersion: %s \npending modified engineVersion: %s ", pointer.StringValue(cr.Spec.ForProvider.EngineVersion), pointer.StringValue(out.DBClusters[0].PendingModifiedValues.EngineVersion))
+		} else {
+			diff += fmt.Sprintf("\ndesired engineVersion: %s \nobserved engineVersion: %s ", pointer.StringValue(cr.Spec.ForProvider.EngineVersion), pointer.StringValue(out.DBClusters[0].EngineVersion))
+		}
 	}
 
 	if !areVPCSecurityGroupIDsUpToDate(cr, out) {
-		return false, "", nil
+		observedIDs := make([]string, 0, len(cr.Spec.ForProvider.VPCSecurityGroupIDs))
+		for _, grp := range out.DBClusters[0].VpcSecurityGroups {
+			observedIDs = append(observedIDs, *grp.VpcSecurityGroupId)
+		}
+		diff += "\ndesired vpcSecurityGroupIDs: " + strings.Join(cr.Spec.ForProvider.VPCSecurityGroupIDs, ",") +
+			", observed vpcSecurityGroupIDs: " + strings.Join(observedIDs, ",")
 	}
 
 	if !areSameElements(cr.Spec.ForProvider.EnableCloudwatchLogsExports, out.DBClusters[0].EnabledCloudwatchLogsExports) {
-		return false, "", nil
+		diff += "\n enabledCloudwatchLogsExports changed"
 	}
 
-	if cr.Spec.ForProvider.DBClusterParameterGroupName != nil &&
-		pointer.StringValue(cr.Spec.ForProvider.DBClusterParameterGroupName) != pointer.StringValue(out.DBClusters[0].DBClusterParameterGroup) {
-		return false, "", nil
+	s.cache.dbClusterParameterGroupNameChanged = !isDBClusterParameterGroupNameUpToDate(cr, out)
+	if s.cache.dbClusterParameterGroupNameChanged {
+		diff += "\ndesired dbClusterParameterGroupName: " + pointer.StringValue(cr.Spec.ForProvider.DBClusterParameterGroupName) +
+			", observed dbClusterParameterGroupName: " + pointer.StringValue(out.DBClusters[0].DBClusterParameterGroup)
 	}
 
 	isScalingConfigurationUpToDate, err := isScalingConfigurationUpToDate(cr.Spec.ForProvider.ScalingConfiguration, out.DBClusters[0].ScalingConfigurationInfo)
-	if !isScalingConfigurationUpToDate {
-		return false, "", err
+	if err != nil {
+		return false, "", errors.Wrap(err, "failed to compare scaling configuration")
 	}
-
-	if diff := cmp.Diff(cr.Spec.ForProvider.ServerlessV2ScalingConfiguration, current.Spec.ForProvider.ServerlessV2ScalingConfiguration); diff != "" {
-		return false, "ServerlessV2ScalingConfiguration: " + diff, nil
+	if !isScalingConfigurationUpToDate {
+		diff += "\nscalingConfiguration changed"
 	}
 
 	// Build ignore rules: implicit aws:* + user supplied rules
@@ -651,10 +697,18 @@ func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out 
 			observedTags = append(observedTags, &svcsdk.Tag{Key: tag.Key, Value: tag.Value})
 		}
 	}
-	add, remove := DiffTags(cr.Spec.ForProvider.Tags, observedTags)
-	if len(add) > 0 || len(remove) > 0 {
-		return false, "", nil
+	s.cache.addTags, s.cache.removeTags = utils.DiffTags(cr.Spec.ForProvider.Tags, observedTags)
+	tagsChanged := len(s.cache.addTags) != 0 || len(s.cache.removeTags) != 0
+	if tagsChanged {
+		diff += fmt.Sprintf("\nadd %d tag(s) and remove %d tag(s)", len(s.cache.addTags), len(s.cache.removeTags))
 	}
+
+	if diff != "" {
+		diff = "Found observed differences in dbCluster\n" + diff
+		log.Println(diff)
+		return false, diff, nil
+	}
+
 	return true, "", nil
 }
 
@@ -736,9 +790,24 @@ func isEngineVersionUpToDate(cr *svcapitypes.DBCluster, out *svcsdk.DescribeDBCl
 			return false
 		}
 
+		desiredEngineVersion := ptr.Deref(cr.Spec.ForProvider.EngineVersion, "")
+		observedEngineVersion := ptr.Deref(out.DBClusters[0].EngineVersion, "")
+		pendingEngineVersion := ""
+		if out.DBClusters[0].PendingModifiedValues != nil {
+			pendingEngineVersion = ptr.Deref(out.DBClusters[0].PendingModifiedValues.EngineVersion, "")
+		}
+		// If the desired version matches the current version and pending version is set means an upgrade should be reverted
+		// so controller should send an update request with the current version again to cancel the pending upgrade
+		if desiredEngineVersion == observedEngineVersion && pendingEngineVersion != "" {
+			return false
+		}
+		// If ApplyImmediately is false and there is a pending version, consider that as the current version for comparison
+		if !ptr.Deref(cr.Spec.ForProvider.ApplyImmediately, false) && pendingEngineVersion != "" {
+			observedEngineVersion = pendingEngineVersion
+		}
 		// Upgrade is only necessary if the spec version is higher.
 		// Downgrades are not possible in pointer.
-		c := utils.CompareEngineVersions(*cr.Spec.ForProvider.EngineVersion, *out.DBClusters[0].EngineVersion)
+		c := utils.CompareEngineVersions(*cr.Spec.ForProvider.EngineVersion, observedEngineVersion)
 		return c <= 0
 	}
 	return true
@@ -793,19 +862,18 @@ func areVPCSecurityGroupIDsUpToDate(cr *svcapitypes.DBCluster, out *svcsdk.Descr
 	return cmp.Equal(desiredIDs, actualIDs)
 }
 
-func (e *custom) preUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterInput) error {
+func (s *shared) preUpdate(_ context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterInput) error {
 	obj.DBClusterIdentifier = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
 	obj.ApplyImmediately = cr.Spec.ForProvider.ApplyImmediately
 
 	obj.CloudwatchLogsExportConfiguration = generateCloudWatchExportConfiguration(
 		cr.Spec.ForProvider.EnableCloudwatchLogsExports,
 		cr.Status.AtProvider.EnabledCloudwatchLogsExports)
-
-	desiredPassword, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
-	if err != nil {
-		return errors.Wrap(err, dbinstance.ErrRetrievePasswordForUpdate)
+	// Only set MasterUserPassword if it has changed, otherwise it triggers "Resetting master password" on aws side,
+	// it happens because aws doesn't know current password, so any set causes a change.
+	if s.cache.passwordChanged {
+		obj.MasterUserPassword = pointer.ToOrNilIfZeroValue(s.cache.desiredPassword)
 	}
-	obj.MasterUserPassword = pointer.ToOrNilIfZeroValue(desiredPassword)
 
 	if cr.Spec.ForProvider.VPCSecurityGroupIDs != nil {
 		obj.VpcSecurityGroupIds = make([]*string, len(cr.Spec.ForProvider.VPCSecurityGroupIDs))
@@ -820,36 +888,33 @@ func (e *custom) preUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 	// therefore EngineVersion update is entirely done separately in postUpdate
 	// Note: strangely ModifyDBInstance does not seem to behave this way
 	obj.EngineVersion = nil
-	// In case of a custom DBClusterParameterGroup, AWS requires for a major version update that
+	// In case of a shared DBClusterParameterGroup, AWS requires for a major version update that
 	// EngineVersion and DBClusterParameterGroupName are in the same ModifyDBCluster()-call
 	obj.DBClusterParameterGroupName = nil
 
 	// AWS Backup takes ownership of BackupRetentionPeriod and PreferredBackupWindow if it is in use.
 	// So we need to check there is no associated RecoveryPoint, before trying to update these fields.
-	// Therefore we only add some in postUpdate, where we have the DescribeDBClustersOutput available.
-	obj.BackupRetentionPeriod = nil
+	// Therefore we only set these fields in the ModifyDBInstanceInput if they are changed and not in use by AWS Backup.
 	obj.PreferredBackupWindow = nil
+	obj.BackupRetentionPeriod = nil
 
 	return nil
 }
 
 //nolint:gocyclo
-func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterOutput, upd managed.ExternalUpdate, err error) (managed.ExternalUpdate, error) {
+func (s *shared) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterOutput, upd managed.ExternalUpdate, err error) (managed.ExternalUpdate, error) {
 	if err != nil {
 		return upd, err
 	}
 
-	desiredPassword, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
-	if err != nil {
-		return upd, errors.Wrap(err, dbinstance.ErrRetrievePasswordForUpdate)
-	}
-
-	_, err = dbinstance.Cache(ctx, e.kube, cr, map[string]string{
-		dbinstance.PasswordCacheKey:    desiredPassword,
-		dbinstance.RestoreFlagCacheKay: "", // reset restore flag
-	})
-	if err != nil {
-		return upd, errors.Wrap(err, dbinstance.ErrCachePassword)
+	if s.cache.passwordChanged {
+		_, err = dbinstance.Cache(ctx, s.kube, cr, map[string]string{
+			dbinstance.PasswordCacheKey:    s.cache.desiredPassword,
+			dbinstance.RestoreFlagCacheKay: "", // reset restore flag
+		})
+		if err != nil {
+			return upd, errors.Wrap(err, dbinstance.ErrCachePassword)
+		}
 	}
 
 	input := GenerateDescribeDBClustersInput(cr)
@@ -857,16 +922,12 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj 
 	// and the function is generated by ack-generate, so we manually need to set the
 	// DBClusterIdentifier
 	input.DBClusterIdentifier = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
-	resp, err := e.client.DescribeDBClustersWithContext(ctx, input)
+	resp, err := s.client.DescribeDBClustersWithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalUpdate{}, errorutils.Wrap(cpresource.Ignore(IsNotFound, err), errDescribe)
 	}
 
-	needsEngineVersionUpdate := !isEngineVersionUpToDate(cr, resp)
-	needsDBClusterParamGroupUpdate := !isDBClusterParameterGroupNameUpToDate(cr, resp)
-	needsPreferredBackupWindowUpdate := !isPreferredBackupWindowUpToDate(cr, resp)
-	needsBackupRetentionPeriodUpdate := !isBackupRetentionPeriodUpToDate(cr, resp)
-	needsPostUpdate := needsEngineVersionUpdate || needsDBClusterParamGroupUpdate || needsPreferredBackupWindowUpdate || needsBackupRetentionPeriodUpdate
+	needsPostUpdate := s.cache.engineVersionChanged || s.cache.dbClusterParameterGroupNameChanged || s.cache.backupWindowChanged || s.cache.backupRetentionPeriodChanged
 
 	if needsPostUpdate {
 		modifyInput := &svcsdk.ModifyDBClusterInput{
@@ -874,39 +935,24 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj 
 			ApplyImmediately:            cr.Spec.ForProvider.ApplyImmediately,
 			DBClusterParameterGroupName: cr.Spec.ForProvider.DBClusterParameterGroupName,
 		}
-		if needsEngineVersionUpdate {
+		if s.cache.engineVersionChanged {
 			modifyInput.EngineVersion = cr.Spec.ForProvider.EngineVersion
 			modifyInput.AllowMajorVersionUpgrade = cr.Spec.ForProvider.AllowMajorVersionUpgrade
 		}
-		if needsPreferredBackupWindowUpdate {
+		if s.cache.backupWindowChanged {
 			modifyInput.PreferredBackupWindow = cr.Spec.ForProvider.PreferredBackupWindow
 		}
-		if needsBackupRetentionPeriodUpdate {
+		if s.cache.backupRetentionPeriodChanged {
 			modifyInput.BackupRetentionPeriod = cr.Spec.ForProvider.BackupRetentionPeriod
 		}
 
-		if _, err = e.client.ModifyDBClusterWithContext(ctx, modifyInput); err != nil {
+		if _, err = s.client.ModifyDBClusterWithContext(ctx, modifyInput); err != nil {
 			return managed.ExternalUpdate{}, err
 		}
 	}
 
-	tags := resp.DBClusters[0].TagList
-	// Filter tags using the same ignore rules as isUpToDate
-	updateIgnore := []string{"aws:*"}
-	for _, r := range cr.Spec.ForProvider.TagsIgnore {
-		updateIgnore = append(updateIgnore, r.Key)
-	}
-	filteredTags := make([]*svcsdk.Tag, 0, len(tags))
-	for _, tag := range tags {
-		if utils.ShouldIgnore(pointer.StringValue(tag.Key), updateIgnore) {
-			continue
-		}
-		filteredTags = append(filteredTags, tag)
-	}
-	add, remove := DiffTags(cr.Spec.ForProvider.Tags, filteredTags)
-
-	if len(add) > 0 || len(remove) > 0 {
-		err := e.updateTags(ctx, cr, add, remove)
+	if len(s.cache.addTags) > 0 || len(s.cache.removeTags) > 0 {
+		err := s.updateTags(ctx, cr, s.cache.addTags, s.cache.removeTags)
 		if err != nil {
 			return managed.ExternalUpdate{}, err
 		}
@@ -931,12 +977,12 @@ func preDelete(_ context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.DeleteD
 	return false, nil
 }
 
-func (e *custom) postDelete(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.DeleteDBClusterOutput, err error) (managed.ExternalDelete, error) {
+func (s *shared) postDelete(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.DeleteDBClusterOutput, err error) (managed.ExternalDelete, error) {
 	if err != nil {
 		return managed.ExternalDelete{}, err
 	}
 
-	return managed.ExternalDelete{}, dbinstance.DeleteCache(ctx, e.kube, cr)
+	return managed.ExternalDelete{}, dbinstance.DeleteCache(ctx, s.kube, cr)
 }
 
 func filterList(cr *svcapitypes.DBCluster, obj *svcsdk.DescribeDBClustersOutput) *svcsdk.DescribeDBClustersOutput {
@@ -951,30 +997,7 @@ func filterList(cr *svcapitypes.DBCluster, obj *svcsdk.DescribeDBClustersOutput)
 	return resp
 }
 
-// DiffTags returns tags that should be added or removed.
-func DiffTags(spec []*svcapitypes.Tag, current []*svcsdk.Tag) (addTags []*svcsdk.Tag, remove []*string) {
-	addMap := make(map[string]string, len(spec))
-	for _, t := range spec {
-		addMap[pointer.StringValue(t.Key)] = pointer.StringValue(t.Value)
-	}
-	removeMap := make(map[string]string, len(spec))
-	for _, t := range current {
-		if addMap[pointer.StringValue(t.Key)] == pointer.StringValue(t.Value) {
-			delete(addMap, pointer.StringValue(t.Key))
-			continue
-		}
-		removeMap[pointer.StringValue(t.Key)] = pointer.StringValue(t.Value)
-	}
-	for k, v := range addMap {
-		addTags = append(addTags, &svcsdk.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
-	}
-	for k := range removeMap {
-		remove = append(remove, pointer.ToOrNilIfZeroValue(k))
-	}
-	return
-}
-
-func (e *custom) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addTags []*svcsdk.Tag, removeTags []*string) error {
+func (s *shared) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addTags []*svcsdk.Tag, removeTags []*string) error {
 
 	arn := cr.Status.AtProvider.DBClusterARN
 	if arn != nil {
@@ -984,7 +1007,7 @@ func (e *custom) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addT
 				TagKeys:      removeTags,
 			}
 
-			_, err := e.client.RemoveTagsFromResourceWithContext(ctx, inputR)
+			_, err := s.client.RemoveTagsFromResourceWithContext(ctx, inputR)
 			if err != nil {
 				return errors.New(errUpdateTags)
 			}
@@ -995,7 +1018,7 @@ func (e *custom) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addT
 				Tags:         addTags,
 			}
 
-			_, err := e.client.AddTagsToResourceWithContext(ctx, inputC)
+			_, err := s.client.AddTagsToResourceWithContext(ctx, inputC)
 			if err != nil {
 				return errors.New(errUpdateTags)
 			}
@@ -1055,4 +1078,47 @@ func areSameElements(a1, a2 []*string) bool {
 	}
 
 	return true
+}
+func (s *shared) updateConnectionDetails(ctx context.Context, cr *svcapitypes.DBCluster, details managed.ConnectionDetails) (managed.ConnectionDetails, error) {
+	if details == nil {
+		details = managed.ConnectionDetails{}
+	}
+
+	details[xpv1.ResourceCredentialsSecretUserKey] = []byte(pointer.StringValue(cr.Spec.ForProvider.MasterUsername))
+	password := s.cache.desiredPassword
+	if password == "" {
+		pw, err := dbinstance.GetDesiredPassword(ctx, s.kube, cr)
+		if err != nil {
+			return details, errors.Wrap(err, dbinstance.ErrGetCachedPassword)
+		}
+		password = pw
+	}
+	details[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(password)
+
+	if cr.Status.AtProvider.Endpoint == nil {
+		return details, nil
+	}
+	if pointer.StringValue(cr.Status.AtProvider.Endpoint) != "" {
+		details[xpv1.ResourceCredentialsSecretEndpointKey] = []byte(pointer.StringValue(cr.Status.AtProvider.Endpoint))
+	}
+	if pointer.Int64Value(cr.Status.AtProvider.Port) > 0 {
+		details[xpv1.ResourceCredentialsSecretPortKey] = []byte(strconv.FormatInt(*cr.Status.AtProvider.Port, 10))
+	}
+	if pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint) != "" {
+		details["readerEndpoint"] = []byte(pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint))
+	}
+
+	return details, nil
+}
+
+func createPatch(observed *svcapitypes.DBClusterParameters, desired *svcapitypes.DBClusterParameters) (*svcapitypes.DBClusterParameters, error) {
+	jsonPatch, err := jsonpatch.CreateJSONPatch(observed, desired)
+	if err != nil {
+		return nil, err
+	}
+	patch := &svcapitypes.DBClusterParameters{}
+	if err := json.Unmarshal(jsonPatch, patch); err != nil {
+		return nil, err
+	}
+	return patch, nil
 }

--- a/pkg/controller/rds/dbcluster/setup_test.go
+++ b/pkg/controller/rds/dbcluster/setup_test.go
@@ -3,16 +3,51 @@ package dbcluster
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"testing"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/rds/v1alpha1"
+	rds "github.com/crossplane-contrib/provider-aws/pkg/clients/rds"
 )
+
+type objectFnCustom func(obj client.Object, diff bool) error
+
+// NewMockGetFn returns a MockGetFn that returns the supplied error.
+func newMockGetFnCustomWithDiff(diff bool, err error, ofn []objectFnCustom) test.MockGetFn {
+	return func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+		for _, fn := range ofn {
+			if err := fn(obj, diff); err != nil {
+				return err
+			}
+		}
+		return err
+	}
+}
+func mockGettingSecretData(obj client.Object, diff bool) error {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return errors.New("the mock function only supports secret objects")
+	}
+	secret.Data = map[string][]byte{
+		rds.PasswordCacheKey:    []byte("cachedPassword"),
+		rds.RestoreFlagCacheKay: []byte(""),
+	}
+	if diff {
+		secret.Data[xpv1.ResourceCredentialsSecretPasswordKey] = []byte("differentPassword")
+	} else {
+		secret.Data[xpv1.ResourceCredentialsSecretPasswordKey] = []byte("cachedPassword")
+
+	}
+	return nil
+}
 
 func TestIsVPCSecurityGroupIDsUpToDate(t *testing.T) {
 	type args struct {
@@ -913,6 +948,932 @@ func TestIsUpToDate(t *testing.T) {
 				isUpToDate: false,
 			},
 		},
+		"ChangedMasterPassword": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("16"),
+								MasterUserPasswordSecretRef: &xpv1.SecretKeySelector{
+									SecretReference: xpv1.SecretReference{
+										Name:      "masterUserPassword",
+										Namespace: "default",
+									},
+									Key: "password",
+								},
+							},
+							Region: "eu-central-2",
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("16"),
+						},
+					},
+				},
+				kube: &test.MockClient{
+					// This mock returns different passwords from masterUserPasswordSecretRef and cached secret
+					MockGet: newMockGetFnCustomWithDiff(true, nil, []objectFnCustom{mockGettingSecretData}),
+				},
+			},
+			want: want{
+				isUpToDate: false,
+			},
+		},
+		"UpToDatePendingModifiedValue": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("gp2"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("gp3"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								StorageType: ptr.To("gp2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"IsNoTUpToDatePendingModifiedValue": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("gp2"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("io1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								StorageType: ptr.To("gp3"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IsNoTUpToDatePendingModifiedValueApplyImmediately": { // The parameter is already scheduled to be updated, but we want to update it immediately
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							BackupRetentionPeriod: ptr.To(int64(21)),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								ApplyImmediately: ptr.To(true),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							BackupRetentionPeriod: ptr.To(int64(7)),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								BackupRetentionPeriod: ptr.To(int64(21)),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"UpToDatePendingModifiedValueEngineVersion": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"IsNotUpToDatePendingModifiedValueEngineVersion": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("15.3"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IsNotUpToDatePendingModifiedValueEngineVersionRevert": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("15.1"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IsNotUpToDatePendingModifiedValueEngineVersionApplyImmediately": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								ApplyImmediately: ptr.To(true),
+								EngineVersion:    ptr.To("15.3"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.3"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"DifferentIAMDatabaseAuthenticationEnabled": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							EnableIAMDatabaseAuthentication: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							IAMDatabaseAuthenticationEnabled: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IAMDatabaseAuthenticationEnabledNotMapped": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                           ptr.To("aurora-postgresql"),
+							IAMDatabaseAuthenticationEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentPubliclyAccessible": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							PubliclyAccessible: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							PubliclyAccessible: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SamePubliclyAccessible": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							PubliclyAccessible: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							PubliclyAccessible: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentStorageEncrypted": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageEncrypted: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageEncrypted: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameStorageEncrypted": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageEncrypted: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageEncrypted: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentAutoMinorVersionUpgrade": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							AutoMinorVersionUpgrade: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameAutoMinorVersionUpgrade": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentEnablePerformanceInsights": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("mysql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"SameEnablePerformanceInsights": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("mysql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// Port tests (integer parameter)
+		"DifferentPort": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Port: ptr.To(int64(3307)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SamePort": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"PortNotSet": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Port: nil,
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// StorageType tests
+		"DifferentStorageType": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("aurora-iopt1"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("aurora"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameStorageType": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("aurora-iopt1"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("aurora-iopt1"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"StorageTypeAuroraDefault": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("aurora"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To(""),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentCopyTagsToSnapshot": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:             ptr.To("aurora-mysql"),
+							CopyTagsToSnapshot: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:             ptr.To("aurora-mysql"),
+							CopyTagsToSnapshot: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameCopyTagsToSnapshot": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							CopyTagsToSnapshot: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							CopyTagsToSnapshot: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// DeletionProtection tests
+		"DifferentDeletionProtection": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							DeletionProtection: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							DeletionProtection: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameDeletionProtection": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							DeletionProtection: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							DeletionProtection: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+
+		"DifferentIOPS": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("mysql"),
+							IOPS:   ptr.To(int64(3000)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine: ptr.To("mysql"),
+							Iops:   ptr.To(int64(1000)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameIOPS": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							IOPS: ptr.To(int64(3000)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Iops: ptr.To(int64(3000)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// AllocatedStorage tests
+		"DifferentAllocatedStorage": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							AllocatedStorage: ptr.To(int64(100)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							AllocatedStorage: ptr.To(int64(50)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// Engine tests (string parameter)
+		"DifferentEngine": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-mysql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine: ptr.To("aurora-postgresql"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// KMSKeyID tests
+		"DifferentKMSKeyID": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							KMSKeyID: ptr.To("arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							KmsKeyId: ptr.To("arn:aws:kms:us-east-1:123456789012:key/87654321-4321-4321-4321-210987654321"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// MasterUsername tests
+		"DifferentMasterUsername": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							MasterUsername: ptr.To("admin"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							MasterUsername: ptr.To("root"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// EngineMode tests
+		"DifferentEngineMode": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							EngineMode: ptr.To("provisioned"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							EngineMode: ptr.To("serverless"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+
+		// NetworkType tests
+		"DifferentNetworkType": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							NetworkType: ptr.To("DUAL"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							NetworkType: ptr.To("IPV4"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+
+		// CharacterSetName tests
+		"DifferentCharacterSetName": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							CharacterSetName: ptr.To("UTF8"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							CharacterSetName: ptr.To("LATIN1"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
 		"IgnoresTagsWithTagsIgnorePrefixGlob": {
 			args: args{
 				kube: test.NewMockClient(),
@@ -934,7 +1895,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: ptr.To(true),
 							TagList: []*svcsdk.Tag{
-								{Key: ptr.To("aws:createdBy"), Value: ptr.To("terraform")},
+								{Key: ptr.To("aws:createdBy"), Value: ptr.To("value")},
 								{Key: ptr.To("c7n:policy"), Value: ptr.To("auto")},
 								{Key: ptr.To("env"), Value: ptr.To("prod")},
 							},
@@ -967,7 +1928,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: ptr.To(true),
 							TagList: []*svcsdk.Tag{
-								{Key: ptr.To("aws:createdBy"), Value: ptr.To("terraform")},
+								{Key: ptr.To("aws:createdBy"), Value: ptr.To("value")},
 								{Key: ptr.To("c7n:policy"), Value: ptr.To("auto")},
 								{Key: ptr.To("c7n:other"), Value: ptr.To("x")},
 								{Key: ptr.To("env"), Value: ptr.To("prod")},
@@ -1013,10 +1974,10 @@ func TestIsUpToDate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			custom := custom{kube: tc.args.kube}
-			isUpToDate, _, err := custom.isUpToDate(context.Background(), tc.args.cr, tc.args.out)
+			custom := shared{kube: tc.args.kube, cache: &cache{}}
+			isUpToDate, diffMsg, err := custom.isUpToDate(context.Background(), tc.args.cr, tc.args.out)
 			if diff := cmp.Diff(tc.want.isUpToDate, isUpToDate); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s\ndiff message: %s", diff, diffMsg)
 			}
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
 				t.Errorf("error: -want, +got:\n%s", diff)

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -567,63 +567,10 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 	return nil
 }
 
-// setPendingModifiedValues updates the DescribeDBInstancesOutput with any
-// PendingModifiedValues so that they are considered during isUpToDate checks. Exception is Engine version, which is handled separately.
-func setPendingModifiedValues(cr *svcsdk.DescribeDBInstancesOutput) { //nolint:gocyclo
-	if len(cr.DBInstances) > 0 {
-		if cr.DBInstances[0].PendingModifiedValues != nil {
-			if cr.DBInstances[0].PendingModifiedValues.AllocatedStorage != nil {
-				cr.DBInstances[0].AllocatedStorage = cr.DBInstances[0].PendingModifiedValues.AllocatedStorage
-			}
-			if cr.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod != nil {
-				cr.DBInstances[0].BackupRetentionPeriod = cr.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod
-			}
-			if cr.DBInstances[0].PendingModifiedValues.CACertificateIdentifier != nil {
-				cr.DBInstances[0].CACertificateIdentifier = cr.DBInstances[0].PendingModifiedValues.CACertificateIdentifier
-			}
-			if cr.DBInstances[0].PendingModifiedValues.DBInstanceClass != nil {
-				cr.DBInstances[0].DBInstanceClass = cr.DBInstances[0].PendingModifiedValues.DBInstanceClass
-			}
-			if cr.DBInstances[0].PendingModifiedValues.DBSubnetGroupName != nil {
-				cr.DBInstances[0].DBSubnetGroup = &svcsdk.DBSubnetGroup{
-					DBSubnetGroupName: cr.DBInstances[0].PendingModifiedValues.DBSubnetGroupName,
-				}
-			}
-			if cr.DBInstances[0].PendingModifiedValues.DedicatedLogVolume != nil {
-				cr.DBInstances[0].DedicatedLogVolume = cr.DBInstances[0].PendingModifiedValues.DedicatedLogVolume
-			}
-			if cr.DBInstances[0].PendingModifiedValues.Iops != nil {
-				cr.DBInstances[0].Iops = cr.DBInstances[0].PendingModifiedValues.Iops
-			}
-			if cr.DBInstances[0].PendingModifiedValues.LicenseModel != nil {
-				cr.DBInstances[0].LicenseModel = cr.DBInstances[0].PendingModifiedValues.LicenseModel
-			}
-			if cr.DBInstances[0].PendingModifiedValues.MultiAZ != nil {
-				cr.DBInstances[0].MultiAZ = cr.DBInstances[0].PendingModifiedValues.MultiAZ
-			}
-			if cr.DBInstances[0].PendingModifiedValues.Port != nil {
-				if cr.DBInstances[0].Endpoint == nil {
-					cr.DBInstances[0].Endpoint = &svcsdk.Endpoint{}
-				}
-				cr.DBInstances[0].Endpoint.Port = cr.DBInstances[0].PendingModifiedValues.Port
-			}
-			if cr.DBInstances[0].PendingModifiedValues.ProcessorFeatures != nil {
-				cr.DBInstances[0].ProcessorFeatures = cr.DBInstances[0].PendingModifiedValues.ProcessorFeatures
-			}
-			if cr.DBInstances[0].PendingModifiedValues.StorageThroughput != nil {
-				cr.DBInstances[0].StorageThroughput = cr.DBInstances[0].PendingModifiedValues.StorageThroughput
-			}
-			if cr.DBInstances[0].PendingModifiedValues.StorageType != nil {
-				cr.DBInstances[0].StorageType = cr.DBInstances[0].PendingModifiedValues.StorageType
-			}
-		}
-	}
-}
-
 func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBInstance, out *svcsdk.DescribeDBInstancesOutput) (upToDate bool, diff string, err error) { //nolint:gocyclo
 	// If ApplyImmediately is not true we update external state of db instance with pending modified values to prevent redundant updates
 	if !ptr.Deref(cr.Spec.ForProvider.ApplyImmediately, false) {
-		setPendingModifiedValues(out)
+		utils.SetPmvDBInstance(out)
 	}
 	db := out.DBInstances[0]
 	patch, err := createPatch(out, &cr.Spec.ForProvider)

--- a/pkg/controller/rds/dbinstance/setup_test.go
+++ b/pkg/controller/rds/dbinstance/setup_test.go
@@ -445,7 +445,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: aws.Bool(true),
 							TagList: []*svcsdk.Tag{
-								{Key: aws.String("aws:createdBy"), Value: aws.String("terraform")},
+								{Key: aws.String("aws:createdBy"), Value: aws.String("value")},
 								{Key: aws.String("c7n:policy"), Value: aws.String("auto")},
 								{Key: aws.String("env"), Value: aws.String("prod")},
 							},
@@ -479,7 +479,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: aws.Bool(true),
 							TagList: []*svcsdk.Tag{
-								{Key: aws.String("aws:createdBy"), Value: aws.String("terraform")},
+								{Key: aws.String("aws:createdBy"), Value: aws.String("value")},
 								{Key: aws.String("c7n:policy"), Value: aws.String("auto")},
 								{Key: aws.String("c7n:other"), Value: aws.String("x")},
 								{Key: aws.String("env"), Value: aws.String("prod")},

--- a/pkg/controller/rds/utils/pending_modified_values.go
+++ b/pkg/controller/rds/utils/pending_modified_values.go
@@ -1,0 +1,184 @@
+package utils
+
+import (
+	svcsdk "github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
+)
+
+// SetPmvDBInstance updates the DescribeDBInstancesOutput with any
+// PendingModifiedValues so that they are considered during isUpToDate checks. Exception is Engine version, which is handled separately.
+func SetPmvDBInstance(obs *svcsdk.DescribeDBInstancesOutput) { //nolint:gocyclo
+	if len(obs.DBInstances) > 0 {
+		if obs.DBInstances[0].PendingModifiedValues != nil {
+			if obs.DBInstances[0].PendingModifiedValues.AllocatedStorage != nil {
+				obs.DBInstances[0].AllocatedStorage = obs.DBInstances[0].PendingModifiedValues.AllocatedStorage
+			}
+			if obs.DBInstances[0].PendingModifiedValues.AutomationMode != nil {
+				obs.DBInstances[0].AutomationMode = obs.DBInstances[0].PendingModifiedValues.AutomationMode
+			}
+			if obs.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod != nil {
+				obs.DBInstances[0].BackupRetentionPeriod = obs.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod
+			}
+			if obs.DBInstances[0].PendingModifiedValues.CACertificateIdentifier != nil {
+				obs.DBInstances[0].CACertificateIdentifier = obs.DBInstances[0].PendingModifiedValues.CACertificateIdentifier
+			}
+			if obs.DBInstances[0].PendingModifiedValues.DBInstanceClass != nil {
+				obs.DBInstances[0].DBInstanceClass = obs.DBInstances[0].PendingModifiedValues.DBInstanceClass
+			}
+			if obs.DBInstances[0].PendingModifiedValues.DBSubnetGroupName != nil {
+				obs.DBInstances[0].DBSubnetGroup = &svcsdk.DBSubnetGroup{
+					DBSubnetGroupName: obs.DBInstances[0].PendingModifiedValues.DBSubnetGroupName,
+				}
+			}
+			if obs.DBInstances[0].PendingModifiedValues.DedicatedLogVolume != nil {
+				obs.DBInstances[0].DedicatedLogVolume = obs.DBInstances[0].PendingModifiedValues.DedicatedLogVolume
+			}
+			if obs.DBInstances[0].PendingModifiedValues.Iops != nil {
+				obs.DBInstances[0].Iops = obs.DBInstances[0].PendingModifiedValues.Iops
+			}
+			if obs.DBInstances[0].PendingModifiedValues.LicenseModel != nil {
+				obs.DBInstances[0].LicenseModel = obs.DBInstances[0].PendingModifiedValues.LicenseModel
+			}
+			if obs.DBInstances[0].PendingModifiedValues.MultiAZ != nil {
+				obs.DBInstances[0].MultiAZ = obs.DBInstances[0].PendingModifiedValues.MultiAZ
+			}
+			if obs.DBInstances[0].PendingModifiedValues.PendingCloudwatchLogsExports != nil {
+				applyInstancePendingCloudwatchLogsExports(obs)
+			}
+			if obs.DBInstances[0].PendingModifiedValues.Port != nil {
+				if obs.DBInstances[0].Endpoint == nil {
+					obs.DBInstances[0].Endpoint = &svcsdk.Endpoint{}
+				}
+				obs.DBInstances[0].Endpoint.Port = obs.DBInstances[0].PendingModifiedValues.Port
+			}
+			if obs.DBInstances[0].PendingModifiedValues.ProcessorFeatures != nil {
+				obs.DBInstances[0].ProcessorFeatures = obs.DBInstances[0].PendingModifiedValues.ProcessorFeatures
+			}
+			if obs.DBInstances[0].PendingModifiedValues.StorageThroughput != nil {
+				obs.DBInstances[0].StorageThroughput = obs.DBInstances[0].PendingModifiedValues.StorageThroughput
+			}
+			if obs.DBInstances[0].PendingModifiedValues.StorageType != nil {
+				obs.DBInstances[0].StorageType = obs.DBInstances[0].PendingModifiedValues.StorageType
+			}
+		}
+	}
+}
+
+// SetPmvDBCluster updates the DescribeDBClustersOutput with any
+// PendingModifiedValues so that they are considered during isUpToDate checks. Exception is Engine version, which is handled separately.
+func SetPmvDBCluster(obs *svcsdk.DescribeDBClustersOutput) {
+	if len(obs.DBClusters) > 0 {
+		if obs.DBClusters[0].PendingModifiedValues != nil {
+			if obs.DBClusters[0].PendingModifiedValues.AllocatedStorage != nil {
+				obs.DBClusters[0].AllocatedStorage = obs.DBClusters[0].PendingModifiedValues.AllocatedStorage
+			}
+			if obs.DBClusters[0].PendingModifiedValues.BackupRetentionPeriod != nil {
+				obs.DBClusters[0].BackupRetentionPeriod = obs.DBClusters[0].PendingModifiedValues.BackupRetentionPeriod
+			}
+			if obs.DBClusters[0].PendingModifiedValues.IAMDatabaseAuthenticationEnabled != nil {
+				obs.DBClusters[0].IAMDatabaseAuthenticationEnabled = obs.DBClusters[0].PendingModifiedValues.IAMDatabaseAuthenticationEnabled
+			}
+			if obs.DBClusters[0].PendingModifiedValues.Iops != nil {
+				obs.DBClusters[0].Iops = obs.DBClusters[0].PendingModifiedValues.Iops
+			}
+			if obs.DBClusters[0].PendingModifiedValues.PendingCloudwatchLogsExports != nil {
+				applyClusterPendingCloudwatchLogsExports(obs)
+			}
+			if obs.DBClusters[0].PendingModifiedValues.RdsCustomClusterConfiguration != nil {
+				obs.DBClusters[0].RdsCustomClusterConfiguration = obs.DBClusters[0].PendingModifiedValues.RdsCustomClusterConfiguration
+			}
+			if obs.DBClusters[0].PendingModifiedValues.StorageType != nil {
+				obs.DBClusters[0].StorageType = obs.DBClusters[0].PendingModifiedValues.StorageType
+			}
+		}
+	}
+}
+
+func applyInstancePendingCloudwatchLogsExports(cr *svcsdk.DescribeDBInstancesOutput) { //nolint:gocyclo
+	if len(cr.DBInstances) == 0 || cr.DBInstances[0].PendingModifiedValues == nil {
+		return
+	}
+
+	pending := cr.DBInstances[0].PendingModifiedValues.PendingCloudwatchLogsExports
+	if pending == nil {
+		return
+	}
+
+	// Handle LogTypesToDisable
+	if pending.LogTypesToDisable != nil {
+		disableSet := make(map[string]struct{}, len(pending.LogTypesToDisable))
+		for _, logType := range pending.LogTypesToDisable {
+			disableSet[pointer.StringValue(logType)] = struct{}{}
+		}
+
+		filtered := make([]*string, 0)
+		for _, enabled := range cr.DBInstances[0].EnabledCloudwatchLogsExports {
+			if _, shouldDisable := disableSet[pointer.StringValue(enabled)]; !shouldDisable {
+				filtered = append(filtered, enabled)
+			}
+		}
+		cr.DBInstances[0].EnabledCloudwatchLogsExports = filtered
+	}
+
+	// Handle LogTypesToEnable
+	if pending.LogTypesToEnable != nil {
+		for _, toEnable := range pending.LogTypesToEnable {
+			enableStr := pointer.StringValue(toEnable)
+			found := false
+			for _, enabled := range cr.DBInstances[0].EnabledCloudwatchLogsExports {
+				if pointer.StringValue(enabled) == enableStr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				cr.DBInstances[0].EnabledCloudwatchLogsExports = append(cr.DBInstances[0].EnabledCloudwatchLogsExports, toEnable)
+			}
+		}
+	}
+}
+
+func applyClusterPendingCloudwatchLogsExports(cr *svcsdk.DescribeDBClustersOutput) { //nolint:gocyclo
+	if len(cr.DBClusters) == 0 || cr.DBClusters[0].PendingModifiedValues == nil {
+		return
+	}
+
+	pending := cr.DBClusters[0].PendingModifiedValues.PendingCloudwatchLogsExports
+	if pending == nil {
+		return
+	}
+
+	// Handle LogTypesToDisable
+	if pending.LogTypesToDisable != nil {
+		disableSet := make(map[string]struct{}, len(pending.LogTypesToDisable))
+		for _, logType := range pending.LogTypesToDisable {
+			disableSet[pointer.StringValue(logType)] = struct{}{}
+		}
+
+		filtered := make([]*string, 0)
+		for _, enabled := range cr.DBClusters[0].EnabledCloudwatchLogsExports {
+			if _, shouldDisable := disableSet[pointer.StringValue(enabled)]; !shouldDisable {
+				filtered = append(filtered, enabled)
+			}
+		}
+		cr.DBClusters[0].EnabledCloudwatchLogsExports = filtered
+	}
+
+	// Handle LogTypesToEnable
+	if pending.LogTypesToEnable != nil {
+		for _, toEnable := range pending.LogTypesToEnable {
+			enableStr := pointer.StringValue(toEnable)
+			found := false
+			for _, enabled := range cr.DBClusters[0].EnabledCloudwatchLogsExports {
+				if pointer.StringValue(enabled) == enableStr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				cr.DBClusters[0].EnabledCloudwatchLogsExports = append(cr.DBClusters[0].EnabledCloudwatchLogsExports, toEnable)
+			}
+		}
+	}
+}


### PR DESCRIPTION


### Description of your changes

I applied the same fixes that were implemented for DBInstance in [2277](https://github.com/crossplane-contrib/provider-aws/pull/2277), but for DBCluster.

Additionally:
  - aligned the code between DBCluster and DBInstance
  - removed duplicated API calls within the same reconciliation loop
  - added logging for observed differences in isUpToDate
  - introduced a patch-based strategy for parameter comparison instead of dedicated checks for each parameter (previously not all parameters were covered)
  - added comprehensive tests for isUpToDate

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually, unit tests

