### PR TITLE
Bugfix/dynamodb strip provisioned throughput for pay per request

### DIFF
--- a/pkg/controller/dynamodb/table/hooks.go
+++ b/pkg/controller/dynamodb/table/hooks.go
@@ -157,6 +157,13 @@ func preObserve(_ context.Context, cr *svcapitypes.Table, obj *svcsdk.DescribeTa
 }
 func preCreate(_ context.Context, cr *svcapitypes.Table, obj *svcsdk.CreateTableInput) error {
 	obj.TableName = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
+	// AWS rejects CreateTableInput with ProvisionedThroughput when
+	// BillingMode is PAY_PER_REQUEST. This can happen when a table was
+	// previously observed (late-initializing ProvisionedThroughput with
+	// zero values from DescribeTable) and then needs to be recreated.
+	if pointer.StringValue(obj.BillingMode) == svcsdk.BillingModePayPerRequest {
+		obj.ProvisionedThroughput = nil
+	}
 	return nil
 }
 func preDelete(_ context.Context, cr *svcapitypes.Table, obj *svcsdk.DeleteTableInput) (bool, error) {
@@ -238,9 +245,17 @@ func lateInitialize(in *svcapitypes.TableParameters, t *svcsdk.DescribeTableOutp
 		}
 	}
 	if in.ProvisionedThroughput == nil && t.Table.ProvisionedThroughput != nil {
-		in.ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{
-			ReadCapacityUnits:  t.Table.ProvisionedThroughput.ReadCapacityUnits,
-			WriteCapacityUnits: t.Table.ProvisionedThroughput.WriteCapacityUnits,
+		// NOTE: AWS always returns ProvisionedThroughput in DescribeTable
+		// output, even for PAY_PER_REQUEST tables (with values of 0). We
+		// must not late-initialize these zero values because they would
+		// cause a CreateTable failure if the table needs to be recreated:
+		// AWS rejects ProvisionedThroughput in CreateTableInput when
+		// BillingMode is PAY_PER_REQUEST.
+		if pointer.StringValue(in.BillingMode) != svcsdk.BillingModePayPerRequest {
+			in.ProvisionedThroughput = &svcapitypes.ProvisionedThroughput{
+				ReadCapacityUnits:  t.Table.ProvisionedThroughput.ReadCapacityUnits,
+				WriteCapacityUnits: t.Table.ProvisionedThroughput.WriteCapacityUnits,
+			}
 		}
 	}
 	if t.Table.SSEDescription != nil {

--- a/pkg/controller/dynamodb/table/hooks_test.go
+++ b/pkg/controller/dynamodb/table/hooks_test.go
@@ -494,10 +494,10 @@ func TestLateInitialize(t *testing.T) {
 						AttributeName: aws.String("N"),
 						KeyType:       aws.String("T"),
 					}},
-					ProvisionedThroughput: &svcapitypes.ProvisionedThroughput{
-						ReadCapacityUnits:  aws.Int64(42),
-						WriteCapacityUnits: aws.Int64(42),
-					},
+					// ProvisionedThroughput is NOT late-initialized when
+					// BillingMode is PAY_PER_REQUEST. AWS returns zeros for
+					// on-demand tables which would cause CreateTable to fail
+					// if the table needs to be recreated.
 					SSESpecification: &svcapitypes.SSESpecification{
 						Enabled:        aws.Bool(true),
 						KMSMasterKeyID: aws.String("some-arn"),
@@ -507,6 +507,45 @@ func TestLateInitialize(t *testing.T) {
 						StreamEnabled:  aws.Bool(true),
 						StreamViewType: aws.String("the-good-type"),
 					},
+				},
+			},
+		},
+		"EmptyParamsProvisioned": {
+			args: args{
+				p: &svcapitypes.TableParameters{},
+				in: &svcsdk.DescribeTableOutput{
+					Table: &svcsdk.TableDescription{
+						AttributeDefinitions: []*svcsdk.AttributeDefinition{{
+							AttributeName: aws.String("N"),
+							AttributeType: aws.String("T"),
+						}},
+						KeySchema: []*svcsdk.KeySchemaElement{{
+							AttributeName: aws.String("N"),
+							KeyType:       aws.String("T"),
+						}},
+						ProvisionedThroughput: &svcsdk.ProvisionedThroughputDescription{
+							ReadCapacityUnits:  aws.Int64(5),
+							WriteCapacityUnits: aws.Int64(5),
+						},
+					},
+				},
+			},
+			want: want{
+				p: &svcapitypes.TableParameters{
+					BillingMode: aws.String(svcsdk.BillingModeProvisioned),
+					AttributeDefinitions: []*svcapitypes.AttributeDefinition{{
+						AttributeName: aws.String("N"),
+						AttributeType: aws.String("T"),
+					}},
+					KeySchema: []*svcapitypes.KeySchemaElement{{
+						AttributeName: aws.String("N"),
+						KeyType:       aws.String("T"),
+					}},
+					ProvisionedThroughput: &svcapitypes.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(5),
+						WriteCapacityUnits: aws.Int64(5),
+					},
+					StreamSpecification: &svcapitypes.StreamSpecification{StreamEnabled: aws.Bool(false)},
 				},
 			},
 		},
