### PR TITLE
SNS Topic: Stop False Reconcile Loop on Plain Topics

### DIFF
--- a/pkg/clients/sns/topic.go
+++ b/pkg/clients/sns/topic.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/crossplane-contrib/provider-aws/apis/sns/v1beta1"
-	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
 	policyutils "github.com/crossplane-contrib/provider-aws/pkg/utils/policy"
 )
 
@@ -97,19 +96,36 @@ func GenerateCreateTopicInput(p *v1beta1.TopicParameters) *sns.CreateTopicInput 
 	return input
 }
 
-// LateInitializeTopicAttr fills the empty fields in *v1beta1.TopicParameters with the
-// values seen in sns.Topic.
-func LateInitializeTopicAttr(in *v1beta1.TopicParameters, attrs map[string]string) {
-	in.DisplayName = pointer.LateInitialize(in.DisplayName, aws.String(attrs[string(TopicDisplayName)]))
-	in.DeliveryPolicy = pointer.LateInitialize(in.DeliveryPolicy, aws.String(attrs[string(TopicDeliveryPolicy)]))
-	in.KMSMasterKeyID = pointer.LateInitialize(in.KMSMasterKeyID, aws.String(attrs[string(TopicKmsMasterKeyID)]))
-	in.Policy = pointer.LateInitialize(in.Policy, aws.String(attrs[string(TopicPolicy)]))
+// LateInitializeTopicAttr fills unset fields in *v1beta1.TopicParameters with
+// server-side defaults returned by GetTopicAttributes. Only non-empty attribute
+// values are copied; writing an empty-string pointer would mark the resource as
+// late-initialized on every reconcile even when the attribute is unset in AWS
+// (missing map keys return "" in Go). Returns true when any field was changed.
+func LateInitializeTopicAttr(in *v1beta1.TopicParameters, attrs map[string]string) bool {
+	modified := false
+	modified = lateInitStringAttr(attrs[string(TopicDisplayName)], &in.DisplayName) || modified
+	modified = lateInitStringAttr(attrs[string(TopicDeliveryPolicy)], &in.DeliveryPolicy) || modified
+	modified = lateInitStringAttr(attrs[string(TopicKmsMasterKeyID)], &in.KMSMasterKeyID) || modified
+	modified = lateInitStringAttr(attrs[string(TopicPolicy)], &in.Policy) || modified
 
-	in.FifoTopic = nil
-	fifoTopic, err := strconv.ParseBool(attrs[string(TopicFifoTopic)])
-	if err == nil && fifoTopic {
-		in.FifoTopic = pointer.LateInitialize(in.FifoTopic, aws.Bool(fifoTopic))
+	// FifoTopic is immutable; only late-initialize when AWS confirms it is true.
+	if in.FifoTopic == nil {
+		if fifoTopic, err := strconv.ParseBool(attrs[string(TopicFifoTopic)]); err == nil && fifoTopic {
+			in.FifoTopic = aws.Bool(true)
+			modified = true
+		}
 	}
+	return modified
+}
+
+// lateInitStringAttr copies awsVal into *field when the AWS value is non-empty
+// and the field has not yet been set. Returns true when the field was updated.
+func lateInitStringAttr(awsVal string, field **string) bool {
+	if awsVal != "" && *field == nil {
+		*field = aws.String(awsVal)
+		return true
+	}
+	return false
 }
 
 // GetChangedAttributes will return the changed attributes for a topic in AWS side.

--- a/pkg/clients/sns/topic_test.go
+++ b/pkg/clients/sns/topic_test.go
@@ -434,3 +434,192 @@ func TestIsSNSTopicUpToDate(t *testing.T) {
 		})
 	}
 }
