### PR TITLE
fix(mq/broker): implement isUpToDate so spec changes are actually applied

### DIFF
--- a/pkg/controller/mq/broker/setup.go
+++ b/pkg/controller/mq/broker/setup.go
@@ -207,32 +207,53 @@ func isUpToDate(_ context.Context, cr *svcapitypes.Broker, obj *svcsdk.DescribeB
 	// GenerateUpdateBrokerRequest, an unset sub-field is never sent to AWS,
 	// so comparing it against the observed value could flag a permanent,
 	// unfixable diff.
-	var currentAudit, currentGeneral *bool
-	if obj.Logs != nil {
-		currentAudit, currentGeneral = obj.Logs.Audit, obj.Logs.General
+	if !logsUpToDate(p.Logs, obj.Logs) {
+		return false, "logs is not up to date", nil
 	}
-	if want := p.Logs; want != nil {
-		if (want.Audit != nil && pointer.BoolValue(want.Audit) != pointer.BoolValue(currentAudit)) ||
-			(want.General != nil && pointer.BoolValue(want.General) != pointer.BoolValue(currentGeneral)) {
-			return false, "logs is not up to date", nil
-		}
-	}
-
-	var currentDayOfWeek, currentTimeOfDay, currentTimeZone *string
-	if obj.MaintenanceWindowStartTime != nil {
-		currentDayOfWeek = obj.MaintenanceWindowStartTime.DayOfWeek
-		currentTimeOfDay = obj.MaintenanceWindowStartTime.TimeOfDay
-		currentTimeZone = obj.MaintenanceWindowStartTime.TimeZone
-	}
-	if want := p.MaintenanceWindowStartTime; want != nil {
-		if (want.DayOfWeek != nil && pointer.StringValue(want.DayOfWeek) != pointer.StringValue(currentDayOfWeek)) ||
-			(want.TimeOfDay != nil && pointer.StringValue(want.TimeOfDay) != pointer.StringValue(currentTimeOfDay)) ||
-			(want.TimeZone != nil && pointer.StringValue(want.TimeZone) != pointer.StringValue(currentTimeZone)) {
-			return false, "maintenanceWindowStartTime is not up to date", nil
-		}
+	if !maintenanceWindowUpToDate(p.MaintenanceWindowStartTime, obj.MaintenanceWindowStartTime) {
+		return false, "maintenanceWindowStartTime is not up to date", nil
 	}
 
 	return true, "", nil
+}
+
+func logsUpToDate(want *svcapitypes.Logs, current *svcsdk.LogsSummary) bool {
+	if want == nil {
+		return true
+	}
+	var currentAudit, currentGeneral *bool
+	if current != nil {
+		currentAudit, currentGeneral = current.Audit, current.General
+	}
+	if want.Audit != nil && pointer.BoolValue(want.Audit) != pointer.BoolValue(currentAudit) {
+		return false
+	}
+	if want.General != nil && pointer.BoolValue(want.General) != pointer.BoolValue(currentGeneral) {
+		return false
+	}
+	return true
+}
+
+func maintenanceWindowUpToDate(want *svcapitypes.WeeklyStartTime, current *svcsdk.WeeklyStartTime) bool {
+	if want == nil {
+		return true
+	}
+	var currentDayOfWeek, currentTimeOfDay, currentTimeZone *string
+	if current != nil {
+		currentDayOfWeek = current.DayOfWeek
+		currentTimeOfDay = current.TimeOfDay
+		currentTimeZone = current.TimeZone
+	}
+	if want.DayOfWeek != nil && pointer.StringValue(want.DayOfWeek) != pointer.StringValue(currentDayOfWeek) {
+		return false
+	}
+	if want.TimeOfDay != nil && pointer.StringValue(want.TimeOfDay) != pointer.StringValue(currentTimeOfDay) {
+		return false
+	}
+	if want.TimeZone != nil && pointer.StringValue(want.TimeZone) != pointer.StringValue(currentTimeZone) {
+		return false
+	}
+	return true
 }
 
 // LateInitialize fills the empty fields in *svcapitypes.BrokerParameters with

--- a/pkg/controller/mq/broker/setup.go
+++ b/pkg/controller/mq/broker/setup.go
@@ -40,6 +40,7 @@ func SetupBroker(mgr ctrl.Manager, o controller.Options) error {
 			e.preDelete = preDelete
 			e.postObserve = c.postObserve
 			e.lateInitialize = LateInitialize
+			e.isUpToDate = isUpToDate
 		},
 	}
 
@@ -180,6 +181,58 @@ func postCreate(_ context.Context, cr *svcapitypes.Broker, obj *svcsdk.CreateBro
 
 	meta.SetExternalName(cr, pointer.StringValue(obj.BrokerId))
 	return cre, nil
+}
+
+// isUpToDate compares the mutable fields accepted by UpdateBroker (see
+// GenerateUpdateBrokerRequest) against the broker's observed state. Broker's
+// generated isUpToDate defaulted to alwaysUpToDate, so changes to e.g.
+// EngineVersion or MaintenanceWindowStartTime were silently ignored.
+func isUpToDate(_ context.Context, cr *svcapitypes.Broker, obj *svcsdk.DescribeBrokerResponse) (bool, string, error) {
+	p := cr.Spec.ForProvider
+
+	if pointer.StringValue(p.AuthenticationStrategy) != pointer.StringValue(obj.AuthenticationStrategy) {
+		return false, "authenticationStrategy is not up to date", nil
+	}
+	if pointer.BoolValue(p.AutoMinorVersionUpgrade) != pointer.BoolValue(obj.AutoMinorVersionUpgrade) {
+		return false, "autoMinorVersionUpgrade is not up to date", nil
+	}
+	if pointer.StringValue(p.EngineVersion) != pointer.StringValue(obj.EngineVersion) {
+		return false, "engineVersion is not up to date", nil
+	}
+	if pointer.StringValue(p.HostInstanceType) != pointer.StringValue(obj.HostInstanceType) {
+		return false, "hostInstanceType is not up to date", nil
+	}
+
+	// Only sub-fields the caller actually set are compared: like
+	// GenerateUpdateBrokerRequest, an unset sub-field is never sent to AWS,
+	// so comparing it against the observed value could flag a permanent,
+	// unfixable diff.
+	var currentAudit, currentGeneral *bool
+	if obj.Logs != nil {
+		currentAudit, currentGeneral = obj.Logs.Audit, obj.Logs.General
+	}
+	if want := p.Logs; want != nil {
+		if (want.Audit != nil && pointer.BoolValue(want.Audit) != pointer.BoolValue(currentAudit)) ||
+			(want.General != nil && pointer.BoolValue(want.General) != pointer.BoolValue(currentGeneral)) {
+			return false, "logs is not up to date", nil
+		}
+	}
+
+	var currentDayOfWeek, currentTimeOfDay, currentTimeZone *string
+	if obj.MaintenanceWindowStartTime != nil {
+		currentDayOfWeek = obj.MaintenanceWindowStartTime.DayOfWeek
+		currentTimeOfDay = obj.MaintenanceWindowStartTime.TimeOfDay
+		currentTimeZone = obj.MaintenanceWindowStartTime.TimeZone
+	}
+	if want := p.MaintenanceWindowStartTime; want != nil {
+		if (want.DayOfWeek != nil && pointer.StringValue(want.DayOfWeek) != pointer.StringValue(currentDayOfWeek)) ||
+			(want.TimeOfDay != nil && pointer.StringValue(want.TimeOfDay) != pointer.StringValue(currentTimeOfDay)) ||
+			(want.TimeZone != nil && pointer.StringValue(want.TimeZone) != pointer.StringValue(currentTimeZone)) {
+			return false, "maintenanceWindowStartTime is not up to date", nil
+		}
+	}
+
+	return true, "", nil
 }
 
 // LateInitialize fills the empty fields in *svcapitypes.BrokerParameters with

--- a/pkg/controller/mq/broker/setup_test.go
+++ b/pkg/controller/mq/broker/setup_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broker
+
+import (
+	"context"
+	"testing"
+
+	svcsdk "github.com/aws/aws-sdk-go/service/mq"
+	"github.com/google/go-cmp/cmp"
+
+	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/mq/v1alpha1"
+)
+
+func TestIsUpToDate(t *testing.T) {
+	engineVersion := "3.10.25"
+	newEngineVersion := "3.11.16"
+
+	hostInstanceType := "mq.t3.micro"
+	newHostInstanceType := "mq.m5.large"
+
+	dayOfWeek := "MONDAY"
+	newDayOfWeek := "TUESDAY"
+	timeOfDay := "03:00"
+	timeZone := "UTC"
+
+	type args struct {
+		broker                 *svcapitypes.Broker
+		describeBrokerResponse *svcsdk.DescribeBrokerResponse
+	}
+	type want struct {
+		result bool
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"NothingChanged": {
+			args: args{
+				broker: &svcapitypes.Broker{
+					Spec: svcapitypes.BrokerSpec{
+						ForProvider: svcapitypes.BrokerParameters{
+							EngineVersion:    &engineVersion,
+							HostInstanceType: &hostInstanceType,
+							MaintenanceWindowStartTime: &svcapitypes.WeeklyStartTime{
+								DayOfWeek: &dayOfWeek,
+								TimeOfDay: &timeOfDay,
+								TimeZone:  &timeZone,
+							},
+						},
+					},
+				},
+				describeBrokerResponse: &svcsdk.DescribeBrokerResponse{
+					EngineVersion:    &engineVersion,
+					HostInstanceType: &hostInstanceType,
+					MaintenanceWindowStartTime: &svcsdk.WeeklyStartTime{
+						DayOfWeek: &dayOfWeek,
+						TimeOfDay: &timeOfDay,
+						TimeZone:  &timeZone,
+					},
+				},
+			},
+			want: want{result: true},
+		},
+		"EngineVersionChanged": {
+			args: args{
+				broker: &svcapitypes.Broker{
+					Spec: svcapitypes.BrokerSpec{
+						ForProvider: svcapitypes.BrokerParameters{
+							EngineVersion:    &newEngineVersion,
+							HostInstanceType: &hostInstanceType,
+						},
+					},
+				},
+				describeBrokerResponse: &svcsdk.DescribeBrokerResponse{
+					EngineVersion:    &engineVersion,
+					HostInstanceType: &hostInstanceType,
+				},
+			},
+			want: want{result: false},
+		},
+		"HostInstanceTypeChanged": {
+			args: args{
+				broker: &svcapitypes.Broker{
+					Spec: svcapitypes.BrokerSpec{
+						ForProvider: svcapitypes.BrokerParameters{
+							EngineVersion:    &engineVersion,
+							HostInstanceType: &newHostInstanceType,
+						},
+					},
+				},
+				describeBrokerResponse: &svcsdk.DescribeBrokerResponse{
+					EngineVersion:    &engineVersion,
+					HostInstanceType: &hostInstanceType,
+				},
+			},
+			want: want{result: false},
+		},
+		"MaintenanceWindowChanged": {
+			args: args{
+				broker: &svcapitypes.Broker{
+					Spec: svcapitypes.BrokerSpec{
+						ForProvider: svcapitypes.BrokerParameters{
+							EngineVersion: &engineVersion,
+							MaintenanceWindowStartTime: &svcapitypes.WeeklyStartTime{
+								DayOfWeek: &newDayOfWeek,
+								TimeOfDay: &timeOfDay,
+								TimeZone:  &timeZone,
+							},
+						},
+					},
+				},
+				describeBrokerResponse: &svcsdk.DescribeBrokerResponse{
+					EngineVersion: &engineVersion,
+					MaintenanceWindowStartTime: &svcsdk.WeeklyStartTime{
+						DayOfWeek: &dayOfWeek,
+						TimeOfDay: &timeOfDay,
+						TimeZone:  &timeZone,
+					},
+				},
+			},
+			want: want{result: false},
+		},
+		"PartiallySpecifiedMaintenanceWindowMatchesObserved": {
+			// A caller may only set DayOfWeek, leaving TimeOfDay/TimeZone
+			// unset. Since GenerateUpdateBrokerRequest never sends unset
+			// sub-fields to AWS, isUpToDate must not flag a diff for them
+			// either or the resource would be stuck in a permanent,
+			// unfixable "not up to date" loop.
+			args: args{
+				broker: &svcapitypes.Broker{
+					Spec: svcapitypes.BrokerSpec{
+						ForProvider: svcapitypes.BrokerParameters{
+							EngineVersion: &engineVersion,
+							MaintenanceWindowStartTime: &svcapitypes.WeeklyStartTime{
+								DayOfWeek: &dayOfWeek,
+							},
+						},
+					},
+				},
+				describeBrokerResponse: &svcsdk.DescribeBrokerResponse{
+					EngineVersion: &engineVersion,
+					MaintenanceWindowStartTime: &svcsdk.WeeklyStartTime{
+						DayOfWeek: &dayOfWeek,
+						TimeOfDay: &timeOfDay,
+						TimeZone:  &timeZone,
+					},
+				},
+			},
+			want: want{result: true},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result, _, err := isUpToDate(context.TODO(), tc.args.broker, tc.args.describeBrokerResponse)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want.result, result); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The `Broker` (`broker.mq`) controller never overrode the generated `isUpToDate`
hook, so it always used the ACK-generated `alwaysUpToDate` stub
(`pkg/controller/mq/broker/zz_controller.go`), which unconditionally reports
`true`. This meant `Update` was effectively unreachable: changing
`engineVersion`, `hostInstanceType`, `maintenanceWindowStartTime`,
`authenticationStrategy`, or `logs` on the spec was silently ignored, and the
reconciler always logged "External resource is up to date" even though AWS
still had the old configuration.

This adds a real `isUpToDate` in `pkg/controller/mq/broker/setup.go`, wired up
the same way sibling ACK-generated controllers in this repo do it (e.g.
`mwaa/environment`, `glue/trigger`). It compares the spec against the observed
`DescribeBroker` response for exactly the fields that `GenerateUpdateBrokerRequest`
(`zz_conversions.go`) actually sends on Update: `AuthenticationStrategy`,
`AutoMinorVersionUpgrade`, `EngineVersion`, `HostInstanceType`, `Logs`, and
`MaintenanceWindowStartTime`.

Fields were deliberately excluded to avoid introducing a new, worse bug (a
permanent, unfixable "not up to date" diff / no-op update loop):
- `Configuration` and `LDAPServerMetadata` are not symmetrically returned by
  `DescribeBroker` into `Spec.ForProvider` (or are masked, e.g. the LDAP bind
  password), so comparing them would always show a diff.
- `DataReplicationMode` is mutable but not late-initialized, so an unset spec
  value could permanently diff against a non-nil AWS value that `Update` would
  never actually send.
- For `Logs` and `MaintenanceWindowStartTime`, each sub-field comparison is
  individually gated on the corresponding spec sub-field being non-nil,
  matching `GenerateUpdateBrokerRequest`'s own per-sub-field `if != nil`
  behavior, so partially-specified structs don't cause a permanent diff either.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran, from the repo root:

- `go build ./...` — passes.
- `go vet ./pkg/controller/mq/broker/...` — only a pre-existing warning in the
  generated `zz_conversions.go` (unkeyed `metav1.Time` struct literal),
  unrelated to this change and present before it too.
- `go test ./pkg/controller/mq/... ./pkg/clients/mq/...` — passes.

Added a new table-driven `TestIsUpToDate` in
`pkg/controller/mq/broker/setup_test.go` covering: no change, `engineVersion`
changed, `hostInstanceType` changed, `maintenanceWindowStartTime` changed, and
a partially-specified `maintenanceWindowStartTime` (only `dayOfWeek` set in
spec) correctly reporting up-to-date against an AWS response that also has
`timeOfDay`/`timeZone` set. Before this change `isUpToDate` didn't exist as a
standalone function (the generated stub was used directly), so these cases
could not even be expressed as a unit test — this failing-to-compile-then-passing
progression is the reproduction for this defect class (an always-true stub).

I did not have access to a live AWS account/broker to reproduce the original
end-to-end symptom described in the issue (updating a running RabbitMQ broker
and observing the reconciler log). The fix is scoped strictly to the fields
`GenerateUpdateBrokerRequest` actually sends on `Update`, so the mechanism by
which the bug occurred (missing `isUpToDate` override defaulting to
`alwaysUpToDate`) is directly addressed and verifiable by reading
`zz_controller.go`'s `newExternal()`/`alwaysUpToDate`.

[contribution process]: https://git.io/fj2m9

Fixes #2093