@@ -833,6 +872,106 @@ func TestDiffGlobalSecondaryIndexes(t *testing.T) {
 			got := diffGlobalSecondaryIndexes(tc.args.spec, tc.args.obs)
 			if diff := cmp.Diff(got, tc.want.result); diff != "" {
 				t.Errorf("diffGlobalSecondaryIndexes(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPreCreate(t *testing.T) {
+	type args struct {
+		cr  *svcapitypes.Table
+		obj *svcsdk.CreateTableInput
+	}
+	type want struct {
+		obj *svcsdk.CreateTableInput
+		err error
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"PayPerRequestStripsProvisionedThroughput": {
+			args: args{
+				cr: &svcapitypes.Table{},
+				obj: &svcsdk.CreateTableInput{
+					BillingMode: aws.String(svcsdk.BillingModePayPerRequest),
+					ProvisionedThroughput: &svcsdk.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(0),
+						WriteCapacityUnits: aws.Int64(0),
+					},
+				},
+			},
+			want: want{
+				obj: &svcsdk.CreateTableInput{
+					BillingMode:           aws.String(svcsdk.BillingModePayPerRequest),
+					ProvisionedThroughput: nil,
+				},
+			},
+		},
+		"ProvisionedKeepsProvisionedThroughput": {
+			args: args{
+				cr: &svcapitypes.Table{},
+				obj: &svcsdk.CreateTableInput{
+					BillingMode: aws.String(svcsdk.BillingModeProvisioned),
+					ProvisionedThroughput: &svcsdk.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(5),
+						WriteCapacityUnits: aws.Int64(5),
+					},
+				},
+			},
+			want: want{
+				obj: &svcsdk.CreateTableInput{
+					BillingMode: aws.String(svcsdk.BillingModeProvisioned),
+					ProvisionedThroughput: &svcsdk.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(5),
+						WriteCapacityUnits: aws.Int64(5),
+					},
+				},
+			},
+		},
+		"NilBillingModeKeepsProvisionedThroughput": {
+			args: args{
+				cr: &svcapitypes.Table{},
+				obj: &svcsdk.CreateTableInput{
+					ProvisionedThroughput: &svcsdk.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(1),
+						WriteCapacityUnits: aws.Int64(1),
+					},
+				},
+			},
+			want: want{
+				obj: &svcsdk.CreateTableInput{
+					ProvisionedThroughput: &svcsdk.ProvisionedThroughput{
+						ReadCapacityUnits:  aws.Int64(1),
+						WriteCapacityUnits: aws.Int64(1),
+					},
+				},
+			},
+		},
+		"PayPerRequestWithNilProvisionedThroughput": {
+			args: args{
+				cr: &svcapitypes.Table{},
+				obj: &svcsdk.CreateTableInput{
+					BillingMode: aws.String(svcsdk.BillingModePayPerRequest),
+				},
+			},
+			want: want{
+				obj: &svcsdk.CreateTableInput{
+					BillingMode:           aws.String(svcsdk.BillingModePayPerRequest),
+					ProvisionedThroughput: nil,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := preCreate(context.Background(), tc.args.cr, tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err); diff != "" {
+				t.Errorf("preCreate(...): -want error, +got error:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.obj, tc.args.obj); diff != "" {
+				t.Errorf("preCreate(...): -want, +got:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2324 

When a DynamoDB table uses PAY_PER_REQUEST billing mode, AWS always returns ProvisionedThroughput: {0, 0} in DescribeTable output (meaningless filler for on-demand tables). The provider was blindly late-initializing these zero values into the managed resource spec. If the table was later deleted externally, the provider would try to recreate it with those zeros in the CreateTableInput, which AWS rejects because:
-  You cannot specify ProvisionedThroughput when BillingMode is PAY_PER_REQUEST
-  Even for PROVISIONED mode, the minimum value is 1 (not 0)

  This PR fixes the issue in two places:

  1. lateInitialize: Skip late-initializing ProvisionedThroughput when BillingMode is PAY_PER_REQUEST. The billing mode is always
  resolved earlier in the function, so it's guaranteed to be set by this point.
  2. preCreate: Strip ProvisionedThroughput from CreateTableInput when BillingMode is PAY_PER_REQUEST. This is a safety net for existing managed resources that already have the zero values persisted in their spec from before the fix.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Added unit tests covering:

- TestLateInitialize: Updated EmptyParams case to verify ProvisionedThroughput is NOT late-initialized when BillingMode is
  PAY_PER_REQUEST. Added EmptyParamsProvisioned case to verify it IS still late-initialized for PROVISIONED tables.
- TestPreCreate: New test with 4 cases — PAY_PER_REQUEST strips throughput, PROVISIONED keeps throughput, nil BillingMode keep throughput, PAY_PER_REQUEST with nil throughput (no-op).

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
