### PR TITLE
DynamoDB Table: Detect and reconcile tag drift using sorted ListTagsOfResource

### DIFF
--- a/pkg/controller/dynamodb/table/hooks.go
+++ b/pkg/controller/dynamodb/table/hooks.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
 	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -357,6 +359,81 @@ func buildLocalIndexes(indexes []*svcsdk.LocalSecondaryIndexDescription) []*svca
 	return localSecondaryIndexes
 }
 
+// tagLister is a narrow interface for fetching DynamoDB resource tags.
+// Using a narrow interface instead of the full svcsdkapi.DynamoDBAPI keeps the
+// updateClient lean and makes unit-testing the tag comparison straightforward.
+type tagLister interface {
+	ListTagsOfResourceWithContext(aws.Context, *svcsdk.ListTagsOfResourceInput, ...request.Option) (*svcsdk.ListTagsOfResourceOutput, error)
+}
+
+// sortDynamoDBTags returns a stable copy of the tag slice sorted by key then
+// value. The original slice is not modified.
+func sortDynamoDBTags(tags []*svcsdk.Tag) []*svcsdk.Tag {
+	out := make([]*svcsdk.Tag, len(tags))
+	copy(out, tags)
+	sort.Slice(out, func(i, j int) bool {
+		ki, kj := ptr.Deref(out[i].Key, ""), ptr.Deref(out[j].Key, "")
+		if ki != kj {
+			return ki < kj
+		}
+		return ptr.Deref(out[i].Value, "") < ptr.Deref(out[j].Value, "")
+	})
+	return out
+}
+
+// specTagsToSDK converts the spec tag slice (svcapitypes.Tag) into the SDK
+// wire type ([]*svcsdk.Tag) so both sides can be compared uniformly.
+func specTagsToSDK(tags []*svcapitypes.Tag) []*svcsdk.Tag {
+	out := make([]*svcsdk.Tag, 0, len(tags))
+	for _, t := range tags {
+		if t == nil {
+			continue
+		}
+		out = append(out, &svcsdk.Tag{Key: t.Key, Value: t.Value})
+	}
+	return out
+}
+
+// filterManagedTags removes AWS-managed tags (keys prefixed with "aws:") from
+// the slice. These tags are appended by AWS services and are not user-managed,
+// so including them in drift detection would cause false positives.
+func filterManagedTags(tags []*svcsdk.Tag) []*svcsdk.Tag {
+	out := make([]*svcsdk.Tag, 0, len(tags))
+	for _, t := range tags {
+		if t != nil && !strings.HasPrefix(ptr.Deref(t.Key, ""), "aws:") {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// areDynamoDBTagsEqual fetches the current tags for the table from AWS and
+// compares them (order-insensitively) with what is declared in the spec.
+// AWS-managed tags (keys prefixed with "aws:") are excluded from comparison.
+// Returns true when the user-managed tag sets are identical.
+func (e *updateClient) areDynamoDBTagsEqual(ctx aws.Context, tableArn *string, specTags []*svcapitypes.Tag) (bool, error) {
+	resp, err := e.client.ListTagsOfResourceWithContext(ctx, &svcsdk.ListTagsOfResourceInput{
+		ResourceArn: tableArn,
+	})
+	if err != nil {
+		return false, errors.Wrap(err, "cannot list DynamoDB resource tags")
+	}
+
+	observed := sortDynamoDBTags(filterManagedTags(resp.Tags))
+	desired := sortDynamoDBTags(specTagsToSDK(specTags))
+
+	if len(observed) != len(desired) {
+		return false, nil
+	}
+	for i := range observed {
+		if ptr.Deref(observed[i].Key, "") != ptr.Deref(desired[i].Key, "") ||
+			ptr.Deref(observed[i].Value, "") != ptr.Deref(desired[i].Value, "") {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // createPatch creates a *svcapitypes.TableParameters that has only the changed
 // values between the target *svcapitypes.TableParameters and the current
 // *dynamodb.TableDescription
@@ -406,8 +483,19 @@ func (e *updateClient) isCoreResourceUpToDate(ctx context.Context, cr *svcapityp
 		return false, err
 	}
 
-	// TODO(negz): Support updating tags if possible.
-	// https://github.com/crossplane-contrib/provider-aws/issues/945
+	// Compare tags order-insensitively. DescribeTable does not return tags;
+	// they require a separate ListTagsOfResource call. We always run this
+	// check (when we have a TableArn) so we can detect drift in both
+	// directions: tags added outside the spec or tags removed from AWS.
+	if resp.Table.TableArn != nil {
+		tagsEqual, err := e.areDynamoDBTagsEqual(ctx, resp.Table.TableArn, cr.Spec.ForProvider.Tags)
+		if err != nil {
+			return false, errors.Wrap(err, "cannot compare DynamoDB tags")
+		}
+		if !tagsEqual {
+			return false, nil
+		}
+	}
 
 	// At least one of ProvisionedThroughput, BillingMode, UpdateStreamEnabled,
 	// GlobalSecondaryIndexUpdates or SSESpecification or ReplicaUpdates is

--- a/pkg/controller/dynamodb/table/hooks_test.go
+++ b/pkg/controller/dynamodb/table/hooks_test.go
@@ -21,10 +21,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	svcsdk "github.com/aws/aws-sdk-go/service/dynamodb"
+	svcsdkapi "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	kmstypes "github.com/aws/aws-sdk-go/service/kms"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 
 	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/dynamodb/v1alpha1"
@@ -34,6 +37,8 @@ import (
 var (
 	readCapacityUnits  = 1
 	writeCapacityUnits = 1
+
+	errListTagsFailed = errors.New("ListTagsOfResource boom")
 )
 
 type kmsAPIModifier func(mock *mockkms.MockKMSAPI)
@@ -972,6 +977,253 @@ func TestPreCreate(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.obj, tc.args.obj); diff != "" {
 				t.Errorf("preCreate(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+// fakeTagLister implements svcsdkapi.DynamoDBAPI just enough for tag tests.
+// All methods not used by the tag helpers panic to surface unexpected calls.
+type fakeTagLister struct {
+	svcsdkapi.DynamoDBAPI // embed to satisfy the interface
+	tags                  []*svcsdk.Tag
+	err                   error
+}
+
+func (f *fakeTagLister) ListTagsOfResourceWithContext(_ aws.Context, _ *svcsdk.ListTagsOfResourceInput, _ ...request.Option) (*svcsdk.ListTagsOfResourceOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &svcsdk.ListTagsOfResourceOutput{Tags: f.tags}, nil
+}
+
+func TestSortDynamoDBTags(t *testing.T) {
+	cases := map[string]struct {
+		input []*svcsdk.Tag
+		want  []*svcsdk.Tag
+	}{
+		"AlreadySorted": {
+			input: []*svcsdk.Tag{
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("b"), Value: aws.String("2")},
+			},
+			want: []*svcsdk.Tag{
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("b"), Value: aws.String("2")},
+			},
+		},
+		"ReverseOrder": {
+			input: []*svcsdk.Tag{
+				{Key: aws.String("z"), Value: aws.String("9")},
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("m"), Value: aws.String("5")},
+			},
+			want: []*svcsdk.Tag{
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("m"), Value: aws.String("5")},
+				{Key: aws.String("z"), Value: aws.String("9")},
+			},
+		},
+		"SameKeySortByValue": {
+			input: []*svcsdk.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("env"), Value: aws.String("dev")},
+			},
+			want: []*svcsdk.Tag{
+				{Key: aws.String("env"), Value: aws.String("dev")},
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+		},
+		"EmptySlice": {
+			input: []*svcsdk.Tag{},
+			want:  []*svcsdk.Tag{},
+		},
+		"NilSlice": {
+			input: nil,
+			want:  []*svcsdk.Tag{},
+		},
+		"OriginalNotMutated": {
+			// sortDynamoDBTags must not mutate the original slice
+			input: []*svcsdk.Tag{
+				{Key: aws.String("b"), Value: aws.String("2")},
+				{Key: aws.String("a"), Value: aws.String("1")},
+			},
+			want: []*svcsdk.Tag{
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("b"), Value: aws.String("2")},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// keep a copy of the original to verify it wasn't mutated
+			origLen := len(tc.input)
+			origKeys := make([]string, origLen)
+			for i, tag := range tc.input {
+				if tag != nil && tag.Key != nil {
+					origKeys[i] = *tag.Key
+				}
+			}
+
+			got := sortDynamoDBTags(tc.input)
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("sortDynamoDBTags(%v): -want, +got:\n%s", name, diff)
+			}
+
+			// verify original slice key order was not changed
+			for i, tag := range tc.input {
+				if tag != nil && tag.Key != nil && *tag.Key != origKeys[i] {
+					t.Errorf("sortDynamoDBTags mutated the original slice at index %d", i)
+				}
+			}
+		})
+	}
+}
+
+func TestAreDynamoDBTagsEqual(t *testing.T) {
+	tableArn := aws.String("arn:aws:dynamodb:us-east-1:123456789012:table/test-table")
+
+	cases := map[string]struct {
+		observedTags []*svcsdk.Tag
+		specTags     []*svcapitypes.Tag
+		listErr      error
+		wantEqual    bool
+		wantErr      bool
+	}{
+		// Core behaviour: equal sets regardless of arrival order
+		"EqualTagsAlreadySorted": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("team"), Value: aws.String("platform")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("team"), Value: aws.String("platform")},
+			},
+			wantEqual: true,
+		},
+		// KEY FIX: unsorted tags from AWS must still compare equal to sorted spec
+		"EqualTagsUnsortedFromAWS": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("team"), Value: aws.String("platform")},
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("cost-center"), Value: aws.String("eng")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("cost-center"), Value: aws.String("eng")},
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("team"), Value: aws.String("platform")},
+			},
+			wantEqual: true,
+		},
+		// KEY FIX: unsorted spec must still match sorted AWS response
+		"EqualTagsUnsortedSpec": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("b"), Value: aws.String("2")},
+				{Key: aws.String("c"), Value: aws.String("3")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("c"), Value: aws.String("3")},
+				{Key: aws.String("a"), Value: aws.String("1")},
+				{Key: aws.String("b"), Value: aws.String("2")},
+			},
+			wantEqual: true,
+		},
+		"DifferentTagValues": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("env"), Value: aws.String("staging")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+			wantEqual: false,
+		},
+		"DifferentTagKeys": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("environment"), Value: aws.String("prod")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+			wantEqual: false,
+		},
+		"ExtraTagOnAWS": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("extra"), Value: aws.String("val")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+			wantEqual: false,
+		},
+		"ExtraTagInSpec": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+				{Key: aws.String("extra"), Value: aws.String("val")},
+			},
+			wantEqual: false,
+		},
+		"BothEmpty": {
+			observedTags: []*svcsdk.Tag{},
+			specTags:     []*svcapitypes.Tag{},
+			wantEqual:    true,
+		},
+		"BothNil": {
+			observedTags: nil,
+			specTags:     nil,
+			wantEqual:    true,
+		},
+		"ListTagsError": {
+			listErr: errListTagsFailed,
+			wantErr: true,
+		},
+		// AWS-managed tags (aws: prefix) must be ignored; their presence on the
+		// observed side should not cause a false drift signal.
+		"AWSManagedTagsIgnored": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("aws:cloudformation:stack-name"), Value: aws.String("my-stack")},
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+			specTags: []*svcapitypes.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			},
+			wantEqual: true,
+		},
+		// Only aws: tags differ — no user-managed drift, must be equal.
+		"OnlyAWSManagedTagsOnAWSSide": {
+			observedTags: []*svcsdk.Tag{
+				{Key: aws.String("aws:eks:cluster-name"), Value: aws.String("cluster")},
+			},
+			specTags:  []*svcapitypes.Tag{},
+			wantEqual: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			u := &updateClient{
+				client: &fakeTagLister{
+					tags: tc.observedTags,
+					err:  tc.listErr,
+				},
+			}
+
+			got, err := u.areDynamoDBTagsEqual(context.Background(), tableArn, tc.specTags)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("areDynamoDBTagsEqual() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if !tc.wantErr {
+				if diff := cmp.Diff(tc.wantEqual, got); diff != "" {
+					t.Errorf("areDynamoDBTagsEqual(): -want, +got:\n%s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Desc:

`DescribeTable` does not return resource tags — they require a separate `ListTagsOfResource` call. The reconciler previously had no tag comparison at all (only a TODO comment), meaning tag drift was silently ignored after initial resource creation and any tags changed outside Crossplane were never reconciled back.

AWS returns tag slices in non-deterministic order. Without sorting before comparison, any tag check would produce false "needs update" signals on every reconcile, contributing to the throttling pattern described in #1081.

AWS-managed tags (`aws:` prefix, e.g. `aws:cloudformation:stack-name`) are excluded from comparison — these are appended by AWS services outside user control and would cause permanent false drift on tables co-managed with CloudFormation or EKS.

S3 already handles this correctly via `SortS3TagSet` in `tagging_config.go` — no change needed there.

**What changed:**
- `tagLister`: narrow interface wrapping `ListTagsOfResource` — no new dependency, easy to stub in tests.
- `filterManagedTags`: strips `aws:`-prefixed keys before comparison; applied to the observed (AWS) side only.
- `sortDynamoDBTags`: returns a sorted copy without mutating the input.
- `specTagsToSDK`: converts `svcapitypes.Tag` to `svcsdk.Tag` for a consistent comparison type on both sides.
- `areDynamoDBTagsEqual`: fetches live tags, filters managed tags, sorts both sides, compares element-by-element.
- Plugged into `isCoreResourceUpToDate`, replacing the existing TODO.

Related: #1081, #385

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

New table-driven tests in `hooks_test.go` (`TestSortDynamoDBTags` + `TestAreDynamoDBTagsEqual`, 18 cases):

| Scenario | Validates |
|---|---|
| Equal tags, already sorted | baseline correctness |
| Equal tags, unsorted AWS response | core fix — no false positive |
| Equal tags, unsorted spec | symmetry |
| Same key, sort by value | sort stability |
| Value / key mismatch | drift detected |
| Extra tag on AWS or in spec | count mismatch caught |
| Both nil / both empty | zero-value safety |
| `aws:` tags alongside user tags | system tags correctly ignored |
| Only `aws:` tags on AWS side | no false drift |
| `ListTagsOfResource` error | error propagated correctly |
| Input slice not mutated by sort | no side-effects |

```
ok  github.com/crossplane-contrib/provider-aws/pkg/controller/dynamodb/table
```

[contribution process]: https://git.io/fj2m9
