### PR TITLE
fix(rds/dbinstance): fix port and licenseModel handling in ModifyDBInstance

### DIFF
--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -320,7 +320,7 @@ func (s *shared) updateConnectionDetails(ctx context.Context, cr *svcapitypes.DB
 	return details, nil
 }
 
-func (s *shared) preUpdate(ctx context.Context, cr *svcapitypes.DBInstance, obj *svcsdk.ModifyDBInstanceInput) (err error) {
+func (s *shared) preUpdate(ctx context.Context, cr *svcapitypes.DBInstance, obj *svcsdk.ModifyDBInstanceInput) (err error) { //nolint:gocyclo
 	obj.DBInstanceIdentifier = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
 	obj.ApplyImmediately = cr.Spec.ForProvider.ApplyImmediately
 	// Only set MasterUserPassword if it has changed, otherwise it triggers "Resetting master password" on aws side,
@@ -360,6 +360,15 @@ func (s *shared) preUpdate(ctx context.Context, cr *svcapitypes.DBInstance, obj 
 	}
 	if s.cache.backupRetentionPeriodUpToDate {
 		obj.BackupRetentionPeriod = nil
+	}
+
+	obj.DBPortNumber = cr.Spec.ForProvider.Port
+
+	// LicenseModel cannot be modified on read replicas - AWS rejects the entire ModifyDBInstance request.
+	// After LateInitialize(), licenseModel is always populated in spec.forProvider from the observed AWS state,
+	// which causes it to be included in every subsequent modify call.
+	if cr.Spec.ForProvider.SourceDBInstanceID != nil {
+		obj.LicenseModel = nil
 	}
 
 	return nil
@@ -617,6 +626,9 @@ func setPendingModifiedValues(cr *svcsdk.DescribeDBInstancesOutput) { //nolint:g
 			}
 			if cr.DBInstances[0].PendingModifiedValues.StorageType != nil {
 				cr.DBInstances[0].StorageType = cr.DBInstances[0].PendingModifiedValues.StorageType
+			}
+			if cr.DBInstances[0].PendingModifiedValues.Port != nil {
+				cr.DBInstances[0].DbInstancePort = cr.DBInstances[0].PendingModifiedValues.Port
 			}
 		}
 	}

--- a/pkg/controller/rds/dbinstance/setup_test.go
+++ b/pkg/controller/rds/dbinstance/setup_test.go
@@ -822,3 +822,124 @@ func errToString(err error) string {
 	}
 	return err.Error()
 }
+
+func TestPreUpdate(t *testing.T) {
+	type args struct {
+		cr  *svcapitypes.DBInstance
+		obj *svcsdk.ModifyDBInstanceInput
+	}
+
+	type want struct {
+		obj *svcsdk.ModifyDBInstanceInput
+		err error
+	}
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"PortIsSetAsDBPortNumber": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							Port: aws.Int64(5432),
+						},
+					},
+				},
+				obj: &svcsdk.ModifyDBInstanceInput{},
+			},
+			want: want{
+				obj: &svcsdk.ModifyDBInstanceInput{
+					DBPortNumber: aws.Int64(5432),
+				},
+			},
+		},
+		"LicenseModelNilForPostgresReplica": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							Port: aws.Int64(5432),
+							CustomDBInstanceParameters: svcapitypes.CustomDBInstanceParameters{
+								SourceDBInstanceID: aws.String("source-db"),
+							},
+							Engine:       aws.String("postgres"),
+							LicenseModel: aws.String("postgresql-license"),
+						},
+					},
+				},
+				obj: &svcsdk.ModifyDBInstanceInput{
+					LicenseModel: aws.String("postgresql-license"),
+				},
+			},
+			want: want{
+				obj: &svcsdk.ModifyDBInstanceInput{
+					DBPortNumber: aws.Int64(5432),
+					LicenseModel: nil,
+				},
+			},
+		},
+		"LicenseModelKeptForPostgresPrimary": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							Port:         aws.Int64(5432),
+							Engine:       aws.String("postgres"),
+							LicenseModel: aws.String("postgresql-license"),
+						},
+					},
+				},
+				obj: &svcsdk.ModifyDBInstanceInput{
+					LicenseModel: aws.String("postgresql-license"),
+				},
+			},
+			want: want{
+				obj: &svcsdk.ModifyDBInstanceInput{
+					DBPortNumber: aws.Int64(5432),
+					LicenseModel: aws.String("postgresql-license"),
+				},
+			},
+		},
+		"LicenseModelNilForMariaDBReplica": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							Port:   aws.Int64(3306),
+							Engine: aws.String("mariadb"),
+							CustomDBInstanceParameters: svcapitypes.CustomDBInstanceParameters{
+								SourceDBInstanceID: aws.String("mariadb-primary"),
+							},
+							LicenseModel: aws.String("general-public-license"),
+						},
+					},
+				},
+				obj: &svcsdk.ModifyDBInstanceInput{
+					LicenseModel: aws.String("general-public-license"),
+				},
+			},
+			want: want{
+				obj: &svcsdk.ModifyDBInstanceInput{
+					DBPortNumber: aws.Int64(3306),
+					LicenseModel: nil,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := &shared{cache: &cache{}}
+			err := s.preUpdate(context.TODO(), tc.args.cr, tc.args.obj)
+
+			if diff := cmp.Diff(tc.want.err, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("r: -want, +got error:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.obj, tc.args.obj, cmpopts.IgnoreUnexported(svcsdk.ModifyDBInstanceInput{})); diff != "" {
+				t.Errorf("ModifyDBInstanceInput: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION

### Description 

  ### Port
   The controller detected port changes as a diff but never sent the new value in the `ModifyDBInstance` request. Fixed by setting `DBPortNumber` from `spec.forProvider.port` in `preUpdate`.

   ### LicenseModel
   AWS rejects `ModifyDBInstance` requests on read replicas when `licenseModel` is included, even if unchanged. After `LateInitialize()` populates this field from observed state, it gets included in every
   subsequent modify call, causing all replica modifications to fail with:

   InvalidParameterValue: You can't change the license model on a Read Replica

   Fixed by excluding `licenseModel` from modify requests for read replicas (`SourceDBInstanceID != nil`).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Added `TestPreUpdate` covering both fixes.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
