### PR TITLE
fix(docdb): omit AutoMinorVersionUpgrade from ModifyDBInstance requests

### DIFF
--- a/pkg/controller/docdb/dbinstance/setup.go
+++ b/pkg/controller/docdb/dbinstance/setup.go
@@ -129,8 +129,7 @@ func (e *hooks) isUpToDate(_ context.Context, cr *svcapitypes.DBInstance, resp *
 	instance := resp.DBInstances[0]
 
 	switch {
-	case pointer.BoolValue(cr.Spec.ForProvider.AutoMinorVersionUpgrade) != pointer.BoolValue(instance.AutoMinorVersionUpgrade),
-		pointer.StringValue(cr.Spec.ForProvider.CACertificateIdentifier) != pointer.StringValue(instance.CACertificateIdentifier),
+	case pointer.StringValue(cr.Spec.ForProvider.CACertificateIdentifier) != pointer.StringValue(instance.CACertificateIdentifier),
 		pointer.StringValue(cr.Spec.ForProvider.DBInstanceClass) != pointer.StringValue(instance.DBInstanceClass),
 		pointer.StringValue(cr.Spec.ForProvider.PreferredMaintenanceWindow) != pointer.StringValue(instance.PreferredMaintenanceWindow),
 		pointer.Int64Value(cr.Spec.ForProvider.PromotionTier) != pointer.Int64Value(instance.PromotionTier):
@@ -145,7 +144,6 @@ func lateInitialize(cr *svcapitypes.DBInstanceParameters, resp *svcsdk.DescribeD
 	instance := resp.DBInstances[0]
 
 	cr.AvailabilityZone = pointer.LateInitialize(cr.AvailabilityZone, instance.AvailabilityZone)
-	cr.AutoMinorVersionUpgrade = pointer.LateInitialize(cr.AutoMinorVersionUpgrade, instance.AutoMinorVersionUpgrade)
 	cr.CACertificateIdentifier = pointer.LateInitialize(cr.CACertificateIdentifier, instance.CACertificateIdentifier)
 	cr.PreferredMaintenanceWindow = pointer.LateInitialize(cr.PreferredMaintenanceWindow, instance.PreferredMaintenanceWindow)
 	cr.PromotionTier = pointer.LateInitialize(cr.PromotionTier, instance.PromotionTier)
@@ -156,6 +154,9 @@ func preUpdate(ctx context.Context, cr *svcapitypes.DBInstance, obj *svcsdk.Modi
 	obj.DBInstanceIdentifier = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
 	obj.CACertificateIdentifier = cr.Spec.ForProvider.CACertificateIdentifier
 	obj.ApplyImmediately = cr.Spec.ForProvider.ApplyImmediately
+	// AutoMinorVersionUpgrade is not supported by the DocumentDB ModifyDBInstance
+	// API and must be omitted from update requests to avoid a terminal error.
+	obj.AutoMinorVersionUpgrade = nil
 	return nil
 }
 

--- a/pkg/controller/docdb/dbinstance/setup_test.go
+++ b/pkg/controller/docdb/dbinstance/setup_test.go
@@ -314,7 +314,7 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"AvailableState_and_outdated_AutoMinorVersionUpgrade": {
+		"AvailableState_AutoMinorVersionUpgrade_diff_ignored": {
 			args: args{
 				docdb: &fake.MockDocDBClient{
 					MockDescribeDBInstancesWithContext: func(c context.Context, ddi *docdb.DescribeDBInstancesInput, o []request.Option) (*docdb.DescribeDBInstancesOutput, error) {
@@ -353,7 +353,7 @@ func TestObserve(t *testing.T) {
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:    true,
-					ResourceUpToDate:  false,
+					ResourceUpToDate:  true,
 					ConnectionDetails: generateConnectionDetails(testAddress, testPort),
 				},
 				docdb: fake.MockDocDBClientCall{
@@ -366,6 +366,9 @@ func TestObserve(t *testing.T) {
 							)),
 							Opts: nil,
 						},
+					},
+					ListTagsForResource: []*fake.CallListTagsForResource{
+						{I: &docdb.ListTagsForResourceInput{ResourceName: pointer.ToOrNilIfZeroValue(testDBInstanceArn)}},
 					},
 				},
 			},
@@ -836,7 +839,7 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"FailedState_and_outdated_AutoMinorVersionUpgrade": {
+		"FailedState_AutoMinorVersionUpgrade_diff_ignored": {
 			args: args{
 				docdb: &fake.MockDocDBClient{
 					MockDescribeDBInstancesWithContext: func(c context.Context, ddi *docdb.DescribeDBInstancesInput, o []request.Option) (*docdb.DescribeDBInstancesOutput, error) {
@@ -873,7 +876,7 @@ func TestObserve(t *testing.T) {
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:    true,
-					ResourceUpToDate:  false,
+					ResourceUpToDate:  true,
 					ConnectionDetails: generateConnectionDetails(testAddress, testPort),
 				},
 				docdb: fake.MockDocDBClientCall{
@@ -886,6 +889,9 @@ func TestObserve(t *testing.T) {
 							)),
 							Opts: nil,
 						},
+					},
+					ListTagsForResource: []*fake.CallListTagsForResource{
+						{I: &docdb.ListTagsForResourceInput{}},
 					},
 				},
 			},
@@ -1351,7 +1357,7 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"DeletingState_and_outdated_AutoMinorVersionUpgrade": {
+		"DeletingState_AutoMinorVersionUpgrade_diff_ignored": {
 			args: args{
 				docdb: &fake.MockDocDBClient{
 					MockDescribeDBInstancesWithContext: func(c context.Context, ddi *docdb.DescribeDBInstancesInput, o []request.Option) (*docdb.DescribeDBInstancesOutput, error) {
@@ -1388,7 +1394,7 @@ func TestObserve(t *testing.T) {
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:    true,
-					ResourceUpToDate:  false,
+					ResourceUpToDate:  true,
 					ConnectionDetails: generateConnectionDetails(testAddress, testPort),
 				},
 				docdb: fake.MockDocDBClientCall{
@@ -1401,6 +1407,9 @@ func TestObserve(t *testing.T) {
 							)),
 							Opts: nil,
 						},
+					},
+					ListTagsForResource: []*fake.CallListTagsForResource{
+						{I: &docdb.ListTagsForResourceInput{}},
 					},
 				},
 			},
@@ -1866,7 +1875,7 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"CreatingState_and_outdated_AutoMinorVersionUpgrade": {
+		"CreatingState_AutoMinorVersionUpgrade_diff_ignored": {
 			args: args{
 				docdb: &fake.MockDocDBClient{
 					MockDescribeDBInstancesWithContext: func(c context.Context, ddi *docdb.DescribeDBInstancesInput, o []request.Option) (*docdb.DescribeDBInstancesOutput, error) {
@@ -1903,7 +1912,7 @@ func TestObserve(t *testing.T) {
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:    true,
-					ResourceUpToDate:  false,
+					ResourceUpToDate:  true,
 					ConnectionDetails: generateConnectionDetails(testAddress, testPort),
 				},
 				docdb: fake.MockDocDBClientCall{
@@ -1916,6 +1925,9 @@ func TestObserve(t *testing.T) {
 							)),
 							Opts: nil,
 						},
+					},
+					ListTagsForResource: []*fake.CallListTagsForResource{
+						{I: &docdb.ListTagsForResourceInput{}},
 					},
 				},
 			},
@@ -2993,6 +3005,58 @@ func TestUpdate(t *testing.T) {
 								Tags: []*docdb.Tag{
 									{Key: pointer.ToOrNilIfZeroValue(testOtherTagKey), Value: pointer.ToOrNilIfZeroValue(testOtherTagValue)},
 								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"SuccessfulUpdate_AutoMinorVersionUpgrade_not_sent": {
+			args: args{
+				docdb: &fake.MockDocDBClient{
+					MockModifyDBInstanceWithContext: func(c context.Context, mdi *docdb.ModifyDBInstanceInput, o []request.Option) (*docdb.ModifyDBInstanceOutput, error) {
+						if mdi.AutoMinorVersionUpgrade != nil {
+							return nil, errors.New("AutoMinorVersionUpgrade must not be sent to DocumentDB ModifyDBInstance")
+						}
+						return &docdb.ModifyDBInstanceOutput{
+							DBInstance: &docdb.DBInstance{
+								DBInstanceIdentifier: pointer.ToOrNilIfZeroValue(testDBIdentifier),
+								DBInstanceArn:        pointer.ToOrNilIfZeroValue(testDBInstanceArn),
+							},
+						}, nil
+					},
+					MockListTagsForResource: func(ltfri *docdb.ListTagsForResourceInput) (*docdb.ListTagsForResourceOutput, error) {
+						return &docdb.ListTagsForResourceOutput{}, nil
+					},
+				},
+				cr: instance(
+					withDBIdentifier(testDBIdentifier),
+					withDBInstanceArn(testDBInstanceArn),
+					withExternalName(testDBIdentifier),
+					withAutoMinorVersionUpgrade(true),
+				),
+			},
+			want: want{
+				cr: instance(
+					withDBIdentifier(testDBIdentifier),
+					withDBInstanceArn(testDBInstanceArn),
+					withExternalName(testDBIdentifier),
+					withAutoMinorVersionUpgrade(true),
+				),
+				result: managed.ExternalUpdate{},
+				docdb: fake.MockDocDBClientCall{
+					ModifyDBInstanceWithContext: []*fake.CallModifyDBInstanceWithContext{
+						{
+							Ctx: context.Background(),
+							I: &docdb.ModifyDBInstanceInput{
+								DBInstanceIdentifier: pointer.ToOrNilIfZeroValue(testDBIdentifier),
+							},
+						},
+					},
+					ListTagsForResource: []*fake.CallListTagsForResource{
+						{
+							I: &docdb.ListTagsForResourceInput{
+								ResourceName: pointer.ToOrNilIfZeroValue(testDBInstanceArn),
 							},
 						},
 					},


### PR DESCRIPTION
### Description of your changes

  The AWS DocumentDB API rejects the `AutoMinorVersionUpgrade` field in
  `ModifyDBInstance` calls. When this field was present in the resource
  spec, the controller would detect a mismatch in `isUpToDate`, trigger
  an update, include the field in the request, and AWS would reject it —
  putting the resource into a `Terminal` condition.

  Fixes #2274

  Changes:
  - **`isUpToDate`**: Remove `AutoMinorVersionUpgrade` from the comparison so changes to this field no longer trigger updates
  - **`lateInitialize`**: Remove `AutoMinorVersionUpgrade` since it cannot be updated via the API
  - **`preUpdate`**: Explicitly nil `AutoMinorVersionUpgrade` in `ModifyDBInstanceInput` so the auto-generated code cannot accidentally include it

  I have:

  - [x] Read and followed Crossplane's [contribution process].
  - [x] Run `make reviewable test` to ensure this PR is ready for review.

  ### How has this code been tested

  Updated existing unit tests to reflect that `AutoMinorVersionUpgrade`
  differences are intentionally ignored (4 observe test cases renamed and
  `ResourceUpToDate` changed from `false` to `true`). Added a new
  `TestUpdate` case that asserts the field is absent from the
  `ModifyDBInstance` API call.