### PR TITLE
fix(kms/key): skip key rotation calls for non-AWS_KMS origin keys

### DIFF
--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -132,19 +132,27 @@ func (u *updater) update(ctx context.Context, cr *svcapitypes.Key) (managed.Exte
 		return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
 	}
 
-	if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) {
-		// EnableKeyRotation
-		if _, err := u.client.EnableKeyRotationWithContext(ctx, &svcsdk.EnableKeyRotationInput{
-			KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
-		}); err != nil {
-			return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
-		}
-	} else {
-		// DisableKeyRotation
-		if _, err := u.client.DisableKeyRotationWithContext(ctx, &svcsdk.DisableKeyRotationInput{
-			KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
-		}); err != nil {
-			return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
+	// Key rotation is only supported for AWS_KMS origin keys. AWS rejects
+	// EnableKeyRotation/DisableKeyRotation for AWS_CLOUDHSM and EXTERNAL
+	// origin keys, so skip the call for those. Origin is late-initialized
+	// from KeyMetadata.Origin after creation, so it is reliably populated
+	// by the time update runs; an empty value preserves existing AWS_KMS
+	// behaviour.
+	if cr.Spec.ForProvider.Origin == nil || pointer.StringValue(cr.Spec.ForProvider.Origin) == string(svcapitypes.OriginType_AWS_KMS) {
+		if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) {
+			// EnableKeyRotation
+			if _, err := u.client.EnableKeyRotationWithContext(ctx, &svcsdk.EnableKeyRotationInput{
+				KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
+			}); err != nil {
+				return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
+			}
+		} else {
+			// DisableKeyRotation
+			if _, err := u.client.DisableKeyRotationWithContext(ctx, &svcsdk.DisableKeyRotationInput{
+				KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
+			}); err != nil {
+				return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
+			}
 		}
 	}
 
@@ -260,6 +268,7 @@ func (o *observer) lateInitialize(in *svcapitypes.KeyParameters, obj *svcsdk.Des
 	}
 
 	in.Enabled = pointer.LateInitialize(in.Enabled, obj.KeyMetadata.Enabled)
+	in.Origin = pointer.LateInitialize(in.Origin, obj.KeyMetadata.Origin)
 
 	if len(in.Tags) == 0 {
 		resTags, err := o.client.ListResourceTags(&svcsdk.ListResourceTagsInput{
@@ -316,15 +325,19 @@ func (o *observer) isUpToDate(_ context.Context, cr *svcapitypes.Key, obj *svcsd
 		return false, "spec.forProvider.policy: " + diff, nil
 	}
 
-	// EnableKeyRotation
-	resRotation, err := o.client.GetKeyRotationStatus(&svcsdk.GetKeyRotationStatusInput{
-		KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
-	})
-	if err != nil {
-		return false, "", errorutils.Wrap(err, "cannot get key rotation status")
-	}
-	if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) != pointer.BoolValue(resRotation.KeyRotationEnabled) {
-		return false, "", nil
+	// EnableKeyRotation is only supported for AWS_KMS origin keys. AWS
+	// rejects GetKeyRotationStatus for AWS_CLOUDHSM and EXTERNAL origin
+	// keys, so skip the check for those.
+	if pointer.StringValue(obj.KeyMetadata.Origin) == string(svcapitypes.OriginType_AWS_KMS) {
+		resRotation, err := o.client.GetKeyRotationStatus(&svcsdk.GetKeyRotationStatusInput{
+			KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
+		})
+		if err != nil {
+			return false, "", errorutils.Wrap(err, "cannot get key rotation status")
+		}
+		if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) != pointer.BoolValue(resRotation.KeyRotationEnabled) {
+			return false, "", nil
+		}
 	}
 
 	// Tags

--- a/pkg/controller/kms/key/setup_test.go
+++ b/pkg/controller/kms/key/setup_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package key
+
+import (
+	"context"
+	"testing"
+
+	svcsdk "github.com/aws/aws-sdk-go/service/kms"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/golang/mock/gomock"
+
+	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/kms/v1alpha1"
+	mockkms "github.com/crossplane-contrib/provider-aws/pkg/clients/mock/kmsiface"
+	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
+)
+
+const testKeyID = "test-key-id"
+
+func newTestKey(origin *string) *svcapitypes.Key {
+	cr := &svcapitypes.Key{
+		Spec: svcapitypes.KeySpec{
+			ForProvider: svcapitypes.KeyParameters{
+				Origin: origin,
+				CustomKeyParameters: svcapitypes.CustomKeyParameters{
+					EnableKeyRotation: pointer.ToOrNilIfZeroValue(true),
+					Enabled:           pointer.ToOrNilIfZeroValue(true),
+				},
+			},
+		},
+		Status: svcapitypes.KeyStatus{
+			AtProvider: svcapitypes.KeyObservation{
+				Enabled: pointer.ToOrNilIfZeroValue(true),
+			},
+		},
+	}
+	meta.SetExternalName(cr, testKeyID)
+	return cr
+}
+
+func TestIsUpToDateSkipsKeyRotationForNonAWSKMSOrigin(t *testing.T) {
+	cases := map[string]struct {
+		origin *string
+		setup  func(mock *mockkms.MockKMSAPI)
+	}{
+		"AWSKMSOriginChecksRotationStatus": {
+			origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_AWS_KMS)),
+			setup: func(mock *mockkms.MockKMSAPI) {
+				mock.EXPECT().GetKeyRotationStatus(gomock.Any()).Return(&svcsdk.GetKeyRotationStatusOutput{
+					KeyRotationEnabled: pointer.ToOrNilIfZeroValue(true),
+				}, nil)
+			},
+		},
+		"CloudHSMOriginSkipsRotationStatus": {
+			origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_AWS_CLOUDHSM)),
+			setup:  func(mock *mockkms.MockKMSAPI) {},
+		},
+		"ExternalOriginSkipsRotationStatus": {
+			origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_EXTERNAL)),
+			setup:  func(mock *mockkms.MockKMSAPI) {},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mockClient := mockkms.NewMockKMSAPI(gomock.NewController(t))
+			mockClient.EXPECT().GetKeyPolicy(gomock.Any()).Return(&svcsdk.GetKeyPolicyOutput{}, nil)
+			mockClient.EXPECT().ListResourceTags(gomock.Any()).Return(&svcsdk.ListResourceTagsOutput{}, nil)
+			tc.setup(mockClient)
+
+			o := &observer{client: mockClient}
+			cr := newTestKey(tc.origin)
+			obj := &svcsdk.DescribeKeyOutput{
+				KeyMetadata: &svcsdk.KeyMetadata{
+					Origin: tc.origin,
+				},
+			}
+
+			// gomock fails the test itself if an unexpected call (e.g.
+			// GetKeyRotationStatus for a non-AWS_KMS origin) is made, so we
+			// only need to assert that isUpToDate returns without error.
+			if _, _, err := o.isUpToDate(context.Background(), cr, obj); err != nil {
+				t.Errorf("isUpToDate(...): unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLateInitializeSetsOrigin(t *testing.T) {
+	mockClient := mockkms.NewMockKMSAPI(gomock.NewController(t))
+	mockClient.EXPECT().GetKeyPolicy(gomock.Any()).Return(&svcsdk.GetKeyPolicyOutput{}, nil)
+	mockClient.EXPECT().ListResourceTags(gomock.Any()).Return(&svcsdk.ListResourceTagsOutput{}, nil)
+
+	o := &observer{client: mockClient}
+	in := &svcapitypes.KeyParameters{}
+	obj := &svcsdk.DescribeKeyOutput{
+		KeyMetadata: &svcsdk.KeyMetadata{
+			KeyId:  pointer.ToOrNilIfZeroValue(testKeyID),
+			Origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_AWS_CLOUDHSM)),
+		},
+	}
+
+	if err := o.lateInitialize(in, obj); err != nil {
+		t.Fatalf("lateInitialize(...): unexpected error: %v", err)
+	}
+	if pointer.StringValue(in.Origin) != string(svcapitypes.OriginType_AWS_CLOUDHSM) {
+		t.Errorf("lateInitialize(...): got origin %q, want %q", pointer.StringValue(in.Origin), svcapitypes.OriginType_AWS_CLOUDHSM)
+	}
+}
+
+func TestUpdateSkipsKeyRotationForNonAWSKMSOrigin(t *testing.T) {
+	cases := map[string]struct {
+		origin *string
+		setup  func(mock *mockkms.MockKMSAPI)
+	}{
+		"NilOriginPreservesLegacyBehaviour": {
+			origin: nil,
+			setup: func(mock *mockkms.MockKMSAPI) {
+				mock.EXPECT().EnableKeyRotationWithContext(gomock.Any(), gomock.Any()).Return(&svcsdk.EnableKeyRotationOutput{}, nil)
+			},
+		},
+		"AWSKMSOriginEnablesRotation": {
+			origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_AWS_KMS)),
+			setup: func(mock *mockkms.MockKMSAPI) {
+				mock.EXPECT().EnableKeyRotationWithContext(gomock.Any(), gomock.Any()).Return(&svcsdk.EnableKeyRotationOutput{}, nil)
+			},
+		},
+		"CloudHSMOriginSkipsRotationCall": {
+			origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_AWS_CLOUDHSM)),
+			setup:  func(mock *mockkms.MockKMSAPI) {},
+		},
+		"ExternalOriginSkipsRotationCall": {
+			origin: pointer.ToOrNilIfZeroValue(string(svcapitypes.OriginType_EXTERNAL)),
+			setup:  func(mock *mockkms.MockKMSAPI) {},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mockClient := mockkms.NewMockKMSAPI(gomock.NewController(t))
+			mockClient.EXPECT().PutKeyPolicyWithContext(gomock.Any(), gomock.Any()).Return(&svcsdk.PutKeyPolicyOutput{}, nil)
+			mockClient.EXPECT().ListResourceTagsWithContext(gomock.Any(), gomock.Any()).Return(&svcsdk.ListResourceTagsOutput{}, nil)
+			tc.setup(mockClient)
+
+			u := &updater{client: mockClient}
+			cr := newTestKey(tc.origin)
+
+			// gomock fails the test itself if an unexpected call (e.g.
+			// EnableKeyRotationWithContext for a non-AWS_KMS origin) is made.
+			if _, err := u.update(context.Background(), cr); err != nil {
+				t.Errorf("update(...): unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Motivation:
KMS Key resources with origin AWS_CLOUDHSM or EXTERNAL fail to
reconcile permanently. AWS does not support the key-rotation APIs
(EnableKeyRotation, DisableKeyRotation, GetKeyRotationStatus) for
CloudHSM custom key store keys or externally-imported keys - only
AWS_KMS origin keys support rotation. The controller called these
APIs unconditionally on every reconcile, so Observe() (via isUpToDate)
returned UnsupportedOperationException every loop and the managed
resource never reached the Ready condition. This is a per-resource
reconcile failure, not a crash of the controller process, and it does
not affect AWS_KMS origin keys, which are unaffected before and after
this change.

Approach:
- isUpToDate: only call GetKeyRotationStatus when the live
  DescribeKey response reports Origin == AWS_KMS.
- update: only call EnableKeyRotation/DisableKeyRotation when
  spec.forProvider.origin is AWS_KMS or unset (unset preserves the
  previous AWS_KMS-only behaviour).
- lateInitialize: backfill spec.forProvider.origin from the live
  DescribeKey response, same as the existing Enabled field, so the
  update() guard is populated for Key resources imported into
  Crossplane rather than created through this controller (origin was
  previously only set on the Create() response path).

Validation:
go build ./pkg/controller/kms/...
go test ./pkg/controller/kms/... -v
All tests pass, including new table-driven tests in setup_test.go
that assert (via gomock strict expectations) that
GetKeyRotationStatus/EnableKeyRotationWithContext/
DisableKeyRotationWithContext are not called for AWS_CLOUDHSM and
EXTERNAL origin keys, are still called for AWS_KMS and unset origin
(regression check), and that lateInitialize backfills origin from the
DescribeKey response.

Fixes #2310

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>