+
+func TestLateInitializeTopicAttr(t *testing.T) {
+	kmsKeyID := "arn:aws:kms:us-east-1:123456789012:key/test-key"
+	displayName := "my-topic"
+	deliveryPolicy := `{"http":{"defaultHealthyRetryPolicy":{"numRetries":3}}}`
+	policy := `{"Version":"2012-10-17","Statement":[]}`
+
+	type args struct {
+		in   *v1beta1.TopicParameters
+		attr map[string]string
+	}
+	type want struct {
+		modified bool
+		in       *v1beta1.TopicParameters
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		// Core fix: empty-string attributes must not populate spec fields.
+		"NoOpWhenAllAttrsEmpty": {
+			args: args{
+				in:   &v1beta1.TopicParameters{Name: topicName},
+				attr: topicAttributes(), // all keys absent → zero-value ""
+			},
+			want: want{
+				modified: false,
+				in:       &v1beta1.TopicParameters{Name: topicName},
+			},
+		},
+		// KMSMasterKeyID is populated when AWS returns a real key ARN.
+		"KMSMasterKeyIDCopied": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicKmsMasterKeyID): kmsKeyID,
+				},
+			},
+			want: want{
+				modified: true,
+				in: &v1beta1.TopicParameters{
+					Name:           topicName,
+					KMSMasterKeyID: aws.String(kmsKeyID),
+				},
+			},
+		},
+		// Already-set spec field must not be overwritten.
+		"KMSMasterKeyIDNotOverwritten": {
+			args: args{
+				in: &v1beta1.TopicParameters{
+					Name:           topicName,
+					KMSMasterKeyID: aws.String("existing-key"),
+				},
+				attr: map[string]string{
+					string(TopicKmsMasterKeyID): kmsKeyID,
+				},
+			},
+			want: want{
+				modified: false,
+				in: &v1beta1.TopicParameters{
+					Name:           topicName,
+					KMSMasterKeyID: aws.String("existing-key"),
+				},
+			},
+		},
+		"DisplayNameCopied": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicDisplayName): displayName,
+				},
+			},
+			want: want{
+				modified: true,
+				in: &v1beta1.TopicParameters{
+					Name:        topicName,
+					DisplayName: aws.String(displayName),
+				},
+			},
+		},
+		"DeliveryPolicyCopied": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicDeliveryPolicy): deliveryPolicy,
+				},
+			},
+			want: want{
+				modified: true,
+				in: &v1beta1.TopicParameters{
+					Name:           topicName,
+					DeliveryPolicy: aws.String(deliveryPolicy),
+				},
+			},
+		},
+		"PolicyCopied": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicPolicy): policy,
+				},
+			},
+			want: want{
+				modified: true,
+				in: &v1beta1.TopicParameters{
+					Name:   topicName,
+					Policy: aws.String(policy),
+				},
+			},
+		},
+		// FifoTopic: only true causes a write; false/absent is a no-op.
+		"FifoTopicTrueCopied": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicFifoTopic): "true",
+				},
+			},
+			want: want{
+				modified: true,
+				in: &v1beta1.TopicParameters{
+					Name:      topicName,
+					FifoTopic: aws.Bool(true),
+				},
+			},
+		},
+		"FifoTopicFalseIsNoOp": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicFifoTopic): "false",
+				},
+			},
+			want: want{
+				modified: false,
+				in:       &v1beta1.TopicParameters{Name: topicName},
+			},
+		},
+		"FifoTopicNotOverwrittenWhenAlreadySet": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName, FifoTopic: aws.Bool(true)},
+				attr: map[string]string{
+					string(TopicFifoTopic): "true",
+				},
+			},
+			want: want{
+				modified: false,
+				in:       &v1beta1.TopicParameters{Name: topicName, FifoTopic: aws.Bool(true)},
+			},
+		},
+		// All fields populated in one pass.
+		"AllFieldsCopied": {
+			args: args{
+				in: &v1beta1.TopicParameters{Name: topicName},
+				attr: map[string]string{
+					string(TopicKmsMasterKeyID): kmsKeyID,
+					string(TopicDisplayName):    displayName,
+					string(TopicDeliveryPolicy): deliveryPolicy,
+					string(TopicPolicy):         policy,
+					string(TopicFifoTopic):      "true",
+				},
+			},
+			want: want{
+				modified: true,
+				in: &v1beta1.TopicParameters{
+					Name:           topicName,
+					KMSMasterKeyID: aws.String(kmsKeyID),
+					DisplayName:    aws.String(displayName),
+					DeliveryPolicy: aws.String(deliveryPolicy),
+					Policy:         aws.String(policy),
+					FifoTopic:      aws.Bool(true),
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := LateInitializeTopicAttr(tc.args.in, tc.args.attr)
+			if diff := cmp.Diff(tc.want.modified, got); diff != "" {
+				t.Errorf("LateInitializeTopicAttr() modified: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.in, tc.args.in); diff != "" {
+				t.Errorf("LateInitializeTopicAttr() params: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/sns/topic/controller.go
+++ b/pkg/controller/sns/topic/controller.go
@@ -18,7 +18,6 @@ package topic
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
@@ -130,8 +129,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 			errorutils.Wrap(resource.Ignore(sns.IsTopicNotFound, err), errGetTopicAttr)
 	}
 
-	current := cr.Spec.ForProvider.DeepCopy()
-	snsclient.LateInitializeTopicAttr(&cr.Spec.ForProvider, res.Attributes)
+	lateInitialized := snsclient.LateInitializeTopicAttr(&cr.Spec.ForProvider, res.Attributes)
 
 	cr.SetConditions(xpv1.Available())
 
@@ -146,7 +144,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	return managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        upToDate,
-		ResourceLateInitialized: !reflect.DeepEqual(current, &cr.Spec.ForProvider),
+		ResourceLateInitialized: lateInitialized,
 	}, nil
 }
 

--- a/pkg/controller/sns/topic/controller_test.go
+++ b/pkg/controller/sns/topic/controller_test.go
@@ -212,16 +212,16 @@ func TestObserve(t *testing.T) {
 				cr: topic(
 					withDisplayName(&topicDisplayName),
 					withTopicARN(&topicName),
-					withPolicy(&empty),
-					withDeliveryPolicy(&empty),
-					withKmsMasterKeyID(&empty),
+					// Empty-string attributes are no longer late-initialized into
+					// the spec; only non-empty AWS values are copied (fixes the
+					// spurious ResourceLateInitialized=true loop, ref #1108).
 					withConditions(xpv1.Available()),
 					withObservationOwner(&empty),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:          true,
 					ResourceUpToDate:        false,
-					ResourceLateInitialized: true,
+					ResourceLateInitialized: false,
 				},
 			},
 		},


### PR DESCRIPTION
### Desc:

`GetTopicAttributes` omits keys for attributes that are not configured (e.g. no KMS key, no display name). Accessing a missing key in a Go map returns `""`, and the previous code passed `aws.String("")` — a non-nil pointer — to `pointer.LateInitialize`. This wrote an empty-string pointer into the spec on the first observe, marking `ResourceLateInitialized: true` every subsequent cycle and triggering a redundant spec patch on every reconcile indefinitely.

This is the same pattern behind #1108 and #980: absent optional attributes being treated as present defaults, creating infinite reconcile loops.

**What changed:**
- `LateInitializeTopicAttr` now guards each attribute behind a non-empty check — only real AWS-returned values are written into the spec.
- `lateInitStringAttr`: extracted helper for the repeated non-empty-check + nil-guard pattern; reduces cyclomatic complexity from 12 to 4.
- Returns `bool` (`modified`) for a precise late-init signal, removing the need for a full `reflect.DeepEqual` on the spec struct in the caller.
- `Observe` in `controller.go` uses the return value directly and drops the `reflect` import.
- One existing test expectation updated: `ResourceLateInitialized` is now correctly `false` when AWS returns no meaningful attributes.

Related: #1108, #980

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

New table-driven tests in `pkg/clients/sns/topic_test.go` (`TestLateInitializeTopicAttr`, 10 cases):

| Scenario | Validates |
|---|---|
| All attributes absent (empty map) | no write, `modified=false` — core fix |
| KMS key ARN present | copied correctly, `modified=true` |
| KMS key already set in spec | not overwritten, `modified=false` |
| DisplayName / DeliveryPolicy / Policy | same pattern for each |
| `FifoTopic: true` | copied correctly |
| `FifoTopic: false` or absent | no write (not a meaningful default) |
| FifoTopic already set | not overwritten |
| All fields populated in one pass | composite correctness |

```
ok  github.com/crossplane-contrib/provider-aws/pkg/clients/sns
ok  github.com/crossplane-contrib/provider-aws/pkg/controller/sns/topic
```

[contribution process]: https://git.io/fj2m9
