### PR TITLE
fix(rds): sort VPCSecurityGroupIDs to prevent order-sensitive diffs

### DIFF
--- a/pkg/clients/database/rds.go
+++ b/pkg/clients/database/rds.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -376,6 +377,11 @@ func CreatePatch(in *rdstypes.DBInstance, spec *v1beta1.RDSInstanceParameters) (
 		currentParams.IOPS = target.IOPS
 		currentParams.StorageThroughput = target.StorageThroughput
 	}
+
+	// Sort VPCSecurityGroupIDs in both current and target so that order differences
+	// from the AWS API response don't cause false positives in the patch diff.
+	sort.Strings(currentParams.VPCSecurityGroupIDs)
+	sort.Strings(target.VPCSecurityGroupIDs)
 
 	jsonPatch, err := jsonpatch.CreateJSONPatch(currentParams, target)
 	if err != nil {

--- a/pkg/clients/database/rds_test.go
+++ b/pkg/clients/database/rds_test.go
@@ -563,6 +563,24 @@ func TestIsUpToDate(t *testing.T) {
 			},
 			want: true,
 		},
+		"VPCSecurityGroupIDsSameElementsDifferentOrder": {
+			args: args{
+				db: rdstypes.DBInstance{
+					VpcSecurityGroups: []rdstypes.VpcSecurityGroupMembership{
+						{VpcSecurityGroupId: ptr.To("sg-aaaa"), Status: ptr.To("active")},
+						{VpcSecurityGroupId: ptr.To("sg-bbbb"), Status: ptr.To("active")},
+					},
+				},
+				r: v1beta1.RDSInstance{
+					Spec: v1beta1.RDSInstanceSpec{
+						ForProvider: v1beta1.RDSInstanceParameters{
+							VPCSecurityGroupIDs: []string{"sg-bbbb", "sg-aaaa"},
+						},
+					},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes

This change affects the RDSInstance CR (database.aws.crossplane.io/v1beta1).

When AWS returns multiple VpcSecurityGroups from DescribeDBInstances, their order is arbitrary. The JSON patch comparison in CreatePatch is order-sensitive, causing false positives and re-reconciliation loops when the same security groups were returned in a different order.

This fix sorts VPCSecurityGroupIDs on both the current state (from AWS) and the desired spec before the patch comparison, making it order-insensitive. This prevents unnecessary ModifyDBInstance calls when 2 or more security groups are configured.

### How has this code been tested

- Added test case VPCSecurityGroupIDsSameElementsDifferentOrder in TestIsUpToDate that verifies the same security group IDs in different order are correctly identified as equivalent
- This test would have failed before the fix and now passes
- Ran go test ./pkg/clients/database/... — all tests pass

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run make reviewable test to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->