### PR TITLE
fix(ec2/vpcendpoint): apply spec.forProvider.tags on create

### DIFF
--- a/pkg/controller/ec2/vpcendpoint/setup.go
+++ b/pkg/controller/ec2/vpcendpoint/setup.go
@@ -2,6 +2,7 @@ package vpcendpoint
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -101,7 +102,32 @@ func preCreate(_ context.Context, cr *svcapitypes.VPCEndpoint, obj *svcsdk.Creat
 		obj.SubnetIds = cr.Spec.ForProvider.SubnetIDs
 	}
 
+	// obj.TagSpecifications may already contain entries generated from
+	// spec.forProvider.tagSpecifications; append rather than overwrite so both
+	// that field and spec.forProvider.tags are honored.
+	if len(cr.Spec.ForProvider.Tags) > 0 {
+		obj.TagSpecifications = append(obj.TagSpecifications, generateTagSpecifications(cr)...)
+	}
+
 	return nil
+}
+
+// generateTagSpecifications converts the tags declared in spec.forProvider.tags
+// into a TagSpecification for the vpc-endpoint resource type, so that they are
+// applied when the VPCEndpoint is created.
+func generateTagSpecifications(cr *svcapitypes.VPCEndpoint) []*svcsdk.TagSpecification {
+	tags := make([]*svcsdk.Tag, 0, len(cr.Spec.ForProvider.Tags))
+	for k, v := range cr.Spec.ForProvider.Tags {
+		tags = append(tags, &svcsdk.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	sort.Slice(tags, func(i, j int) bool {
+		return aws.StringValue(tags[i].Key) < aws.StringValue(tags[j].Key)
+	})
+
+	return []*svcsdk.TagSpecification{{
+		ResourceType: aws.String(svcsdk.ResourceTypeVpcEndpoint),
+		Tags:         tags,
+	}}
 }
 
 func postCreate(ctx context.Context, cr *svcapitypes.VPCEndpoint, obj *svcsdk.CreateVpcEndpointOutput, cre managed.ExternalCreation, err error) (managed.ExternalCreation, error) {

--- a/pkg/controller/ec2/vpcendpoint/setup_test.go
+++ b/pkg/controller/ec2/vpcendpoint/setup_test.go
@@ -174,6 +174,97 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestPreCreate(t *testing.T) {
+	type want struct {
+		tagSpecifications []*ec2.TagSpecification
+	}
+
+	cases := map[string]struct {
+		cr               *v1alpha1.VPCEndpoint
+		existingTagSpecs []*ec2.TagSpecification
+		want             want
+	}{
+		"NoTags": {
+			cr: vpcEndpoint(
+				withSpec(v1alpha1.VPCEndpointParameters{
+					CustomVPCEndpointParameters: v1alpha1.CustomVPCEndpointParameters{
+						VPCID: aws.String(testVPCID),
+					},
+				})),
+			want: want{
+				tagSpecifications: nil,
+			},
+		},
+		"WithTags": {
+			cr: vpcEndpoint(
+				withSpec(v1alpha1.VPCEndpointParameters{
+					CustomVPCEndpointParameters: v1alpha1.CustomVPCEndpointParameters{
+						VPCID: aws.String(testVPCID),
+						Tags: map[string]string{
+							"Name": "my-name",
+							"Team": "crossplane",
+						},
+					},
+				})),
+			want: want{
+				tagSpecifications: []*ec2.TagSpecification{{
+					ResourceType: aws.String(ec2.ResourceTypeVpcEndpoint),
+					Tags: []*ec2.Tag{
+						{Key: aws.String("Name"), Value: aws.String("my-name")},
+						{Key: aws.String("Team"), Value: aws.String("crossplane")},
+					},
+				}},
+			},
+		},
+		"WithTagsAndExistingTagSpecifications": {
+			cr: vpcEndpoint(
+				withSpec(v1alpha1.VPCEndpointParameters{
+					CustomVPCEndpointParameters: v1alpha1.CustomVPCEndpointParameters{
+						VPCID: aws.String(testVPCID),
+						Tags: map[string]string{
+							"Name": "my-name",
+						},
+					},
+				})),
+			existingTagSpecs: []*ec2.TagSpecification{{
+				ResourceType: aws.String(ec2.ResourceTypeVpcEndpoint),
+				Tags: []*ec2.Tag{
+					{Key: aws.String("FromTagSpecifications"), Value: aws.String("true")},
+				},
+			}},
+			want: want{
+				tagSpecifications: []*ec2.TagSpecification{
+					{
+						ResourceType: aws.String(ec2.ResourceTypeVpcEndpoint),
+						Tags: []*ec2.Tag{
+							{Key: aws.String("FromTagSpecifications"), Value: aws.String("true")},
+						},
+					},
+					{
+						ResourceType: aws.String(ec2.ResourceTypeVpcEndpoint),
+						Tags: []*ec2.Tag{
+							{Key: aws.String("Name"), Value: aws.String("my-name")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			obj := &ec2.CreateVpcEndpointInput{TagSpecifications: tc.existingTagSpecs}
+			err := preCreate(context.Background(), tc.cr, obj)
+			if err != nil {
+				t.Errorf("preCreate(...): unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(tc.want.tagSpecifications, obj.TagSpecifications); diff != "" {
+				t.Errorf("preCreate(...): -want tagSpecifications, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestDelete(t *testing.T) {
 	type want struct {
 		cr  *v1alpha1.VPCEndpoint


### PR DESCRIPTION
### Description of your changes

Fixes #2330

`VPCEndpoint`'s `preCreate` hook never copied `spec.forProvider.tags`
(`map[string]string`) into the `TagSpecifications` field of the
`CreateVpcEndpoint` API request, so tags set on a `VPCEndpoint` resource
were silently dropped and never applied to the underlying AWS VPC
Endpoint.

This adds a `generateTagSpecifications` helper that converts
`spec.forProvider.tags` into a `vpc-endpoint` `TagSpecification` and
appends it (rather than overwrites) onto whatever `TagSpecifications`
was already populated from the separate, pre-existing
`spec.forProvider.tagSpecifications` field, so both fields are honored
if a user happens to set both.

Note: this only fixes tag application at creation time. This
controller has no tag-update handling at all today (no `isUpToDate`
tag comparison, no `preUpdate` tag diffing), so changing
`spec.forProvider.tags` after creation still won't be reconciled. That
is a separate, larger change and is left as a follow-up.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran `go build ./pkg/controller/ec2/vpcendpoint/...` and
`go test ./pkg/controller/ec2/vpcendpoint/... -v`; the full package
suite passes, including a new `TestPreCreate` with cases for no tags,
tags only, and tags alongside a pre-existing `TagSpecifications` entry
(verifying the merge/append behavior). I confirmed
`TestPreCreate/WithTags` fails against the pre-fix code and passes
against the post-fix code, i.e. it is a genuine regression test for
the reported bug. `gofmt -l` reports no issues on the changed files.

I could not run this repo's pinned `golangci-lint v1.63.4` locally
(only v2.12.2 is available in this environment, and its config format
is incompatible with the repo's v1-style `.golangci.yml`), nor
`make check-diff` / `make generate` — the change does not touch any
generated API types, so these should be a no-op, but I did not
execute them directly. `master`'s own CI (the `CI` workflow) is
currently green.

[contribution process]: https://git.io/fj2m9