### PR TITLE
fix(rds): correct DBCluster/DBInstance update logic & add DBCluster pendingModifiedValues

### DIFF
--- a/apis/rds/generator-config.yaml
+++ b/apis/rds/generator-config.yaml
@@ -38,7 +38,7 @@ resources:
         is_read_only: true
         from:
           operation: DescribeDBClusters
-          path: DBClusters.Port    
+          path: DBClusters.Port
   DBInstanceRoleAssociation:
     exceptions:
       errors:
@@ -56,7 +56,6 @@ ignore:
     - ModifyDBClusterInput.VpcSecurityGroupIds
     - CreateDBClusterInput.EngineVersion
     - ModifyDBClusterInput.EngineVersion
-    - DBCluster.PendingModifiedValues
     - DescribeDBInstancesInput.DBInstanceIndentifier
     - CreateDBInstanceInput.DBInstanceIdentifier
     - ModifyDBInstanceInput.DBInstanceIdentifier

--- a/apis/rds/v1alpha1/zz_db_cluster.go
+++ b/apis/rds/v1alpha1/zz_db_cluster.go
@@ -743,6 +743,10 @@ type DBClusterObservation struct {
 	MasterUserSecret *MasterUserSecret `json:"masterUserSecret,omitempty"`
 	// Indicates whether the DB cluster has instances in multiple Availability Zones.
 	MultiAZ *bool `json:"multiAZ,omitempty"`
+	// Information about pending changes to the DB cluster. This information is
+	// returned only when there are pending changes. Specific changes are identified
+	// by subelements.
+	PendingModifiedValues *ClusterPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
 	// The progress of the operation as a percentage.
 	PercentProgress *string `json:"percentProgress,omitempty"`
 	// Indicates whether Performance Insights is enabled for the DB cluster.

--- a/apis/rds/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/rds/v1alpha1/zz_generated.deepcopy.go
@@ -1652,6 +1652,11 @@ func (in *DBClusterObservation) DeepCopyInto(out *DBClusterObservation) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PendingModifiedValues != nil {
+		in, out := &in.PendingModifiedValues, &out.PendingModifiedValues
+		*out = new(ClusterPendingModifiedValues)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PercentProgress != nil {
 		in, out := &in.PercentProgress, &out.PercentProgress
 		*out = new(string)
@@ -2795,6 +2800,11 @@ func (in *DBCluster_SDK) DeepCopyInto(out *DBCluster_SDK) {
 		in, out := &in.NetworkType, &out.NetworkType
 		*out = new(string)
 		**out = **in
+	}
+	if in.PendingModifiedValues != nil {
+		in, out := &in.PendingModifiedValues, &out.PendingModifiedValues
+		*out = new(ClusterPendingModifiedValues)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PercentProgress != nil {
 		in, out := &in.PercentProgress, &out.PercentProgress

--- a/apis/rds/v1alpha1/zz_types.go
+++ b/apis/rds/v1alpha1/zz_types.go
@@ -445,6 +445,9 @@ type DBCluster_SDK struct {
 	MultiAZ *bool `json:"multiAZ,omitempty"`
 
 	NetworkType *string `json:"networkType,omitempty"`
+	// This data type is used as a response element in the ModifyDBCluster operation
+	// and contains changes that will be applied during the next maintenance window.
+	PendingModifiedValues *ClusterPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
 
 	PercentProgress *string `json:"percentProgress,omitempty"`
 

--- a/package/crds/rds.aws.crossplane.io_dbclusters.yaml
+++ b/package/crds/rds.aws.crossplane.io_dbclusters.yaml
@@ -1923,6 +1923,54 @@ spec:
                           type: string
                       type: object
                     type: array
+                  pendingModifiedValues:
+                    description: |-
+                      Information about pending changes to the DB cluster. This information is
+                      returned only when there are pending changes. Specific changes are identified
+                      by subelements.
+                    properties:
+                      allocatedStorage:
+                        format: int64
+                        type: integer
+                      backupRetentionPeriod:
+                        format: int64
+                        type: integer
+                      dbClusterIdentifier:
+                        type: string
+                      engineVersion:
+                        type: string
+                      iamDatabaseAuthenticationEnabled:
+                        type: boolean
+                      iops:
+                        format: int64
+                        type: integer
+                      masterUserPassword:
+                        type: string
+                      pendingCloudwatchLogsExports:
+                        description: |-
+                          A list of the log types whose configuration is still pending. In other words,
+                          these log types are in the process of being activated or deactivated.
+                        properties:
+                          logTypesToDisable:
+                            items:
+                              type: string
+                            type: array
+                          logTypesToEnable:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      rdsCustomClusterConfiguration:
+                        description: Reserved for future use.
+                        properties:
+                          interconnectSubnetID:
+                            type: string
+                          transitGatewayMulticastDomainID:
+                            type: string
+                        type: object
+                      storageType:
+                        type: string
+                    type: object
                   percentProgress:
                     description: The progress of the operation as a percentage.
                     type: string

--- a/pkg/controller/rds/dbcluster/setup.go
+++ b/pkg/controller/rds/dbcluster/setup.go
@@ -2,6 +2,9 @@ package dbcluster
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,7 +21,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,19 +45,32 @@ const (
 	errUnknownRestoreFromSource = "unknown restoreFrom source"
 )
 
-type custom struct {
+type shared struct {
 	kube   client.Client
 	client svcsdkapi.RDSAPI
+	cache  *cache
+}
+
+type cache struct {
+	addTags                            []*svcsdk.Tag
+	removeTags                         []*string
+	desiredPassword                    string
+	passwordChanged                    bool
+	engineVersionChanged               bool
+	dbClusterParameterGroupNameChanged bool
+	backupRetentionPeriodChanged       bool
+	backupWindowChanged                bool
 }
 
 func setupExternal(e *external) {
-	h := &custom{client: e.client, kube: e.kube}
+	s := &shared{client: e.client, kube: e.kube, cache: &cache{}}
 	e.preObserve = preObserve
-	e.postObserve = h.postObserve
-	e.isUpToDate = h.isUpToDate
-	e.preUpdate = h.preUpdate
-	e.postUpdate = h.postUpdate
-	e.preCreate = h.preCreate
+	e.postObserve = s.postObserve
+	e.isUpToDate = s.isUpToDate
+	e.preUpdate = s.preUpdate
+	e.postUpdate = s.postUpdate
+	e.preCreate = s.preCreate
+	e.postCreate = s.postCreate
 	e.preDelete = preDelete
 	e.filterList = filterList
 }
@@ -101,7 +119,7 @@ func preObserve(_ context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.Descri
 // described here https://docs.pointer.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Status.html
 // Need to get help from community on how to deal with this. Ideally the status should reflect
 // the true status value as described by the provider.
-func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClustersOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
+func (s *shared) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, resp *svcsdk.DescribeDBClustersOutput, obs managed.ExternalObservation, err error) (managed.ExternalObservation, error) {
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
@@ -121,24 +139,12 @@ func (e *custom) postObserve(ctx context.Context, cr *svcapitypes.DBCluster, res
 	default:
 		cr.SetConditions(xpv1.Unavailable().WithMessage("DB Cluster is " + pointer.StringValue(resp.DBClusters[0].Status)))
 	}
+	obs.ConnectionDetails, err = s.updateConnectionDetails(ctx, cr, obs.ConnectionDetails)
 
-	obs.ConnectionDetails = managed.ConnectionDetails{
-		xpv1.ResourceCredentialsSecretEndpointKey: []byte(pointer.StringValue(cr.Status.AtProvider.Endpoint)),
-		xpv1.ResourceCredentialsSecretUserKey:     []byte(pointer.StringValue(cr.Spec.ForProvider.MasterUsername)),
-		xpv1.ResourceCredentialsSecretPortKey:     []byte(strconv.FormatInt(pointer.Int64Value(cr.Status.AtProvider.Port), 10)),
-		"readerEndpoint":                          []byte(pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint)),
-	}
-
-	pw, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
-	if err != nil {
-		return obs, errors.Wrap(err, dbinstance.ErrGetCachedPassword)
-	}
-	obs.ConnectionDetails[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(pw)
-
-	return obs, nil
+	return obs, err
 }
 
-func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.CreateDBClusterInput) (err error) { //nolint:gocyclo
+func (s *shared) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.CreateDBClusterInput) (err error) { //nolint:gocyclo
 	restoreFrom := cr.Spec.ForProvider.RestoreFrom
 	autogenerate := cr.Spec.ForProvider.AutogeneratePassword
 	masterUserPasswordSecretRef := cr.Spec.ForProvider.MasterUserPasswordSecretRef
@@ -151,7 +157,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 		pw, err = password.Generate()
 	case masterUserPasswordSecretRef != nil && autogenerate,
 		masterUserPasswordSecretRef != nil && !autogenerate:
-		pw, err = dbinstance.GetSecretValue(ctx, e.kube, masterUserPasswordSecretRef)
+		pw, err = dbinstance.GetSecretValue(ctx, s.kube, masterUserPasswordSecretRef)
 	}
 	if err != nil {
 		return errors.Wrap(err, dbinstance.ErrNoRetrievePasswordOrGenerate)
@@ -175,7 +181,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 			input.DBClusterIdentifier = obj.DBClusterIdentifier
 			input.VpcSecurityGroupIds = obj.VpcSecurityGroupIds
 
-			if _, err = e.client.RestoreDBClusterFromS3WithContext(ctx, input); err != nil {
+			if _, err = s.client.RestoreDBClusterFromS3WithContext(ctx, input); err != nil {
 				return errors.Wrap(err, errRestore)
 			}
 		case "Snapshot":
@@ -183,7 +189,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 			input.DBClusterIdentifier = obj.DBClusterIdentifier
 			input.VpcSecurityGroupIds = obj.VpcSecurityGroupIds
 
-			if _, err = e.client.RestoreDBClusterFromSnapshotWithContext(ctx, input); err != nil {
+			if _, err = s.client.RestoreDBClusterFromSnapshotWithContext(ctx, input); err != nil {
 				return errors.Wrap(err, errRestore)
 			}
 		case "PointInTime":
@@ -191,7 +197,7 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 			input.DBClusterIdentifier = obj.DBClusterIdentifier
 			input.VpcSecurityGroupIds = obj.VpcSecurityGroupIds
 
-			if _, err = e.client.RestoreDBClusterToPointInTimeWithContext(ctx, input); err != nil {
+			if _, err = s.client.RestoreDBClusterToPointInTimeWithContext(ctx, input); err != nil {
 				return errors.Wrap(err, errRestore)
 			}
 		default:
@@ -201,10 +207,22 @@ func (e *custom) preCreate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 
 	obj.EngineVersion = cr.Spec.ForProvider.EngineVersion
 
-	if _, err = dbinstance.Cache(ctx, e.kube, cr, passwordRestoreInfo); err != nil {
+	if _, err = dbinstance.Cache(ctx, s.kube, cr, passwordRestoreInfo); err != nil {
 		return errors.Wrap(err, dbinstance.ErrCachePassword)
 	}
 	return nil
+}
+
+func (s *shared) postCreate(ctx context.Context, cr *svcapitypes.DBCluster, _ *svcsdk.CreateDBClusterOutput, extCreation managed.ExternalCreation, err error) (managed.ExternalCreation, error) {
+	if err != nil {
+		return extCreation, err
+	}
+	cd, err := s.updateConnectionDetails(ctx, cr, managed.ConnectionDetails{})
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+	extCreation.ConnectionDetails = cd
+	return extCreation, nil
 }
 
 func generateRestoreDBClusterFromS3Input(cr *svcapitypes.DBCluster) *svcsdk.RestoreDBClusterFromS3Input { //nolint:gocyclo
@@ -557,82 +575,196 @@ func generateRestoreDBClusterToPointInTimeInput(cr *svcapitypes.DBCluster) *svcs
 	return res
 }
 
-func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out *svcsdk.DescribeDBClustersOutput) (bool, string, error) { //nolint:gocyclo
-	current := GenerateDBCluster(out)
+func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out *svcsdk.DescribeDBClustersOutput) (bool, string, error) { //nolint:gocyclo
+	// If ApplyImmediately is not true, we fold any pending modified values into the observed
+	// state of the DB cluster to avoid reporting redundant updates.
+	if !ptr.Deref(cr.Spec.ForProvider.ApplyImmediately, false) {
+		utils.SetPmvDBCluster(out)
+	}
+	observed := GenerateDBCluster(out)
 
 	status := pointer.StringValue(out.DBClusters[0].Status)
-	if status == "modifying" || status == "upgrading" || status == "configuring-iam-database-auth" || status == "migrating" || status == "prepairing-data-migration" || status == "creating" {
+	if status == "modifying" || status == "upgrading" || status == "configuring-iam-database-auth" || status == "migrating" || status == "preparing-data-migration" || status == "creating" {
 		return true, "", nil
 	}
 
-	passwordUpToDate, _, err := dbinstance.PasswordUpToDate(ctx, e.kube, cr)
+	passwordUpToDate, desiredPassword, err := dbinstance.PasswordUpToDate(ctx, s.kube, cr)
 	if err != nil {
 		return false, "", errors.Wrap(err, dbinstance.ErrNoPasswordUpToDate)
 	}
-	if !passwordUpToDate {
-		return false, "", nil
+	s.cache.desiredPassword = desiredPassword
+	s.cache.passwordChanged = !passwordUpToDate
+
+	patch, err := createPatch(&observed.Spec.ForProvider, &cr.Spec.ForProvider)
+	if err != nil {
+		return false, "", err
+	}
+	diff := cmp.Diff(&svcapitypes.DBClusterParameters{}, patch, cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "AllowMajorVersionUpgrade"),
+		// AutoMinorVersionUpgrade is a per-instance property for Aurora clusters: AWS returns it
+		// as nil in DescribeDBClusters, so GenerateDBCluster leaves the observed spec value nil
+		// while the desired spec carries a value, which would otherwise cause a permanent diff.
+		// It is compared explicitly below, only when AWS actually returns a value.
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "AutoMinorVersionUpgrade"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "BacktrackWindow"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "BackupRetentionPeriod"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "DBSubnetGroupName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "DBClusterParameterGroupName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnableCloudwatchLogsExports"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EngineVersion"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "FinalDBSnapshotIdentifier"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "MasterUserPasswordSecretRef"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "ScalingConfiguration"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "SkipFinalSnapshot"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "StorageType"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "OptionGroupName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "PreferredBackupWindow"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "Region"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "Tags"),
+		// PerformanceInsightsRetentionPeriod and PerformanceInsightsKMSKeyID are only valid
+		// while Performance Insights is enabled. GenerateDBCluster routes the observed values
+		// into the spec, but AWS omits them (or returns a normalized KMS ARN) when PI is
+		// disabled, so comparing them here would cause a permanent update loop. They are
+		// handled explicitly below, gated on EnablePerformanceInsights.
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "PerformanceInsightsRetentionPeriod"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "PerformanceInsightsKMSKeyID"),
+		// The following fields are write-only from the spec's perspective. createPatch builds
+		// the observed spec via GenerateDBCluster, which routes the corresponding
+		// DescribeDBClusters response values into Status.AtProvider (or does not read them at
+		// all) rather than into Spec.ForProvider. The observed spec therefore never has these
+		// set, so comparing them here would always report a difference and cause a permanent
+		// update loop. PreferredMaintenanceWindow additionally needs case-insensitive
+		// comparison, and EnableIAMDatabaseAuthentication is compared separately below.
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "DestinationRegion"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "Domain"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "DomainIAMRoleName"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnableGlobalWriteForwarding"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnableHTTPEndpoint"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnableIAMDatabaseAuthentication"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnableLocalWriteForwarding"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "EnablePerformanceInsights"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "GlobalClusterIdentifier"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "ManageMasterUserPassword"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "MasterUserSecretKMSKeyID"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "PreSignedURL"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "PreferredMaintenanceWindow"),
+		cmpopts.IgnoreFields(svcapitypes.DBClusterParameters{}, "SourceRegion"),
+		cmpopts.IgnoreTypes(svcapitypes.CustomDBClusterParameters{}),
+	)
+
+	if s.cache.passwordChanged {
+		diff += "\nmaster user password changed"
 	}
 
-	if pointer.BoolValue(cr.Spec.ForProvider.EnableIAMDatabaseAuthentication) != pointer.BoolValue(out.DBClusters[0].IAMDatabaseAuthenticationEnabled) {
-		return false, "", nil
+	s.cache.backupWindowChanged = !isPreferredBackupWindowUpToDate(cr, out)
+	if s.cache.backupWindowChanged {
+		diff += "\ndesired preferredBackupWindow: " + pointer.StringValue(cr.Spec.ForProvider.PreferredBackupWindow) +
+			", observed preferredBackupWindow: " + pointer.StringValue(out.DBClusters[0].PreferredBackupWindow)
 	}
 
+	// PreferredMaintenanceWindow is ignored in the diff above because AWS returns
+	// lowercase weekdays while the spec may use any case, so it needs a
+	// case-insensitive comparison to avoid a permanent update loop.
 	if !isPreferredMaintenanceWindowUpToDate(cr, out) {
-		return false, "", nil
+		diff += "\ndesired preferredMaintenanceWindow: " + pointer.StringValue(cr.Spec.ForProvider.PreferredMaintenanceWindow) +
+			", observed preferredMaintenanceWindow: " + pointer.StringValue(out.DBClusters[0].PreferredMaintenanceWindow)
 	}
 
-	if !isPreferredBackupWindowUpToDate(cr, out) {
-		return false, "", nil
+	// EnableIAMDatabaseAuthentication is write-only on the spec: GenerateDBCluster maps the
+	// value AWS returns into the CR status field IAMDatabaseAuthenticationEnabled, never into
+	// the spec, so it is ignored in the diff above. Here we compare the desired spec value
+	// directly against the value AWS returned in the DescribeDBClusters response
+	// (out.DBClusters[0].IAMDatabaseAuthenticationEnabled). Only compare when the user set
+	// it, to avoid trying to disable a setting that is not managed via the spec.
+	if cr.Spec.ForProvider.EnableIAMDatabaseAuthentication != nil &&
+		pointer.BoolValue(cr.Spec.ForProvider.EnableIAMDatabaseAuthentication) != pointer.BoolValue(out.DBClusters[0].IAMDatabaseAuthenticationEnabled) {
+		diff += "\ndesired enableIAMDatabaseAuthentication: " + strconv.FormatBool(pointer.BoolValue(cr.Spec.ForProvider.EnableIAMDatabaseAuthentication)) +
+			", observed iamDatabaseAuthenticationEnabled: " + strconv.FormatBool(pointer.BoolValue(out.DBClusters[0].IAMDatabaseAuthenticationEnabled))
+	}
+
+	// EnablePerformanceInsights is write-only on the spec: GenerateDBCluster maps the value AWS
+	// returns into the CR status field PerformanceInsightsEnabled, never into the spec, so it is
+	// ignored in the diff above. Compare the desired spec value directly against the value AWS
+	// returned (out.DBClusters[0].PerformanceInsightsEnabled). Only compare when the user set
+	// it, to avoid trying to toggle a setting that is not managed via the spec.
+	if cr.Spec.ForProvider.EnablePerformanceInsights != nil &&
+		pointer.BoolValue(cr.Spec.ForProvider.EnablePerformanceInsights) != pointer.BoolValue(out.DBClusters[0].PerformanceInsightsEnabled) {
+		diff += "\ndesired enablePerformanceInsights: " + strconv.FormatBool(pointer.BoolValue(cr.Spec.ForProvider.EnablePerformanceInsights)) +
+			", observed performanceInsightsEnabled: " + strconv.FormatBool(pointer.BoolValue(out.DBClusters[0].PerformanceInsightsEnabled))
+	}
+
+	// PerformanceInsightsRetentionPeriod is only meaningful while Performance Insights is
+	// enabled. It (and PerformanceInsightsKMSKeyID) are ignored in the diff above because AWS
+	// omits/returns them differently when PI is disabled, which would otherwise create a
+	// permanent diff and a ModifyDBCluster that AWS rejects. Only compare the retention period
+	// when PI is desired-enabled.
+	if pointer.BoolValue(cr.Spec.ForProvider.EnablePerformanceInsights) &&
+		cr.Spec.ForProvider.PerformanceInsightsRetentionPeriod != nil &&
+		pointer.Int64Value(cr.Spec.ForProvider.PerformanceInsightsRetentionPeriod) != pointer.Int64Value(out.DBClusters[0].PerformanceInsightsRetentionPeriod) {
+		diff += "\ndesired performanceInsightsRetentionPeriod: " + strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.PerformanceInsightsRetentionPeriod), 10) +
+			", observed performanceInsightsRetentionPeriod: " + strconv.FormatInt(pointer.Int64Value(out.DBClusters[0].PerformanceInsightsRetentionPeriod), 10)
+	}
+
+	// AutoMinorVersionUpgrade is ignored in the diff above because AWS returns it as nil for
+	// Aurora clusters (it is a per-instance property), which would create a permanent diff.
+	// Only compare when AWS actually returns a value and the user set one in the spec.
+	if cr.Spec.ForProvider.AutoMinorVersionUpgrade != nil && out.DBClusters[0].AutoMinorVersionUpgrade != nil &&
+		pointer.BoolValue(cr.Spec.ForProvider.AutoMinorVersionUpgrade) != pointer.BoolValue(out.DBClusters[0].AutoMinorVersionUpgrade) {
+		diff += "\ndesired autoMinorVersionUpgrade: " + strconv.FormatBool(pointer.BoolValue(cr.Spec.ForProvider.AutoMinorVersionUpgrade)) +
+			", observed autoMinorVersionUpgrade: " + strconv.FormatBool(pointer.BoolValue(out.DBClusters[0].AutoMinorVersionUpgrade))
 	}
 
 	if pointer.Int64Value(cr.Spec.ForProvider.BacktrackWindow) != pointer.Int64Value(out.DBClusters[0].BacktrackWindow) {
-		return false, "", nil
+		diff += "\ndesired backtrackWindow: " + strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.BacktrackWindow), 10) +
+			", observed backtrackWindow: " + strconv.FormatInt(pointer.Int64Value(out.DBClusters[0].BacktrackWindow), 10)
 	}
 
 	if !isStorageTypeUpToDate(cr, out) {
-		return false, "", nil
+		diff += "\ndesired storageType: " + pointer.StringValue(cr.Spec.ForProvider.StorageType) +
+			", observed storageType: " + pointer.StringValue(out.DBClusters[0].StorageType)
 	}
 
-	if !isBackupRetentionPeriodUpToDate(cr, out) {
-		return false, "", nil
-	}
-
-	if pointer.BoolValue(cr.Spec.ForProvider.CopyTagsToSnapshot) != pointer.BoolValue(out.DBClusters[0].CopyTagsToSnapshot) {
-		return false, "", nil
-	}
-
-	if pointer.BoolValue(cr.Spec.ForProvider.DeletionProtection) != pointer.BoolValue(out.DBClusters[0].DeletionProtection) {
-		return false, "", nil
-	}
-
-	if !isEngineVersionUpToDate(cr, out) {
-		return false, "", nil
+	s.cache.backupRetentionPeriodChanged = !isBackupRetentionPeriodUpToDate(cr, out)
+	if s.cache.backupRetentionPeriodChanged {
+		diff += "\ndesired backupRetentionPeriod: " + strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.BackupRetentionPeriod), 10) +
+			", observed backupRetentionPeriod: " + strconv.FormatInt(pointer.Int64Value(out.DBClusters[0].BackupRetentionPeriod), 10)
 	}
 
 	if !isPortUpToDate(cr, out) {
-		return false, "", nil
+		diff += "\ndesired port: " + strconv.FormatInt(pointer.Int64Value(cr.Spec.ForProvider.Port), 10) +
+			", observed port: " + strconv.FormatInt(pointer.Int64Value(out.DBClusters[0].Port), 10)
+	}
+
+	s.cache.engineVersionChanged = !isEngineVersionUpToDate(cr, out)
+	if s.cache.engineVersionChanged {
+		diff += fmt.Sprintf("\ndesired engineVersion: %s \nobserved engineVersion: %s ", pointer.StringValue(cr.Spec.ForProvider.EngineVersion), pointer.StringValue(out.DBClusters[0].EngineVersion))
 	}
 
 	if !areVPCSecurityGroupIDsUpToDate(cr, out) {
-		return false, "", nil
+		observedIDs := make([]string, 0, len(cr.Spec.ForProvider.VPCSecurityGroupIDs))
+		for _, grp := range out.DBClusters[0].VpcSecurityGroups {
+			observedIDs = append(observedIDs, pointer.StringValue(grp.VpcSecurityGroupId))
+		}
+		diff += "\ndesired vpcSecurityGroupIDs: " + strings.Join(cr.Spec.ForProvider.VPCSecurityGroupIDs, ",") +
+			", observed vpcSecurityGroupIDs: " + strings.Join(observedIDs, ",")
 	}
 
 	if !areSameElements(cr.Spec.ForProvider.EnableCloudwatchLogsExports, out.DBClusters[0].EnabledCloudwatchLogsExports) {
-		return false, "", nil
+		diff += "\nenabledCloudwatchLogsExports changed"
 	}
 
-	if cr.Spec.ForProvider.DBClusterParameterGroupName != nil &&
-		pointer.StringValue(cr.Spec.ForProvider.DBClusterParameterGroupName) != pointer.StringValue(out.DBClusters[0].DBClusterParameterGroup) {
-		return false, "", nil
+	s.cache.dbClusterParameterGroupNameChanged = !isDBClusterParameterGroupNameUpToDate(cr, out)
+	if s.cache.dbClusterParameterGroupNameChanged {
+		diff += "\ndesired dbClusterParameterGroupName: " + pointer.StringValue(cr.Spec.ForProvider.DBClusterParameterGroupName) +
+			", observed dbClusterParameterGroupName: " + pointer.StringValue(out.DBClusters[0].DBClusterParameterGroup)
 	}
 
 	isScalingConfigurationUpToDate, err := isScalingConfigurationUpToDate(cr.Spec.ForProvider.ScalingConfiguration, out.DBClusters[0].ScalingConfigurationInfo)
-	if !isScalingConfigurationUpToDate {
-		return false, "", err
+	if err != nil {
+		return false, "", errors.Wrap(err, "failed to compare scaling configuration")
 	}
-
-	if diff := cmp.Diff(cr.Spec.ForProvider.ServerlessV2ScalingConfiguration, current.Spec.ForProvider.ServerlessV2ScalingConfiguration); diff != "" {
-		return false, "ServerlessV2ScalingConfiguration: " + diff, nil
+	if !isScalingConfigurationUpToDate {
+		diff += "\nscalingConfiguration changed"
 	}
 
 	// Build ignore rules: implicit aws:* + user supplied rules
@@ -651,10 +783,18 @@ func (e *custom) isUpToDate(ctx context.Context, cr *svcapitypes.DBCluster, out 
 			observedTags = append(observedTags, &svcsdk.Tag{Key: tag.Key, Value: tag.Value})
 		}
 	}
-	add, remove := DiffTags(cr.Spec.ForProvider.Tags, observedTags)
-	if len(add) > 0 || len(remove) > 0 {
-		return false, "", nil
+	s.cache.addTags, s.cache.removeTags = utils.DiffTags(cr.Spec.ForProvider.Tags, observedTags)
+	tagsChanged := len(s.cache.addTags) != 0 || len(s.cache.removeTags) != 0
+	if tagsChanged {
+		diff += fmt.Sprintf("\nadd %d tag(s) and remove %d tag(s)", len(s.cache.addTags), len(s.cache.removeTags))
 	}
+
+	if diff != "" {
+		diff = "Found observed differences in dbCluster\n" + diff
+		log.Println(diff)
+		return false, diff, nil
+	}
+
 	return true, "", nil
 }
 
@@ -736,9 +876,31 @@ func isEngineVersionUpToDate(cr *svcapitypes.DBCluster, out *svcsdk.DescribeDBCl
 			return false
 		}
 
+		desiredEngineVersion := ptr.Deref(cr.Spec.ForProvider.EngineVersion, "")
+		observedEngineVersion := ptr.Deref(out.DBClusters[0].EngineVersion, "")
+		pendingEngineVersion := ""
+		if out.DBClusters[0].PendingModifiedValues != nil {
+			pendingEngineVersion = ptr.Deref(out.DBClusters[0].PendingModifiedValues.EngineVersion, "")
+		}
+		// If the desired version already matches the current version, the cluster is up to
+		// date regardless of any pending modification. Unlike ModifyDBInstance (where
+		// resubmitting the current version cancels a pending engine-version change, so the
+		// dbinstance controller intentionally keeps that revert behavior), ModifyDBCluster
+		// provides no way to cancel a pending engine-version upgrade: resubmitting the current
+		// version is treated as a no-op (the pending value is left intact) and minor-version
+		// downgrades are not supported.
+		// The pending upgrade remains visible via status.atProvider.pendingModifiedValues.
+		if desiredEngineVersion == observedEngineVersion {
+			return true
+		}
+		// If ApplyImmediately is false and a version change is pending, treat the pending
+		// version as the current version for comparison.
+		if !ptr.Deref(cr.Spec.ForProvider.ApplyImmediately, false) && pendingEngineVersion != "" {
+			observedEngineVersion = pendingEngineVersion
+		}
 		// Upgrade is only necessary if the spec version is higher.
 		// Downgrades are not possible in pointer.
-		c := utils.CompareEngineVersions(*cr.Spec.ForProvider.EngineVersion, *out.DBClusters[0].EngineVersion)
+		c := utils.CompareEngineVersions(*cr.Spec.ForProvider.EngineVersion, observedEngineVersion)
 		return c <= 0
 	}
 	return true
@@ -793,19 +955,19 @@ func areVPCSecurityGroupIDsUpToDate(cr *svcapitypes.DBCluster, out *svcsdk.Descr
 	return cmp.Equal(desiredIDs, actualIDs)
 }
 
-func (e *custom) preUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterInput) error {
+func (s *shared) preUpdate(_ context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterInput) error {
 	obj.DBClusterIdentifier = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
 	obj.ApplyImmediately = cr.Spec.ForProvider.ApplyImmediately
 
 	obj.CloudwatchLogsExportConfiguration = generateCloudWatchExportConfiguration(
 		cr.Spec.ForProvider.EnableCloudwatchLogsExports,
 		cr.Status.AtProvider.EnabledCloudwatchLogsExports)
-
-	desiredPassword, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
-	if err != nil {
-		return errors.Wrap(err, dbinstance.ErrRetrievePasswordForUpdate)
+	// Only set MasterUserPassword if it has actually changed. Otherwise it triggers a
+	// "Resetting master password" event on the AWS side, because AWS does not know the
+	// current password, so any value we send is treated as a change.
+	if s.cache.passwordChanged {
+		obj.MasterUserPassword = pointer.ToOrNilIfZeroValue(s.cache.desiredPassword)
 	}
-	obj.MasterUserPassword = pointer.ToOrNilIfZeroValue(desiredPassword)
 
 	if cr.Spec.ForProvider.VPCSecurityGroupIDs != nil {
 		obj.VpcSecurityGroupIds = make([]*string, len(cr.Spec.ForProvider.VPCSecurityGroupIDs))
@@ -825,31 +987,37 @@ func (e *custom) preUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *
 	obj.DBClusterParameterGroupName = nil
 
 	// AWS Backup takes ownership of BackupRetentionPeriod and PreferredBackupWindow if it is in use.
-	// So we need to check there is no associated RecoveryPoint, before trying to update these fields.
-	// Therefore we only add some in postUpdate, where we have the DescribeDBClustersOutput available.
-	obj.BackupRetentionPeriod = nil
+	// So we need to check there is no associated RecoveryPoint before trying to update these fields.
+	// Therefore we only set these fields on the ModifyDBClusterInput if they have changed and are
+	// not in use by AWS Backup.
 	obj.PreferredBackupWindow = nil
+	obj.BackupRetentionPeriod = nil
+
+	// PerformanceInsightsRetentionPeriod and PerformanceInsightsKMSKeyId are only valid while
+	// Performance Insights is enabled. If PI is being (or staying) disabled, sending a stale
+	// retention/KMS value causes AWS to reject the ModifyDBCluster call, so strip them.
+	if !pointer.BoolValue(cr.Spec.ForProvider.EnablePerformanceInsights) {
+		obj.PerformanceInsightsRetentionPeriod = nil
+		obj.PerformanceInsightsKMSKeyId = nil
+	}
 
 	return nil
 }
 
 //nolint:gocyclo
-func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterOutput, upd managed.ExternalUpdate, err error) (managed.ExternalUpdate, error) {
+func (s *shared) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.ModifyDBClusterOutput, upd managed.ExternalUpdate, err error) (managed.ExternalUpdate, error) {
 	if err != nil {
 		return upd, err
 	}
 
-	desiredPassword, err := dbinstance.GetDesiredPassword(ctx, e.kube, cr)
-	if err != nil {
-		return upd, errors.Wrap(err, dbinstance.ErrRetrievePasswordForUpdate)
-	}
-
-	_, err = dbinstance.Cache(ctx, e.kube, cr, map[string]string{
-		dbinstance.PasswordCacheKey:    desiredPassword,
-		dbinstance.RestoreFlagCacheKay: "", // reset restore flag
-	})
-	if err != nil {
-		return upd, errors.Wrap(err, dbinstance.ErrCachePassword)
+	if s.cache.passwordChanged {
+		_, err = dbinstance.Cache(ctx, s.kube, cr, map[string]string{
+			dbinstance.PasswordCacheKey:    s.cache.desiredPassword,
+			dbinstance.RestoreFlagCacheKay: "", // reset restore flag
+		})
+		if err != nil {
+			return upd, errors.Wrap(err, dbinstance.ErrCachePassword)
+		}
 	}
 
 	input := GenerateDescribeDBClustersInput(cr)
@@ -857,16 +1025,12 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj 
 	// and the function is generated by ack-generate, so we manually need to set the
 	// DBClusterIdentifier
 	input.DBClusterIdentifier = pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr))
-	resp, err := e.client.DescribeDBClustersWithContext(ctx, input)
+	resp, err := s.client.DescribeDBClustersWithContext(ctx, input)
 	if err != nil {
 		return managed.ExternalUpdate{}, errorutils.Wrap(cpresource.Ignore(IsNotFound, err), errDescribe)
 	}
 
-	needsEngineVersionUpdate := !isEngineVersionUpToDate(cr, resp)
-	needsDBClusterParamGroupUpdate := !isDBClusterParameterGroupNameUpToDate(cr, resp)
-	needsPreferredBackupWindowUpdate := !isPreferredBackupWindowUpToDate(cr, resp)
-	needsBackupRetentionPeriodUpdate := !isBackupRetentionPeriodUpToDate(cr, resp)
-	needsPostUpdate := needsEngineVersionUpdate || needsDBClusterParamGroupUpdate || needsPreferredBackupWindowUpdate || needsBackupRetentionPeriodUpdate
+	needsPostUpdate := s.cache.engineVersionChanged || s.cache.dbClusterParameterGroupNameChanged || s.cache.backupWindowChanged || s.cache.backupRetentionPeriodChanged
 
 	if needsPostUpdate {
 		modifyInput := &svcsdk.ModifyDBClusterInput{
@@ -874,39 +1038,24 @@ func (e *custom) postUpdate(ctx context.Context, cr *svcapitypes.DBCluster, obj 
 			ApplyImmediately:            cr.Spec.ForProvider.ApplyImmediately,
 			DBClusterParameterGroupName: cr.Spec.ForProvider.DBClusterParameterGroupName,
 		}
-		if needsEngineVersionUpdate {
+		if s.cache.engineVersionChanged {
 			modifyInput.EngineVersion = cr.Spec.ForProvider.EngineVersion
 			modifyInput.AllowMajorVersionUpgrade = cr.Spec.ForProvider.AllowMajorVersionUpgrade
 		}
-		if needsPreferredBackupWindowUpdate {
+		if s.cache.backupWindowChanged {
 			modifyInput.PreferredBackupWindow = cr.Spec.ForProvider.PreferredBackupWindow
 		}
-		if needsBackupRetentionPeriodUpdate {
+		if s.cache.backupRetentionPeriodChanged {
 			modifyInput.BackupRetentionPeriod = cr.Spec.ForProvider.BackupRetentionPeriod
 		}
 
-		if _, err = e.client.ModifyDBClusterWithContext(ctx, modifyInput); err != nil {
+		if _, err = s.client.ModifyDBClusterWithContext(ctx, modifyInput); err != nil {
 			return managed.ExternalUpdate{}, err
 		}
 	}
 
-	tags := resp.DBClusters[0].TagList
-	// Filter tags using the same ignore rules as isUpToDate
-	updateIgnore := []string{"aws:*"}
-	for _, r := range cr.Spec.ForProvider.TagsIgnore {
-		updateIgnore = append(updateIgnore, r.Key)
-	}
-	filteredTags := make([]*svcsdk.Tag, 0, len(tags))
-	for _, tag := range tags {
-		if utils.ShouldIgnore(pointer.StringValue(tag.Key), updateIgnore) {
-			continue
-		}
-		filteredTags = append(filteredTags, tag)
-	}
-	add, remove := DiffTags(cr.Spec.ForProvider.Tags, filteredTags)
-
-	if len(add) > 0 || len(remove) > 0 {
-		err := e.updateTags(ctx, cr, add, remove)
+	if len(s.cache.addTags) > 0 || len(s.cache.removeTags) > 0 {
+		err := s.updateTags(ctx, cr, s.cache.addTags, s.cache.removeTags)
 		if err != nil {
 			return managed.ExternalUpdate{}, err
 		}
@@ -931,12 +1080,12 @@ func preDelete(_ context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.DeleteD
 	return false, nil
 }
 
-func (e *custom) postDelete(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.DeleteDBClusterOutput, err error) (managed.ExternalDelete, error) {
+func (s *shared) postDelete(ctx context.Context, cr *svcapitypes.DBCluster, obj *svcsdk.DeleteDBClusterOutput, err error) (managed.ExternalDelete, error) {
 	if err != nil {
 		return managed.ExternalDelete{}, err
 	}
 
-	return managed.ExternalDelete{}, dbinstance.DeleteCache(ctx, e.kube, cr)
+	return managed.ExternalDelete{}, dbinstance.DeleteCache(ctx, s.kube, cr)
 }
 
 func filterList(cr *svcapitypes.DBCluster, obj *svcsdk.DescribeDBClustersOutput) *svcsdk.DescribeDBClustersOutput {
@@ -951,30 +1100,7 @@ func filterList(cr *svcapitypes.DBCluster, obj *svcsdk.DescribeDBClustersOutput)
 	return resp
 }
 
-// DiffTags returns tags that should be added or removed.
-func DiffTags(spec []*svcapitypes.Tag, current []*svcsdk.Tag) (addTags []*svcsdk.Tag, remove []*string) {
-	addMap := make(map[string]string, len(spec))
-	for _, t := range spec {
-		addMap[pointer.StringValue(t.Key)] = pointer.StringValue(t.Value)
-	}
-	removeMap := make(map[string]string, len(spec))
-	for _, t := range current {
-		if addMap[pointer.StringValue(t.Key)] == pointer.StringValue(t.Value) {
-			delete(addMap, pointer.StringValue(t.Key))
-			continue
-		}
-		removeMap[pointer.StringValue(t.Key)] = pointer.StringValue(t.Value)
-	}
-	for k, v := range addMap {
-		addTags = append(addTags, &svcsdk.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
-	}
-	for k := range removeMap {
-		remove = append(remove, pointer.ToOrNilIfZeroValue(k))
-	}
-	return
-}
-
-func (e *custom) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addTags []*svcsdk.Tag, removeTags []*string) error {
+func (s *shared) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addTags []*svcsdk.Tag, removeTags []*string) error {
 
 	arn := cr.Status.AtProvider.DBClusterARN
 	if arn != nil {
@@ -984,7 +1110,7 @@ func (e *custom) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addT
 				TagKeys:      removeTags,
 			}
 
-			_, err := e.client.RemoveTagsFromResourceWithContext(ctx, inputR)
+			_, err := s.client.RemoveTagsFromResourceWithContext(ctx, inputR)
 			if err != nil {
 				return errors.New(errUpdateTags)
 			}
@@ -995,7 +1121,7 @@ func (e *custom) updateTags(ctx context.Context, cr *svcapitypes.DBCluster, addT
 				Tags:         addTags,
 			}
 
-			_, err := e.client.AddTagsToResourceWithContext(ctx, inputC)
+			_, err := s.client.AddTagsToResourceWithContext(ctx, inputC)
 			if err != nil {
 				return errors.New(errUpdateTags)
 			}
@@ -1055,4 +1181,47 @@ func areSameElements(a1, a2 []*string) bool {
 	}
 
 	return true
+}
+func (s *shared) updateConnectionDetails(ctx context.Context, cr *svcapitypes.DBCluster, details managed.ConnectionDetails) (managed.ConnectionDetails, error) {
+	if details == nil {
+		details = managed.ConnectionDetails{}
+	}
+
+	details[xpv1.ResourceCredentialsSecretUserKey] = []byte(pointer.StringValue(cr.Spec.ForProvider.MasterUsername))
+	password := s.cache.desiredPassword
+	if password == "" {
+		pw, err := dbinstance.GetDesiredPassword(ctx, s.kube, cr)
+		if err != nil {
+			return details, errors.Wrap(err, dbinstance.ErrGetCachedPassword)
+		}
+		password = pw
+	}
+	details[xpv1.ResourceCredentialsSecretPasswordKey] = []byte(password)
+
+	if cr.Status.AtProvider.Endpoint == nil {
+		return details, nil
+	}
+	if pointer.StringValue(cr.Status.AtProvider.Endpoint) != "" {
+		details[xpv1.ResourceCredentialsSecretEndpointKey] = []byte(pointer.StringValue(cr.Status.AtProvider.Endpoint))
+	}
+	if pointer.Int64Value(cr.Status.AtProvider.Port) > 0 {
+		details[xpv1.ResourceCredentialsSecretPortKey] = []byte(strconv.FormatInt(*cr.Status.AtProvider.Port, 10))
+	}
+	if pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint) != "" {
+		details["readerEndpoint"] = []byte(pointer.StringValue(cr.Status.AtProvider.ReaderEndpoint))
+	}
+
+	return details, nil
+}
+
+func createPatch(observed *svcapitypes.DBClusterParameters, desired *svcapitypes.DBClusterParameters) (*svcapitypes.DBClusterParameters, error) {
+	jsonPatch, err := jsonpatch.CreateJSONPatch(observed, desired)
+	if err != nil {
+		return nil, err
+	}
+	patch := &svcapitypes.DBClusterParameters{}
+	if err := json.Unmarshal(jsonPatch, patch); err != nil {
+		return nil, err
+	}
+	return patch, nil
 }

--- a/pkg/controller/rds/dbcluster/setup_test.go
+++ b/pkg/controller/rds/dbcluster/setup_test.go
@@ -3,16 +3,51 @@ package dbcluster
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"testing"
 
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/rds/v1alpha1"
+	rds "github.com/crossplane-contrib/provider-aws/pkg/clients/rds"
 )
+
+type objectFnCustom func(obj client.Object, diff bool) error
+
+// NewMockGetFn returns a MockGetFn that returns the supplied error.
+func newMockGetFnCustomWithDiff(diff bool, err error, ofn []objectFnCustom) test.MockGetFn {
+	return func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+		for _, fn := range ofn {
+			if err := fn(obj, diff); err != nil {
+				return err
+			}
+		}
+		return err
+	}
+}
+func mockGettingSecretData(obj client.Object, diff bool) error {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return errors.New("the mock function only supports secret objects")
+	}
+	secret.Data = map[string][]byte{
+		rds.PasswordCacheKey:    []byte("cachedPassword"),
+		rds.RestoreFlagCacheKay: []byte(""),
+	}
+	if diff {
+		secret.Data[xpv1.ResourceCredentialsSecretPasswordKey] = []byte("differentPassword")
+	} else {
+		secret.Data[xpv1.ResourceCredentialsSecretPasswordKey] = []byte("cachedPassword")
+
+	}
+	return nil
+}
 
 func TestIsVPCSecurityGroupIDsUpToDate(t *testing.T) {
 	type args struct {
@@ -913,6 +948,1185 @@ func TestIsUpToDate(t *testing.T) {
 				isUpToDate: false,
 			},
 		},
+		"ChangedMasterPassword": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("16"),
+								MasterUserPasswordSecretRef: &xpv1.SecretKeySelector{
+									SecretReference: xpv1.SecretReference{
+										Name:      "masterUserPassword",
+										Namespace: "default",
+									},
+									Key: "password",
+								},
+							},
+							Region: "eu-central-2",
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("16"),
+						},
+					},
+				},
+				kube: &test.MockClient{
+					// This mock returns different passwords from masterUserPasswordSecretRef and cached secret
+					MockGet: newMockGetFnCustomWithDiff(true, nil, []objectFnCustom{mockGettingSecretData}),
+				},
+			},
+			want: want{
+				isUpToDate: false,
+			},
+		},
+		"UpToDatePendingModifiedValue": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("gp2"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("gp3"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								StorageType: ptr.To("gp2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"IsNoTUpToDatePendingModifiedValue": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("gp2"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("io1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								StorageType: ptr.To("gp3"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IsNoTUpToDatePendingModifiedValueApplyImmediately": { // The parameter is already scheduled to be updated, but we want to update it immediately
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							BackupRetentionPeriod: ptr.To(int64(21)),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								ApplyImmediately: ptr.To(true),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							BackupRetentionPeriod: ptr.To(int64(7)),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								BackupRetentionPeriod: ptr.To(int64(21)),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"UpToDatePendingModifiedValueEngineVersion": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"IsNotUpToDatePendingModifiedValueEngineVersion": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("15.3"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// When the desired version already matches the current version but a higher version is
+		// pending, AWS provides no way to cancel the pending upgrade (resubmitting the current
+		// version is a no-op and downgrades are unsupported). The cluster is therefore reported
+		// up to date to avoid an endless update loop; the pending upgrade stays visible in
+		// status.atProvider.pendingModifiedValues.
+		"UpToDatePendingModifiedValueEngineVersionRevertIsNotPossible": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								EngineVersion: ptr.To("15.1"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.2"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"IsNotUpToDatePendingModifiedValueEngineVersionApplyImmediately": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+							CustomDBClusterParameters: svcapitypes.CustomDBClusterParameters{
+								ApplyImmediately: ptr.To(true),
+								EngineVersion:    ptr.To("15.3"),
+							},
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:        ptr.To("aurora-postgresql"),
+							EngineVersion: ptr.To("15.1"),
+							PendingModifiedValues: &svcsdk.ClusterPendingModifiedValues{
+								EngineVersion: ptr.To("15.3"),
+							},
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"DifferentIAMDatabaseAuthenticationEnabled": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							EnableIAMDatabaseAuthentication: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							IAMDatabaseAuthenticationEnabled: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IAMDatabaseAuthenticationEnabledNotMapped": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-postgresql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                           ptr.To("aurora-postgresql"),
+							IAMDatabaseAuthenticationEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"AutoMinorVersionUpgradeNotMappedByAWS": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                  ptr.To("aurora-postgresql"),
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine: ptr.To("aurora-postgresql"),
+							// AWS returns AutoMinorVersionUpgrade as nil for Aurora clusters.
+							AutoMinorVersionUpgrade: nil,
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentAutoMinorVersionUpgradeWhenAWSReturnsValue": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                  ptr.To("aurora-postgresql"),
+							AutoMinorVersionUpgrade: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                  ptr.To("aurora-postgresql"),
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"IAMDatabaseAuthenticationEnabledAlreadyOn": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							EnableIAMDatabaseAuthentication: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							IAMDatabaseAuthenticationEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"PreferredMaintenanceWindowUppercase": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							PreferredMaintenanceWindow: ptr.To("Mon:00:00-Mon:03:00"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							PreferredMaintenanceWindow: ptr.To("mon:00:00-mon:03:00"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"PreferredMaintenanceWindowDifferent": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							PreferredMaintenanceWindow: ptr.To("Mon:00:00-Mon:03:00"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							PreferredMaintenanceWindow: ptr.To("tue:00:00-tue:03:00"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"WriteOnlyEnableFieldsDoNotCausePermanentDiff": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							EnableHTTPEndpoint:          ptr.To(true),
+							EnableGlobalWriteForwarding: ptr.To(true),
+							Domain:                      ptr.To("d-1234567890"),
+							DomainIAMRoleName:           ptr.To("role"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentPubliclyAccessible": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							PubliclyAccessible: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							PubliclyAccessible: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SamePubliclyAccessible": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							PubliclyAccessible: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							PubliclyAccessible: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentStorageEncrypted": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageEncrypted: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageEncrypted: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameStorageEncrypted": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageEncrypted: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageEncrypted: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentAutoMinorVersionUpgrade": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							AutoMinorVersionUpgrade: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameAutoMinorVersionUpgrade": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							AutoMinorVersionUpgrade: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"EnablePerformanceInsightsChangeDetected": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                    ptr.To("mysql"),
+							EnablePerformanceInsights: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"DisablePerformanceInsightsChangeDetected": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                    ptr.To("mysql"),
+							EnablePerformanceInsights: ptr.To(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"PerformanceInsightsUnsetIsIgnored": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("mysql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"SameEnablePerformanceInsights": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                    ptr.To("mysql"),
+							EnablePerformanceInsights: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"PerformanceInsightsRetentionChangeDetectedWhenEnabled": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                             ptr.To("mysql"),
+							EnablePerformanceInsights:          ptr.To(true),
+							PerformanceInsightsRetentionPeriod: ptr.To(int64(731)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                             ptr.To("mysql"),
+							PerformanceInsightsEnabled:         ptr.To(true),
+							PerformanceInsightsRetentionPeriod: ptr.To(int64(7)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"PerformanceInsightsRetentionIgnoredWhenDisabled": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:                             ptr.To("mysql"),
+							EnablePerformanceInsights:          ptr.To(false),
+							PerformanceInsightsRetentionPeriod: ptr.To(int64(7)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:                     ptr.To("mysql"),
+							PerformanceInsightsEnabled: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// Port tests (integer parameter)
+		"DifferentPort": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Port: ptr.To(int64(3307)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SamePort": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"PortNotSet": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Port: nil,
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Port: ptr.To(int64(3306)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// StorageType tests
+		"DifferentStorageType": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("aurora-iopt1"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("aurora"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameStorageType": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("aurora-iopt1"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To("aurora-iopt1"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"StorageTypeAuroraDefault": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							StorageType: ptr.To("aurora"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							StorageType: ptr.To(""),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		"DifferentCopyTagsToSnapshot": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine:             ptr.To("aurora-mysql"),
+							CopyTagsToSnapshot: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine:             ptr.To("aurora-mysql"),
+							CopyTagsToSnapshot: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameCopyTagsToSnapshot": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							CopyTagsToSnapshot: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							CopyTagsToSnapshot: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// DeletionProtection tests
+		"DifferentDeletionProtection": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							DeletionProtection: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							DeletionProtection: ptr.To(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameDeletionProtection": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							DeletionProtection: ptr.To(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							DeletionProtection: ptr.To(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+
+		"DifferentIOPS": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("mysql"),
+							IOPS:   ptr.To(int64(3000)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine: ptr.To("mysql"),
+							Iops:   ptr.To(int64(1000)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		"SameIOPS": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							IOPS: ptr.To(int64(3000)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Iops: ptr.To(int64(3000)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		// AllocatedStorage tests
+		"DifferentAllocatedStorage": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							AllocatedStorage: ptr.To(int64(100)),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							AllocatedStorage: ptr.To(int64(50)),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// Engine tests (string parameter)
+		"DifferentEngine": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							Engine: ptr.To("aurora-mysql"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							Engine: ptr.To("aurora-postgresql"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// KMSKeyID tests
+		"DifferentKMSKeyID": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							KMSKeyID: ptr.To("arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							KmsKeyId: ptr.To("arn:aws:kms:us-east-1:123456789012:key/87654321-4321-4321-4321-210987654321"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// MasterUsername tests
+		"DifferentMasterUsername": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							MasterUsername: ptr.To("admin"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							MasterUsername: ptr.To("root"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+		// EngineMode tests
+		"DifferentEngineMode": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							EngineMode: ptr.To("provisioned"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							EngineMode: ptr.To("serverless"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+
+		// NetworkType tests
+		"DifferentNetworkType": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							NetworkType: ptr.To("DUAL"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							NetworkType: ptr.To("IPV4"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
+
+		// CharacterSetName tests
+		"DifferentCharacterSetName": {
+			args: args{
+				cr: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						ForProvider: svcapitypes.DBClusterParameters{
+							CharacterSetName: ptr.To("UTF8"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBClustersOutput{
+					DBClusters: []*svcsdk.DBCluster{
+						{
+							CharacterSetName: ptr.To("LATIN1"),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				isUpToDate: false,
+				err:        nil,
+			},
+		},
 		"IgnoresTagsWithTagsIgnorePrefixGlob": {
 			args: args{
 				kube: test.NewMockClient(),
@@ -934,7 +2148,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: ptr.To(true),
 							TagList: []*svcsdk.Tag{
-								{Key: ptr.To("aws:createdBy"), Value: ptr.To("terraform")},
+								{Key: ptr.To("aws:createdBy"), Value: ptr.To("value")},
 								{Key: ptr.To("c7n:policy"), Value: ptr.To("auto")},
 								{Key: ptr.To("env"), Value: ptr.To("prod")},
 							},
@@ -967,7 +2181,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: ptr.To(true),
 							TagList: []*svcsdk.Tag{
-								{Key: ptr.To("aws:createdBy"), Value: ptr.To("terraform")},
+								{Key: ptr.To("aws:createdBy"), Value: ptr.To("value")},
 								{Key: ptr.To("c7n:policy"), Value: ptr.To("auto")},
 								{Key: ptr.To("c7n:other"), Value: ptr.To("x")},
 								{Key: ptr.To("env"), Value: ptr.To("prod")},
@@ -1013,15 +2227,69 @@ func TestIsUpToDate(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			custom := custom{kube: tc.args.kube}
-			isUpToDate, _, err := custom.isUpToDate(context.Background(), tc.args.cr, tc.args.out)
+			custom := shared{kube: tc.args.kube, cache: &cache{}}
+			isUpToDate, diffMsg, err := custom.isUpToDate(context.Background(), tc.args.cr, tc.args.out)
 			if diff := cmp.Diff(tc.want.isUpToDate, isUpToDate); diff != "" {
-				t.Errorf("r: -want, +got:\n%s", diff)
+				t.Errorf("r: -want, +got:\n%s\ndiff message: %s", diff, diffMsg)
 			}
 			if diff := cmp.Diff(tc.want.err, err); diff != "" {
 				t.Errorf("error: -want, +got:\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestIsUpToDateCachePopulatedWhenBacktrackWindowDiffers(t *testing.T) {
+	// Regression test: a BacktrackWindow difference must not short-circuit isUpToDate before
+	// the remaining change-detection runs. preUpdate/postUpdate rely on the cache flags that
+	// are populated later in isUpToDate, so an early return would silently skip engine
+	// version, parameter group, backup retention and tag updates when they change together
+	// with the backtrack window.
+	cr := &svcapitypes.DBCluster{
+		Spec: svcapitypes.DBClusterSpec{
+			ForProvider: svcapitypes.DBClusterParameters{
+				Engine:                      ptr.To("aurora-postgresql"),
+				CustomDBClusterParameters:   svcapitypes.CustomDBClusterParameters{EngineVersion: ptr.To("15.4")},
+				BacktrackWindow:             ptr.To[int64](3600),
+				BackupRetentionPeriod:       ptr.To[int64](7),
+				DBClusterParameterGroupName: ptr.To("desired-pg"),
+				Tags: []*svcapitypes.Tag{
+					{Key: ptr.To("team"), Value: ptr.To("db")},
+				},
+			},
+		},
+	}
+	out := &svcsdk.DescribeDBClustersOutput{
+		DBClusters: []*svcsdk.DBCluster{
+			{
+				Engine:                  ptr.To("aurora-postgresql"),
+				EngineVersion:           ptr.To("14.1"),
+				BacktrackWindow:         ptr.To[int64](0),
+				BackupRetentionPeriod:   ptr.To[int64](1),
+				DBClusterParameterGroup: ptr.To("observed-pg"),
+			},
+		},
+	}
+
+	s := shared{kube: test.NewMockClient(), cache: &cache{}}
+	isUpToDate, _, err := s.isUpToDate(context.Background(), cr, out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isUpToDate {
+		t.Fatalf("expected resource to be not up to date")
+	}
+	if !s.cache.engineVersionChanged {
+		t.Errorf("expected cache.engineVersionChanged to be set")
+	}
+	if !s.cache.dbClusterParameterGroupNameChanged {
+		t.Errorf("expected cache.dbClusterParameterGroupNameChanged to be set")
+	}
+	if !s.cache.backupRetentionPeriodChanged {
+		t.Errorf("expected cache.backupRetentionPeriodChanged to be set")
+	}
+	if len(s.cache.addTags) == 0 {
+		t.Errorf("expected cache.addTags to be populated")
 	}
 }
 

--- a/pkg/controller/rds/dbcluster/zz_controller.go
+++ b/pkg/controller/rds/dbcluster/zz_controller.go
@@ -489,6 +489,68 @@ func (e *external) Create(ctx context.Context, cr *svcapitypes.DBCluster) (manag
 	} else {
 		cr.Spec.ForProvider.NetworkType = nil
 	}
+	if resp.DBCluster.PendingModifiedValues != nil {
+		f55 := &svcapitypes.ClusterPendingModifiedValues{}
+		if resp.DBCluster.PendingModifiedValues.AllocatedStorage != nil {
+			f55.AllocatedStorage = resp.DBCluster.PendingModifiedValues.AllocatedStorage
+		}
+		if resp.DBCluster.PendingModifiedValues.BackupRetentionPeriod != nil {
+			f55.BackupRetentionPeriod = resp.DBCluster.PendingModifiedValues.BackupRetentionPeriod
+		}
+		if resp.DBCluster.PendingModifiedValues.DBClusterIdentifier != nil {
+			f55.DBClusterIdentifier = resp.DBCluster.PendingModifiedValues.DBClusterIdentifier
+		}
+		if resp.DBCluster.PendingModifiedValues.EngineVersion != nil {
+			f55.EngineVersion = resp.DBCluster.PendingModifiedValues.EngineVersion
+		}
+		if resp.DBCluster.PendingModifiedValues.IAMDatabaseAuthenticationEnabled != nil {
+			f55.IAMDatabaseAuthenticationEnabled = resp.DBCluster.PendingModifiedValues.IAMDatabaseAuthenticationEnabled
+		}
+		if resp.DBCluster.PendingModifiedValues.Iops != nil {
+			f55.IOPS = resp.DBCluster.PendingModifiedValues.Iops
+		}
+		if resp.DBCluster.PendingModifiedValues.MasterUserPassword != nil {
+			f55.MasterUserPassword = resp.DBCluster.PendingModifiedValues.MasterUserPassword
+		}
+		if resp.DBCluster.PendingModifiedValues.PendingCloudwatchLogsExports != nil {
+			f55f7 := &svcapitypes.PendingCloudwatchLogsExports{}
+			if resp.DBCluster.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable != nil {
+				f55f7f0 := []*string{}
+				for _, f55f7f0iter := range resp.DBCluster.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable {
+					var f55f7f0elem string
+					f55f7f0elem = *f55f7f0iter
+					f55f7f0 = append(f55f7f0, &f55f7f0elem)
+				}
+				f55f7.LogTypesToDisable = f55f7f0
+			}
+			if resp.DBCluster.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable != nil {
+				f55f7f1 := []*string{}
+				for _, f55f7f1iter := range resp.DBCluster.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable {
+					var f55f7f1elem string
+					f55f7f1elem = *f55f7f1iter
+					f55f7f1 = append(f55f7f1, &f55f7f1elem)
+				}
+				f55f7.LogTypesToEnable = f55f7f1
+			}
+			f55.PendingCloudwatchLogsExports = f55f7
+		}
+		if resp.DBCluster.PendingModifiedValues.RdsCustomClusterConfiguration != nil {
+			f55f8 := &svcapitypes.RdsCustomClusterConfiguration{}
+			if resp.DBCluster.PendingModifiedValues.RdsCustomClusterConfiguration.InterconnectSubnetId != nil {
+				f55f8.InterconnectSubnetID = resp.DBCluster.PendingModifiedValues.RdsCustomClusterConfiguration.InterconnectSubnetId
+			}
+			if resp.DBCluster.PendingModifiedValues.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId != nil {
+				f55f8.TransitGatewayMulticastDomainID = resp.DBCluster.PendingModifiedValues.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId
+			}
+			f55.RdsCustomClusterConfiguration = f55f8
+		}
+		if resp.DBCluster.PendingModifiedValues.StorageType != nil {
+			f55.StorageType = resp.DBCluster.PendingModifiedValues.StorageType
+		}
+		cr.Status.AtProvider.PendingModifiedValues = f55
+	} else {
+		cr.Status.AtProvider.PendingModifiedValues = nil
+	}
 	if resp.DBCluster.PercentProgress != nil {
 		cr.Status.AtProvider.PercentProgress = resp.DBCluster.PercentProgress
 	} else {
@@ -530,25 +592,25 @@ func (e *external) Create(ctx context.Context, cr *svcapitypes.DBCluster) (manag
 		cr.Spec.ForProvider.PubliclyAccessible = nil
 	}
 	if resp.DBCluster.RdsCustomClusterConfiguration != nil {
-		f63 := &svcapitypes.RdsCustomClusterConfiguration{}
+		f64 := &svcapitypes.RdsCustomClusterConfiguration{}
 		if resp.DBCluster.RdsCustomClusterConfiguration.InterconnectSubnetId != nil {
-			f63.InterconnectSubnetID = resp.DBCluster.RdsCustomClusterConfiguration.InterconnectSubnetId
+			f64.InterconnectSubnetID = resp.DBCluster.RdsCustomClusterConfiguration.InterconnectSubnetId
 		}
 		if resp.DBCluster.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId != nil {
-			f63.TransitGatewayMulticastDomainID = resp.DBCluster.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId
+			f64.TransitGatewayMulticastDomainID = resp.DBCluster.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId
 		}
-		cr.Spec.ForProvider.RdsCustomClusterConfiguration = f63
+		cr.Spec.ForProvider.RdsCustomClusterConfiguration = f64
 	} else {
 		cr.Spec.ForProvider.RdsCustomClusterConfiguration = nil
 	}
 	if resp.DBCluster.ReadReplicaIdentifiers != nil {
-		f64 := []*string{}
-		for _, f64iter := range resp.DBCluster.ReadReplicaIdentifiers {
-			var f64elem string
-			f64elem = *f64iter
-			f64 = append(f64, &f64elem)
+		f65 := []*string{}
+		for _, f65iter := range resp.DBCluster.ReadReplicaIdentifiers {
+			var f65elem string
+			f65elem = *f65iter
+			f65 = append(f65, &f65elem)
 		}
-		cr.Status.AtProvider.ReadReplicaIdentifiers = f64
+		cr.Status.AtProvider.ReadReplicaIdentifiers = f65
 	} else {
 		cr.Status.AtProvider.ReadReplicaIdentifiers = nil
 	}
@@ -563,38 +625,38 @@ func (e *external) Create(ctx context.Context, cr *svcapitypes.DBCluster) (manag
 		cr.Spec.ForProvider.ReplicationSourceIdentifier = nil
 	}
 	if resp.DBCluster.ScalingConfigurationInfo != nil {
-		f67 := &svcapitypes.ScalingConfigurationInfo{}
+		f68 := &svcapitypes.ScalingConfigurationInfo{}
 		if resp.DBCluster.ScalingConfigurationInfo.AutoPause != nil {
-			f67.AutoPause = resp.DBCluster.ScalingConfigurationInfo.AutoPause
+			f68.AutoPause = resp.DBCluster.ScalingConfigurationInfo.AutoPause
 		}
 		if resp.DBCluster.ScalingConfigurationInfo.MaxCapacity != nil {
-			f67.MaxCapacity = resp.DBCluster.ScalingConfigurationInfo.MaxCapacity
+			f68.MaxCapacity = resp.DBCluster.ScalingConfigurationInfo.MaxCapacity
 		}
 		if resp.DBCluster.ScalingConfigurationInfo.MinCapacity != nil {
-			f67.MinCapacity = resp.DBCluster.ScalingConfigurationInfo.MinCapacity
+			f68.MinCapacity = resp.DBCluster.ScalingConfigurationInfo.MinCapacity
 		}
 		if resp.DBCluster.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
-			f67.SecondsBeforeTimeout = resp.DBCluster.ScalingConfigurationInfo.SecondsBeforeTimeout
+			f68.SecondsBeforeTimeout = resp.DBCluster.ScalingConfigurationInfo.SecondsBeforeTimeout
 		}
 		if resp.DBCluster.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
-			f67.SecondsUntilAutoPause = resp.DBCluster.ScalingConfigurationInfo.SecondsUntilAutoPause
+			f68.SecondsUntilAutoPause = resp.DBCluster.ScalingConfigurationInfo.SecondsUntilAutoPause
 		}
 		if resp.DBCluster.ScalingConfigurationInfo.TimeoutAction != nil {
-			f67.TimeoutAction = resp.DBCluster.ScalingConfigurationInfo.TimeoutAction
+			f68.TimeoutAction = resp.DBCluster.ScalingConfigurationInfo.TimeoutAction
 		}
-		cr.Status.AtProvider.ScalingConfigurationInfo = f67
+		cr.Status.AtProvider.ScalingConfigurationInfo = f68
 	} else {
 		cr.Status.AtProvider.ScalingConfigurationInfo = nil
 	}
 	if resp.DBCluster.ServerlessV2ScalingConfiguration != nil {
-		f68 := &svcapitypes.ServerlessV2ScalingConfiguration{}
+		f69 := &svcapitypes.ServerlessV2ScalingConfiguration{}
 		if resp.DBCluster.ServerlessV2ScalingConfiguration.MaxCapacity != nil {
-			f68.MaxCapacity = resp.DBCluster.ServerlessV2ScalingConfiguration.MaxCapacity
+			f69.MaxCapacity = resp.DBCluster.ServerlessV2ScalingConfiguration.MaxCapacity
 		}
 		if resp.DBCluster.ServerlessV2ScalingConfiguration.MinCapacity != nil {
-			f68.MinCapacity = resp.DBCluster.ServerlessV2ScalingConfiguration.MinCapacity
+			f69.MinCapacity = resp.DBCluster.ServerlessV2ScalingConfiguration.MinCapacity
 		}
-		cr.Spec.ForProvider.ServerlessV2ScalingConfiguration = f68
+		cr.Spec.ForProvider.ServerlessV2ScalingConfiguration = f69
 	} else {
 		cr.Spec.ForProvider.ServerlessV2ScalingConfiguration = nil
 	}
@@ -614,34 +676,34 @@ func (e *external) Create(ctx context.Context, cr *svcapitypes.DBCluster) (manag
 		cr.Spec.ForProvider.StorageType = nil
 	}
 	if resp.DBCluster.TagList != nil {
-		f72 := []*svcapitypes.Tag{}
-		for _, f72iter := range resp.DBCluster.TagList {
-			f72elem := &svcapitypes.Tag{}
-			if f72iter.Key != nil {
-				f72elem.Key = f72iter.Key
+		f73 := []*svcapitypes.Tag{}
+		for _, f73iter := range resp.DBCluster.TagList {
+			f73elem := &svcapitypes.Tag{}
+			if f73iter.Key != nil {
+				f73elem.Key = f73iter.Key
 			}
-			if f72iter.Value != nil {
-				f72elem.Value = f72iter.Value
+			if f73iter.Value != nil {
+				f73elem.Value = f73iter.Value
 			}
-			f72 = append(f72, f72elem)
+			f73 = append(f73, f73elem)
 		}
-		cr.Status.AtProvider.TagList = f72
+		cr.Status.AtProvider.TagList = f73
 	} else {
 		cr.Status.AtProvider.TagList = nil
 	}
 	if resp.DBCluster.VpcSecurityGroups != nil {
-		f73 := []*svcapitypes.VPCSecurityGroupMembership{}
-		for _, f73iter := range resp.DBCluster.VpcSecurityGroups {
-			f73elem := &svcapitypes.VPCSecurityGroupMembership{}
-			if f73iter.Status != nil {
-				f73elem.Status = f73iter.Status
+		f74 := []*svcapitypes.VPCSecurityGroupMembership{}
+		for _, f74iter := range resp.DBCluster.VpcSecurityGroups {
+			f74elem := &svcapitypes.VPCSecurityGroupMembership{}
+			if f74iter.Status != nil {
+				f74elem.Status = f74iter.Status
 			}
-			if f73iter.VpcSecurityGroupId != nil {
-				f73elem.VPCSecurityGroupID = f73iter.VpcSecurityGroupId
+			if f74iter.VpcSecurityGroupId != nil {
+				f74elem.VPCSecurityGroupID = f74iter.VpcSecurityGroupId
 			}
-			f73 = append(f73, f73elem)
+			f74 = append(f74, f74elem)
 		}
-		cr.Status.AtProvider.VPCSecurityGroups = f73
+		cr.Status.AtProvider.VPCSecurityGroups = f74
 	} else {
 		cr.Status.AtProvider.VPCSecurityGroups = nil
 	}

--- a/pkg/controller/rds/dbcluster/zz_conversions.go
+++ b/pkg/controller/rds/dbcluster/zz_conversions.go
@@ -420,6 +420,68 @@ func GenerateDBCluster(resp *svcsdk.DescribeDBClustersOutput) *svcapitypes.DBClu
 		} else {
 			cr.Spec.ForProvider.NetworkType = nil
 		}
+		if elem.PendingModifiedValues != nil {
+			f55 := &svcapitypes.ClusterPendingModifiedValues{}
+			if elem.PendingModifiedValues.AllocatedStorage != nil {
+				f55.AllocatedStorage = elem.PendingModifiedValues.AllocatedStorage
+			}
+			if elem.PendingModifiedValues.BackupRetentionPeriod != nil {
+				f55.BackupRetentionPeriod = elem.PendingModifiedValues.BackupRetentionPeriod
+			}
+			if elem.PendingModifiedValues.DBClusterIdentifier != nil {
+				f55.DBClusterIdentifier = elem.PendingModifiedValues.DBClusterIdentifier
+			}
+			if elem.PendingModifiedValues.EngineVersion != nil {
+				f55.EngineVersion = elem.PendingModifiedValues.EngineVersion
+			}
+			if elem.PendingModifiedValues.IAMDatabaseAuthenticationEnabled != nil {
+				f55.IAMDatabaseAuthenticationEnabled = elem.PendingModifiedValues.IAMDatabaseAuthenticationEnabled
+			}
+			if elem.PendingModifiedValues.Iops != nil {
+				f55.IOPS = elem.PendingModifiedValues.Iops
+			}
+			if elem.PendingModifiedValues.MasterUserPassword != nil {
+				f55.MasterUserPassword = elem.PendingModifiedValues.MasterUserPassword
+			}
+			if elem.PendingModifiedValues.PendingCloudwatchLogsExports != nil {
+				f55f7 := &svcapitypes.PendingCloudwatchLogsExports{}
+				if elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable != nil {
+					f55f7f0 := []*string{}
+					for _, f55f7f0iter := range elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable {
+						var f55f7f0elem string
+						f55f7f0elem = *f55f7f0iter
+						f55f7f0 = append(f55f7f0, &f55f7f0elem)
+					}
+					f55f7.LogTypesToDisable = f55f7f0
+				}
+				if elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable != nil {
+					f55f7f1 := []*string{}
+					for _, f55f7f1iter := range elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable {
+						var f55f7f1elem string
+						f55f7f1elem = *f55f7f1iter
+						f55f7f1 = append(f55f7f1, &f55f7f1elem)
+					}
+					f55f7.LogTypesToEnable = f55f7f1
+				}
+				f55.PendingCloudwatchLogsExports = f55f7
+			}
+			if elem.PendingModifiedValues.RdsCustomClusterConfiguration != nil {
+				f55f8 := &svcapitypes.RdsCustomClusterConfiguration{}
+				if elem.PendingModifiedValues.RdsCustomClusterConfiguration.InterconnectSubnetId != nil {
+					f55f8.InterconnectSubnetID = elem.PendingModifiedValues.RdsCustomClusterConfiguration.InterconnectSubnetId
+				}
+				if elem.PendingModifiedValues.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId != nil {
+					f55f8.TransitGatewayMulticastDomainID = elem.PendingModifiedValues.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId
+				}
+				f55.RdsCustomClusterConfiguration = f55f8
+			}
+			if elem.PendingModifiedValues.StorageType != nil {
+				f55.StorageType = elem.PendingModifiedValues.StorageType
+			}
+			cr.Status.AtProvider.PendingModifiedValues = f55
+		} else {
+			cr.Status.AtProvider.PendingModifiedValues = nil
+		}
 		if elem.PercentProgress != nil {
 			cr.Status.AtProvider.PercentProgress = elem.PercentProgress
 		} else {
@@ -461,25 +523,25 @@ func GenerateDBCluster(resp *svcsdk.DescribeDBClustersOutput) *svcapitypes.DBClu
 			cr.Spec.ForProvider.PubliclyAccessible = nil
 		}
 		if elem.RdsCustomClusterConfiguration != nil {
-			f63 := &svcapitypes.RdsCustomClusterConfiguration{}
+			f64 := &svcapitypes.RdsCustomClusterConfiguration{}
 			if elem.RdsCustomClusterConfiguration.InterconnectSubnetId != nil {
-				f63.InterconnectSubnetID = elem.RdsCustomClusterConfiguration.InterconnectSubnetId
+				f64.InterconnectSubnetID = elem.RdsCustomClusterConfiguration.InterconnectSubnetId
 			}
 			if elem.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId != nil {
-				f63.TransitGatewayMulticastDomainID = elem.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId
+				f64.TransitGatewayMulticastDomainID = elem.RdsCustomClusterConfiguration.TransitGatewayMulticastDomainId
 			}
-			cr.Spec.ForProvider.RdsCustomClusterConfiguration = f63
+			cr.Spec.ForProvider.RdsCustomClusterConfiguration = f64
 		} else {
 			cr.Spec.ForProvider.RdsCustomClusterConfiguration = nil
 		}
 		if elem.ReadReplicaIdentifiers != nil {
-			f64 := []*string{}
-			for _, f64iter := range elem.ReadReplicaIdentifiers {
-				var f64elem string
-				f64elem = *f64iter
-				f64 = append(f64, &f64elem)
+			f65 := []*string{}
+			for _, f65iter := range elem.ReadReplicaIdentifiers {
+				var f65elem string
+				f65elem = *f65iter
+				f65 = append(f65, &f65elem)
 			}
-			cr.Status.AtProvider.ReadReplicaIdentifiers = f64
+			cr.Status.AtProvider.ReadReplicaIdentifiers = f65
 		} else {
 			cr.Status.AtProvider.ReadReplicaIdentifiers = nil
 		}
@@ -494,38 +556,38 @@ func GenerateDBCluster(resp *svcsdk.DescribeDBClustersOutput) *svcapitypes.DBClu
 			cr.Spec.ForProvider.ReplicationSourceIdentifier = nil
 		}
 		if elem.ScalingConfigurationInfo != nil {
-			f67 := &svcapitypes.ScalingConfigurationInfo{}
+			f68 := &svcapitypes.ScalingConfigurationInfo{}
 			if elem.ScalingConfigurationInfo.AutoPause != nil {
-				f67.AutoPause = elem.ScalingConfigurationInfo.AutoPause
+				f68.AutoPause = elem.ScalingConfigurationInfo.AutoPause
 			}
 			if elem.ScalingConfigurationInfo.MaxCapacity != nil {
-				f67.MaxCapacity = elem.ScalingConfigurationInfo.MaxCapacity
+				f68.MaxCapacity = elem.ScalingConfigurationInfo.MaxCapacity
 			}
 			if elem.ScalingConfigurationInfo.MinCapacity != nil {
-				f67.MinCapacity = elem.ScalingConfigurationInfo.MinCapacity
+				f68.MinCapacity = elem.ScalingConfigurationInfo.MinCapacity
 			}
 			if elem.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
-				f67.SecondsBeforeTimeout = elem.ScalingConfigurationInfo.SecondsBeforeTimeout
+				f68.SecondsBeforeTimeout = elem.ScalingConfigurationInfo.SecondsBeforeTimeout
 			}
 			if elem.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
-				f67.SecondsUntilAutoPause = elem.ScalingConfigurationInfo.SecondsUntilAutoPause
+				f68.SecondsUntilAutoPause = elem.ScalingConfigurationInfo.SecondsUntilAutoPause
 			}
 			if elem.ScalingConfigurationInfo.TimeoutAction != nil {
-				f67.TimeoutAction = elem.ScalingConfigurationInfo.TimeoutAction
+				f68.TimeoutAction = elem.ScalingConfigurationInfo.TimeoutAction
 			}
-			cr.Status.AtProvider.ScalingConfigurationInfo = f67
+			cr.Status.AtProvider.ScalingConfigurationInfo = f68
 		} else {
 			cr.Status.AtProvider.ScalingConfigurationInfo = nil
 		}
 		if elem.ServerlessV2ScalingConfiguration != nil {
-			f68 := &svcapitypes.ServerlessV2ScalingConfiguration{}
+			f69 := &svcapitypes.ServerlessV2ScalingConfiguration{}
 			if elem.ServerlessV2ScalingConfiguration.MaxCapacity != nil {
-				f68.MaxCapacity = elem.ServerlessV2ScalingConfiguration.MaxCapacity
+				f69.MaxCapacity = elem.ServerlessV2ScalingConfiguration.MaxCapacity
 			}
 			if elem.ServerlessV2ScalingConfiguration.MinCapacity != nil {
-				f68.MinCapacity = elem.ServerlessV2ScalingConfiguration.MinCapacity
+				f69.MinCapacity = elem.ServerlessV2ScalingConfiguration.MinCapacity
 			}
-			cr.Spec.ForProvider.ServerlessV2ScalingConfiguration = f68
+			cr.Spec.ForProvider.ServerlessV2ScalingConfiguration = f69
 		} else {
 			cr.Spec.ForProvider.ServerlessV2ScalingConfiguration = nil
 		}
@@ -545,34 +607,34 @@ func GenerateDBCluster(resp *svcsdk.DescribeDBClustersOutput) *svcapitypes.DBClu
 			cr.Spec.ForProvider.StorageType = nil
 		}
 		if elem.TagList != nil {
-			f72 := []*svcapitypes.Tag{}
-			for _, f72iter := range elem.TagList {
-				f72elem := &svcapitypes.Tag{}
-				if f72iter.Key != nil {
-					f72elem.Key = f72iter.Key
+			f73 := []*svcapitypes.Tag{}
+			for _, f73iter := range elem.TagList {
+				f73elem := &svcapitypes.Tag{}
+				if f73iter.Key != nil {
+					f73elem.Key = f73iter.Key
 				}
-				if f72iter.Value != nil {
-					f72elem.Value = f72iter.Value
+				if f73iter.Value != nil {
+					f73elem.Value = f73iter.Value
 				}
-				f72 = append(f72, f72elem)
+				f73 = append(f73, f73elem)
 			}
-			cr.Status.AtProvider.TagList = f72
+			cr.Status.AtProvider.TagList = f73
 		} else {
 			cr.Status.AtProvider.TagList = nil
 		}
 		if elem.VpcSecurityGroups != nil {
-			f73 := []*svcapitypes.VPCSecurityGroupMembership{}
-			for _, f73iter := range elem.VpcSecurityGroups {
-				f73elem := &svcapitypes.VPCSecurityGroupMembership{}
-				if f73iter.Status != nil {
-					f73elem.Status = f73iter.Status
+			f74 := []*svcapitypes.VPCSecurityGroupMembership{}
+			for _, f74iter := range elem.VpcSecurityGroups {
+				f74elem := &svcapitypes.VPCSecurityGroupMembership{}
+				if f74iter.Status != nil {
+					f74elem.Status = f74iter.Status
 				}
-				if f73iter.VpcSecurityGroupId != nil {
-					f73elem.VPCSecurityGroupID = f73iter.VpcSecurityGroupId
+				if f74iter.VpcSecurityGroupId != nil {
+					f74elem.VPCSecurityGroupID = f74iter.VpcSecurityGroupId
 				}
-				f73 = append(f73, f73elem)
+				f74 = append(f74, f74elem)
 			}
-			cr.Status.AtProvider.VPCSecurityGroups = f73
+			cr.Status.AtProvider.VPCSecurityGroups = f74
 		} else {
 			cr.Status.AtProvider.VPCSecurityGroups = nil
 		}

--- a/pkg/controller/rds/dbinstance/setup.go
+++ b/pkg/controller/rds/dbinstance/setup.go
@@ -495,8 +495,10 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 	in.Engine = pointer.LateInitialize(in.Engine, db.Engine)
 
 	in.DBClusterIdentifier = pointer.LateInitialize(in.DBClusterIdentifier, db.DBClusterIdentifier)
-	// if the instance belongs to a cluster, these fields should not be lateinit,
-	// to allow the user to manage these via the cluster
+	// If the instance belongs to a cluster, these fields must not be late-initialized, to allow
+	// the user to manage them via the cluster. AWS echoes the cluster's values per-instance in
+	// DescribeDBInstances, so late-initializing them would plant cluster-owned values into the
+	// spec that are then resent on every ModifyDBInstance, causing perpetual updates.
 	if in.DBClusterIdentifier == nil {
 		in.AllocatedStorage = pointer.LateInitialize(in.AllocatedStorage, db.AllocatedStorage)
 		in.BackupRetentionPeriod = pointer.LateInitialize(in.BackupRetentionPeriod, db.BackupRetentionPeriod)
@@ -507,6 +509,14 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 		in.StorageEncrypted = pointer.LateInitialize(in.StorageEncrypted, db.StorageEncrypted)
 		in.StorageType = pointer.LateInitialize(in.StorageType, db.StorageType)
 		in.EngineVersion = pointer.LateInitialize(in.EngineVersion, db.EngineVersion)
+		in.IOPS = pointer.LateInitialize(in.IOPS, db.Iops)
+		in.MaxAllocatedStorage = pointer.LateInitialize(in.MaxAllocatedStorage, db.MaxAllocatedStorage)
+		in.StorageThroughput = pointer.LateInitialize(in.StorageThroughput, db.StorageThroughput)
+		in.MultiAZ = pointer.LateInitialize(in.MultiAZ, db.MultiAZ)
+		in.AutoMinorVersionUpgrade = pointer.LateInitialize(in.AutoMinorVersionUpgrade, db.AutoMinorVersionUpgrade)
+		if db.Endpoint != nil {
+			in.Port = pointer.LateInitialize(in.Port, db.Endpoint.Port)
+		}
 		if in.DBParameterGroupName == nil {
 			for i := range db.DBParameterGroups {
 				if db.DBParameterGroups[i].DBParameterGroupName != nil {
@@ -522,36 +532,38 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 			}
 		}
 	}
-	in.AutoMinorVersionUpgrade = pointer.LateInitialize(in.AutoMinorVersionUpgrade, db.AutoMinorVersionUpgrade)
 	in.AvailabilityZone = pointer.LateInitialize(in.AvailabilityZone, db.AvailabilityZone)
 	in.CACertificateIdentifier = pointer.LateInitialize(in.CACertificateIdentifier, db.CACertificateIdentifier)
 	in.CharacterSetName = pointer.LateInitialize(in.CharacterSetName, db.CharacterSetName)
 	in.DBName = pointer.LateInitialize(in.DBName, db.DBName)
 	in.EnablePerformanceInsights = pointer.LateInitialize(in.EnablePerformanceInsights, db.PerformanceInsightsEnabled)
-	in.IOPS = pointer.LateInitialize(in.IOPS, db.Iops)
 	kmsKey := handleKmsKey(in.KMSKeyID, db.KmsKeyId)
 	in.KMSKeyID = pointer.LateInitialize(in.KMSKeyID, kmsKey)
 	in.LicenseModel = pointer.LateInitialize(in.LicenseModel, db.LicenseModel)
 	in.MasterUsername = pointer.LateInitialize(in.MasterUsername, db.MasterUsername)
-	in.MaxAllocatedStorage = pointer.LateInitialize(in.MaxAllocatedStorage, db.MaxAllocatedStorage)
-	in.StorageThroughput = pointer.LateInitialize(in.StorageThroughput, db.StorageThroughput)
 
 	if pointer.Int64Value(db.MonitoringInterval) > 0 {
 		in.MonitoringInterval = pointer.LateInitialize(in.MonitoringInterval, db.MonitoringInterval)
 	}
 
 	in.MonitoringRoleARN = pointer.LateInitialize(in.MonitoringRoleARN, db.MonitoringRoleArn)
-	in.MultiAZ = pointer.LateInitialize(in.MultiAZ, db.MultiAZ)
-	in.PerformanceInsightsKMSKeyID = pointer.LateInitialize(in.PerformanceInsightsKMSKeyID, db.PerformanceInsightsKMSKeyId)
-	in.PerformanceInsightsRetentionPeriod = pointer.LateInitialize(in.PerformanceInsightsRetentionPeriod, db.PerformanceInsightsRetentionPeriod)
+	// PerformanceInsightsKMSKeyID and PerformanceInsightsRetentionPeriod are only meaningful
+	// while Performance Insights is enabled. AWS omits them from the describe response when PI
+	// is disabled, so a one-directional LateInitialize would leave a stale value stuck in the
+	// spec forever once PI is turned off (perpetual diff and a ModifyDBInstance that AWS
+	// rejects). Fill them only while PI is desired-enabled, and clear them otherwise so a
+	// previously planted value cannot get stuck.
+	if pointer.BoolValue(in.EnablePerformanceInsights) {
+		in.PerformanceInsightsKMSKeyID = pointer.LateInitialize(in.PerformanceInsightsKMSKeyID, db.PerformanceInsightsKMSKeyId)
+		in.PerformanceInsightsRetentionPeriod = pointer.LateInitialize(in.PerformanceInsightsRetentionPeriod, db.PerformanceInsightsRetentionPeriod)
+	} else {
+		in.PerformanceInsightsKMSKeyID = nil
+		in.PerformanceInsightsRetentionPeriod = nil
+	}
 	in.PreferredMaintenanceWindow = pointer.LateInitialize(in.PreferredMaintenanceWindow, db.PreferredMaintenanceWindow)
 	in.PromotionTier = pointer.LateInitialize(in.PromotionTier, db.PromotionTier)
 	in.PubliclyAccessible = pointer.LateInitialize(in.PubliclyAccessible, db.PubliclyAccessible)
 	in.Timezone = pointer.LateInitialize(in.Timezone, db.Timezone)
-
-	if db.Endpoint != nil {
-		in.Port = pointer.LateInitialize(in.Port, db.Endpoint.Port)
-	}
 
 	if len(in.DBSecurityGroups) == 0 && len(db.DBSecurityGroups) != 0 {
 		in.DBSecurityGroups = make([]string, len(db.DBSecurityGroups))
@@ -578,66 +590,10 @@ func lateInitialize(in *svcapitypes.DBInstanceParameters, out *svcsdk.DescribeDB
 	return nil
 }
 
-// setPendingModifiedValues updates the DescribeDBInstancesOutput with any
-// PendingModifiedValues so that they are considered during isUpToDate checks. Exception is Engine version, which is handled separately.
-func setPendingModifiedValues(cr *svcsdk.DescribeDBInstancesOutput) { //nolint:gocyclo
-	if len(cr.DBInstances) > 0 {
-		if cr.DBInstances[0].PendingModifiedValues != nil {
-			if cr.DBInstances[0].PendingModifiedValues.AllocatedStorage != nil {
-				cr.DBInstances[0].AllocatedStorage = cr.DBInstances[0].PendingModifiedValues.AllocatedStorage
-			}
-			if cr.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod != nil {
-				cr.DBInstances[0].BackupRetentionPeriod = cr.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod
-			}
-			if cr.DBInstances[0].PendingModifiedValues.CACertificateIdentifier != nil {
-				cr.DBInstances[0].CACertificateIdentifier = cr.DBInstances[0].PendingModifiedValues.CACertificateIdentifier
-			}
-			if cr.DBInstances[0].PendingModifiedValues.DBInstanceClass != nil {
-				cr.DBInstances[0].DBInstanceClass = cr.DBInstances[0].PendingModifiedValues.DBInstanceClass
-			}
-			if cr.DBInstances[0].PendingModifiedValues.DBSubnetGroupName != nil {
-				cr.DBInstances[0].DBSubnetGroup = &svcsdk.DBSubnetGroup{
-					DBSubnetGroupName: cr.DBInstances[0].PendingModifiedValues.DBSubnetGroupName,
-				}
-			}
-			if cr.DBInstances[0].PendingModifiedValues.DedicatedLogVolume != nil {
-				cr.DBInstances[0].DedicatedLogVolume = cr.DBInstances[0].PendingModifiedValues.DedicatedLogVolume
-			}
-			if cr.DBInstances[0].PendingModifiedValues.Iops != nil {
-				cr.DBInstances[0].Iops = cr.DBInstances[0].PendingModifiedValues.Iops
-			}
-			if cr.DBInstances[0].PendingModifiedValues.LicenseModel != nil {
-				cr.DBInstances[0].LicenseModel = cr.DBInstances[0].PendingModifiedValues.LicenseModel
-			}
-			if cr.DBInstances[0].PendingModifiedValues.MultiAZ != nil {
-				cr.DBInstances[0].MultiAZ = cr.DBInstances[0].PendingModifiedValues.MultiAZ
-			}
-			if cr.DBInstances[0].PendingModifiedValues.Port != nil {
-				if cr.DBInstances[0].Endpoint == nil {
-					cr.DBInstances[0].Endpoint = &svcsdk.Endpoint{}
-				}
-				cr.DBInstances[0].Endpoint.Port = cr.DBInstances[0].PendingModifiedValues.Port
-			}
-			if cr.DBInstances[0].PendingModifiedValues.ProcessorFeatures != nil {
-				cr.DBInstances[0].ProcessorFeatures = cr.DBInstances[0].PendingModifiedValues.ProcessorFeatures
-			}
-			if cr.DBInstances[0].PendingModifiedValues.StorageThroughput != nil {
-				cr.DBInstances[0].StorageThroughput = cr.DBInstances[0].PendingModifiedValues.StorageThroughput
-			}
-			if cr.DBInstances[0].PendingModifiedValues.StorageType != nil {
-				cr.DBInstances[0].StorageType = cr.DBInstances[0].PendingModifiedValues.StorageType
-			}
-			if cr.DBInstances[0].PendingModifiedValues.Port != nil {
-				cr.DBInstances[0].DbInstancePort = cr.DBInstances[0].PendingModifiedValues.Port
-			}
-		}
-	}
-}
-
 func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBInstance, out *svcsdk.DescribeDBInstancesOutput) (upToDate bool, diff string, err error) { //nolint:gocyclo
 	// If ApplyImmediately is not true we update external state of db instance with pending modified values to prevent redundant updates
 	if !ptr.Deref(cr.Spec.ForProvider.ApplyImmediately, false) {
-		setPendingModifiedValues(out)
+		utils.SetPmvDBInstance(out)
 	}
 	db := out.DBInstances[0]
 	patch, err := createPatch(out, &cr.Spec.ForProvider)
@@ -700,15 +656,31 @@ func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBInstance, out
 	// iops/storageThroughput values. Return an error so the resource shows SYNCED=False.
 	iopsChanged := false
 	storageThroughputChanged := false
-	if isStorageTypeGP3BelowAllocatedStorageThreshold(cr) {
-		if pointer.Int64Value(cr.Spec.ForProvider.IOPS) != pointer.Int64Value(db.Iops) ||
-			pointer.Int64Value(cr.Spec.ForProvider.StorageThroughput) != pointer.Int64Value(db.StorageThroughput) {
-			return false, "", fmt.Errorf("cannot reconcile desired iops/storageThroughput: gp3 volumes below %dGB (engine: %s) use fixed defaults (3000 IOPS / 125 MB/s). Increase allocatedStorage to provision custom values",
-				gp3AllocatedStorageThreshold(cr), pointer.StringValue(cr.Spec.ForProvider.Engine))
+	// IOPS and StorageThroughput are managed by the cluster for instances that belong to one,
+	// so they are not late-initialized into the spec and must not be compared here (the spec
+	// value is intentionally nil while AWS echoes the cluster's value, which would otherwise
+	// look like a permanent drift).
+	//
+	// MultiAZ and AutoMinorVersionUpgrade are likewise cluster-managed for cluster members:
+	// AWS returns them as nil in DescribeDBInstances for Aurora cluster instances while the
+	// spec (often populated by a composition) carries a value, which would otherwise cause a
+	// permanent diff and a ModifyDBInstance that AWS ignores. They are ignored in the cmp.Diff
+	// below and only compared here for standalone instances.
+	autoMinorVersionUpgradeChanged := false
+	multiAZChanged := false
+	if db.DBClusterIdentifier == nil {
+		autoMinorVersionUpgradeChanged = pointer.BoolValue(cr.Spec.ForProvider.AutoMinorVersionUpgrade) != pointer.BoolValue(db.AutoMinorVersionUpgrade)
+		multiAZChanged = pointer.BoolValue(cr.Spec.ForProvider.MultiAZ) != pointer.BoolValue(db.MultiAZ)
+		if isStorageTypeGP3BelowAllocatedStorageThreshold(cr) {
+			if pointer.Int64Value(cr.Spec.ForProvider.IOPS) != pointer.Int64Value(db.Iops) ||
+				pointer.Int64Value(cr.Spec.ForProvider.StorageThroughput) != pointer.Int64Value(db.StorageThroughput) {
+				return false, "", fmt.Errorf("cannot reconcile desired iops/storageThroughput: gp3 volumes below %dGB (engine: %s) use fixed defaults (3000 IOPS / 125 MB/s). Increase allocatedStorage to provision custom values",
+					gp3AllocatedStorageThreshold(cr), pointer.StringValue(cr.Spec.ForProvider.Engine))
+			}
+		} else {
+			iopsChanged = !(pointer.Int64Value(cr.Spec.ForProvider.IOPS) == pointer.Int64Value(db.Iops))
+			storageThroughputChanged = !(pointer.Int64Value(cr.Spec.ForProvider.StorageThroughput) == pointer.Int64Value(db.StorageThroughput))
 		}
-	} else {
-		iopsChanged = !(pointer.Int64Value(cr.Spec.ForProvider.IOPS) == pointer.Int64Value(db.Iops))
-		storageThroughputChanged = !(pointer.Int64Value(cr.Spec.ForProvider.StorageThroughput) == pointer.Int64Value(db.StorageThroughput))
 	}
 	s.cache.engineVersionUpToDate = isEngineVersionUpToDate(cr, out)
 	versionChanged := !s.cache.engineVersionUpToDate
@@ -727,6 +699,11 @@ func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBInstance, out
 		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "EngineVersion"),
 		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "IOPS"),
 		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "StorageThroughput"),
+		// MultiAZ and AutoMinorVersionUpgrade are cluster-managed for cluster members (AWS
+		// returns nil for Aurora cluster instances). They are compared explicitly above,
+		// guarded to standalone instances, to avoid a permanent diff for cluster members.
+		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "MultiAZ"),
+		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "AutoMinorVersionUpgrade"),
 		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "Tags"),
 		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "SkipFinalSnapshot"),
 		cmpopts.IgnoreFields(svcapitypes.DBInstanceParameters{}, "FinalDBSnapshotIdentifier"),
@@ -769,7 +746,7 @@ func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBInstance, out
 
 	if diff == "" && !maintenanceWindowChanged && !backupWindowChanged && !backupRetentionPeriodChanged &&
 		!iopsChanged && !storageThroughputChanged && !versionChanged && !vpcSGsChanged && !dbParameterGroupChanged &&
-		!optionGroupChanged && !tagsChanged && !passwordChanged {
+		!optionGroupChanged && !tagsChanged && !passwordChanged && !autoMinorVersionUpgradeChanged && !multiAZChanged {
 		return true, diff, nil
 	}
 
@@ -816,6 +793,12 @@ func (s *shared) isUpToDate(ctx context.Context, cr *svcapitypes.DBInstance, out
 	}
 	if passwordChanged {
 		diff += "\nmaster user password changed"
+	}
+	if autoMinorVersionUpgradeChanged {
+		diff += fmt.Sprintf("\ndesired autoMinorVersionUpgrade: %t \nobserved autoMinorVersionUpgrade: %t ", pointer.BoolValue(cr.Spec.ForProvider.AutoMinorVersionUpgrade), pointer.BoolValue(db.AutoMinorVersionUpgrade))
+	}
+	if multiAZChanged {
+		diff += fmt.Sprintf("\ndesired multiAZ: %t \nobserved multiAZ: %t ", pointer.BoolValue(cr.Spec.ForProvider.MultiAZ), pointer.BoolValue(db.MultiAZ))
 	}
 
 	log.Println(diff)

--- a/pkg/controller/rds/dbinstance/setup_test.go
+++ b/pkg/controller/rds/dbinstance/setup_test.go
@@ -131,6 +131,106 @@ func TestIsUpToDate(t *testing.T) {
 		want
 	}{
 
+		"ClusterMemberIgnoresClusterManagedIops": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							DBClusterIdentifier: aws.String("my-cluster"),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{
+						{
+							DBClusterIdentifier: aws.String("my-cluster"),
+							Iops:                aws.Int64(3000),
+							StorageThroughput:   aws.Int64(125),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				upToDate: true,
+				err:      nil,
+			},
+		},
+		"ClusterMemberIgnoresClusterManagedMultiAZAndAutoMinor": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							DBClusterIdentifier: aws.String("my-cluster"),
+							// Values commonly planted by a composition; AWS returns nil for
+							// Aurora cluster instances, so they must not cause a diff.
+							MultiAZ:                 aws.Bool(false),
+							AutoMinorVersionUpgrade: aws.Bool(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{
+						{
+							DBClusterIdentifier:     aws.String("my-cluster"),
+							MultiAZ:                 nil,
+							AutoMinorVersionUpgrade: nil,
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				upToDate: true,
+				err:      nil,
+			},
+		},
+		"StandaloneDetectsMultiAZChange": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							MultiAZ: aws.Bool(true),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{
+						{
+							MultiAZ: aws.Bool(false),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				upToDate: false,
+				err:      nil,
+			},
+		},
+		"StandaloneDetectsAutoMinorVersionUpgradeChange": {
+			args: args{
+				cr: &svcapitypes.DBInstance{
+					Spec: svcapitypes.DBInstanceSpec{
+						ForProvider: svcapitypes.DBInstanceParameters{
+							AutoMinorVersionUpgrade: aws.Bool(false),
+						},
+					},
+				},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{
+						{
+							AutoMinorVersionUpgrade: aws.Bool(true),
+						},
+					},
+				},
+				kube: test.NewMockClient(),
+			},
+			want: want{
+				upToDate: false,
+				err:      nil,
+			},
+		},
 		"PreferredBackupWindowNotUpToDate": {
 			args: args{
 				cr: &svcapitypes.DBInstance{
@@ -446,7 +546,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: aws.Bool(true),
 							TagList: []*svcsdk.Tag{
-								{Key: aws.String("aws:createdBy"), Value: aws.String("terraform")},
+								{Key: aws.String("aws:createdBy"), Value: aws.String("value")},
 								{Key: aws.String("c7n:policy"), Value: aws.String("auto")},
 								{Key: aws.String("env"), Value: aws.String("prod")},
 							},
@@ -480,7 +580,7 @@ func TestIsUpToDate(t *testing.T) {
 						{
 							DeletionProtection: aws.Bool(true),
 							TagList: []*svcsdk.Tag{
-								{Key: aws.String("aws:createdBy"), Value: aws.String("terraform")},
+								{Key: aws.String("aws:createdBy"), Value: aws.String("value")},
 								{Key: aws.String("c7n:policy"), Value: aws.String("auto")},
 								{Key: aws.String("c7n:other"), Value: aws.String("x")},
 								{Key: aws.String("env"), Value: aws.String("prod")},
@@ -939,6 +1039,141 @@ func TestPreUpdate(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.obj, tc.args.obj, cmpopts.IgnoreUnexported(svcsdk.ModifyDBInstanceInput{})); diff != "" {
 				t.Errorf("ModifyDBInstanceInput: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLateInitialize(t *testing.T) {
+	type args struct {
+		in  *svcapitypes.DBInstanceParameters
+		out *svcsdk.DescribeDBInstancesOutput
+	}
+	type want struct {
+		in *svcapitypes.DBInstanceParameters
+	}
+
+	clusterID := aws.String("my-cluster")
+
+	cases := map[string]struct {
+		args
+		want
+	}{
+		// Cluster-managed storage/network fields must not be planted into the spec for
+		// instances that belong to a cluster, otherwise they get resent on every modify.
+		"ClusterMemberDoesNotLateInitClusterManagedFields": {
+			args: args{
+				in: &svcapitypes.DBInstanceParameters{},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{{
+						DBClusterIdentifier: clusterID,
+						Iops:                aws.Int64(3000),
+						StorageThroughput:   aws.Int64(125),
+						MaxAllocatedStorage: aws.Int64(200),
+						MultiAZ:             aws.Bool(true),
+						Endpoint:            &svcsdk.Endpoint{Port: aws.Int64(5432)},
+					}},
+				},
+			},
+			want: want{
+				in: &svcapitypes.DBInstanceParameters{
+					DBClusterIdentifier: clusterID,
+				},
+			},
+		},
+		// Standalone instances still late-init those fields.
+		"StandaloneLateInitsClusterManagedFields": {
+			args: args{
+				in: &svcapitypes.DBInstanceParameters{},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{{
+						Iops:                aws.Int64(3000),
+						StorageThroughput:   aws.Int64(125),
+						MaxAllocatedStorage: aws.Int64(200),
+						MultiAZ:             aws.Bool(true),
+						Endpoint:            &svcsdk.Endpoint{Port: aws.Int64(5432)},
+					}},
+				},
+			},
+			want: want{
+				in: &svcapitypes.DBInstanceParameters{
+					IOPS:                aws.Int64(3000),
+					StorageThroughput:   aws.Int64(125),
+					MaxAllocatedStorage: aws.Int64(200),
+					MultiAZ:             aws.Bool(true),
+					Port:                aws.Int64(5432),
+				},
+			},
+		},
+		// A stale PerformanceInsightsRetentionPeriod must be cleared once PI is disabled,
+		// otherwise it sticks in the spec forever (perpetual diff / rejected modify).
+		"ClearsStalePerformanceInsightsRetentionWhenDisabled": {
+			args: args{
+				in: &svcapitypes.DBInstanceParameters{
+					EnablePerformanceInsights:          aws.Bool(false),
+					PerformanceInsightsRetentionPeriod: aws.Int64(62),
+					PerformanceInsightsKMSKeyID:        aws.String("stale-key"),
+				},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{{
+						PerformanceInsightsEnabled: aws.Bool(false),
+					}},
+				},
+			},
+			want: want{
+				in: &svcapitypes.DBInstanceParameters{
+					EnablePerformanceInsights: aws.Bool(false),
+				},
+			},
+		},
+		// The user's desired retention must be preserved while enabling PI even though AWS
+		// still reports PI as disabled during the transition.
+		"KeepsDesiredRetentionWhileEnabling": {
+			args: args{
+				in: &svcapitypes.DBInstanceParameters{
+					EnablePerformanceInsights:          aws.Bool(true),
+					PerformanceInsightsRetentionPeriod: aws.Int64(7),
+				},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{{
+						PerformanceInsightsEnabled: aws.Bool(false),
+					}},
+				},
+			},
+			want: want{
+				in: &svcapitypes.DBInstanceParameters{
+					EnablePerformanceInsights:          aws.Bool(true),
+					PerformanceInsightsRetentionPeriod: aws.Int64(7),
+				},
+			},
+		},
+		// When PI is enabled, retention is late-initialized from AWS.
+		"LateInitsRetentionWhenEnabled": {
+			args: args{
+				in: &svcapitypes.DBInstanceParameters{},
+				out: &svcsdk.DescribeDBInstancesOutput{
+					DBInstances: []*svcsdk.DBInstance{{
+						PerformanceInsightsEnabled:         aws.Bool(true),
+						PerformanceInsightsRetentionPeriod: aws.Int64(7),
+					}},
+				},
+			},
+			want: want{
+				in: &svcapitypes.DBInstanceParameters{
+					EnablePerformanceInsights:          aws.Bool(true),
+					PerformanceInsightsRetentionPeriod: aws.Int64(7),
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := lateInitialize(tc.args.in, tc.args.out); err != nil {
+				t.Fatalf("lateInitialize returned error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want.in, tc.args.in); diff != "" {
+				t.Errorf("lateInitialize: -want, +got:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/rds/utils/pending_modified_values.go
+++ b/pkg/controller/rds/utils/pending_modified_values.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	svcsdk "github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/crossplane-contrib/provider-aws/pkg/utils/pointer"
+)
+
+// SetPmvDBInstance folds any PendingModifiedValues in the DescribeDBInstancesOutput into
+// the observed fields, so that they are taken into account during isUpToDate checks. The
+// engine version is an exception and is handled separately.
+func SetPmvDBInstance(obs *svcsdk.DescribeDBInstancesOutput) { //nolint:gocyclo
+	if len(obs.DBInstances) > 0 {
+		if obs.DBInstances[0].PendingModifiedValues != nil {
+			if obs.DBInstances[0].PendingModifiedValues.AllocatedStorage != nil {
+				obs.DBInstances[0].AllocatedStorage = obs.DBInstances[0].PendingModifiedValues.AllocatedStorage
+			}
+			if obs.DBInstances[0].PendingModifiedValues.AutomationMode != nil {
+				obs.DBInstances[0].AutomationMode = obs.DBInstances[0].PendingModifiedValues.AutomationMode
+			}
+			if obs.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod != nil {
+				obs.DBInstances[0].BackupRetentionPeriod = obs.DBInstances[0].PendingModifiedValues.BackupRetentionPeriod
+			}
+			if obs.DBInstances[0].PendingModifiedValues.CACertificateIdentifier != nil {
+				obs.DBInstances[0].CACertificateIdentifier = obs.DBInstances[0].PendingModifiedValues.CACertificateIdentifier
+			}
+			if obs.DBInstances[0].PendingModifiedValues.DBInstanceClass != nil {
+				obs.DBInstances[0].DBInstanceClass = obs.DBInstances[0].PendingModifiedValues.DBInstanceClass
+			}
+			if obs.DBInstances[0].PendingModifiedValues.DBSubnetGroupName != nil {
+				obs.DBInstances[0].DBSubnetGroup = &svcsdk.DBSubnetGroup{
+					DBSubnetGroupName: obs.DBInstances[0].PendingModifiedValues.DBSubnetGroupName,
+				}
+			}
+			if obs.DBInstances[0].PendingModifiedValues.DedicatedLogVolume != nil {
+				obs.DBInstances[0].DedicatedLogVolume = obs.DBInstances[0].PendingModifiedValues.DedicatedLogVolume
+			}
+			if obs.DBInstances[0].PendingModifiedValues.Iops != nil {
+				obs.DBInstances[0].Iops = obs.DBInstances[0].PendingModifiedValues.Iops
+			}
+			if obs.DBInstances[0].PendingModifiedValues.LicenseModel != nil {
+				obs.DBInstances[0].LicenseModel = obs.DBInstances[0].PendingModifiedValues.LicenseModel
+			}
+			if obs.DBInstances[0].PendingModifiedValues.MultiAZ != nil {
+				obs.DBInstances[0].MultiAZ = obs.DBInstances[0].PendingModifiedValues.MultiAZ
+			}
+			if obs.DBInstances[0].PendingModifiedValues.PendingCloudwatchLogsExports != nil {
+				applyInstancePendingCloudwatchLogsExports(obs)
+			}
+			if obs.DBInstances[0].PendingModifiedValues.Port != nil {
+				if obs.DBInstances[0].Endpoint == nil {
+					obs.DBInstances[0].Endpoint = &svcsdk.Endpoint{}
+				}
+				obs.DBInstances[0].Endpoint.Port = obs.DBInstances[0].PendingModifiedValues.Port
+				obs.DBInstances[0].DbInstancePort = obs.DBInstances[0].PendingModifiedValues.Port
+			}
+			if obs.DBInstances[0].PendingModifiedValues.ProcessorFeatures != nil {
+				obs.DBInstances[0].ProcessorFeatures = obs.DBInstances[0].PendingModifiedValues.ProcessorFeatures
+			}
+			if obs.DBInstances[0].PendingModifiedValues.StorageThroughput != nil {
+				obs.DBInstances[0].StorageThroughput = obs.DBInstances[0].PendingModifiedValues.StorageThroughput
+			}
+			if obs.DBInstances[0].PendingModifiedValues.StorageType != nil {
+				obs.DBInstances[0].StorageType = obs.DBInstances[0].PendingModifiedValues.StorageType
+			}
+		}
+	}
+}
+
+// SetPmvDBCluster folds any PendingModifiedValues in the DescribeDBClustersOutput into the
+// observed fields, so that they are taken into account during isUpToDate checks. The engine
+// version is an exception and is handled separately.
+func SetPmvDBCluster(obs *svcsdk.DescribeDBClustersOutput) {
+	if len(obs.DBClusters) > 0 {
+		if obs.DBClusters[0].PendingModifiedValues != nil {
+			if obs.DBClusters[0].PendingModifiedValues.AllocatedStorage != nil {
+				obs.DBClusters[0].AllocatedStorage = obs.DBClusters[0].PendingModifiedValues.AllocatedStorage
+			}
+			if obs.DBClusters[0].PendingModifiedValues.BackupRetentionPeriod != nil {
+				obs.DBClusters[0].BackupRetentionPeriod = obs.DBClusters[0].PendingModifiedValues.BackupRetentionPeriod
+			}
+			if obs.DBClusters[0].PendingModifiedValues.IAMDatabaseAuthenticationEnabled != nil {
+				obs.DBClusters[0].IAMDatabaseAuthenticationEnabled = obs.DBClusters[0].PendingModifiedValues.IAMDatabaseAuthenticationEnabled
+			}
+			if obs.DBClusters[0].PendingModifiedValues.Iops != nil {
+				obs.DBClusters[0].Iops = obs.DBClusters[0].PendingModifiedValues.Iops
+			}
+			if obs.DBClusters[0].PendingModifiedValues.PendingCloudwatchLogsExports != nil {
+				applyClusterPendingCloudwatchLogsExports(obs)
+			}
+			if obs.DBClusters[0].PendingModifiedValues.RdsCustomClusterConfiguration != nil {
+				obs.DBClusters[0].RdsCustomClusterConfiguration = obs.DBClusters[0].PendingModifiedValues.RdsCustomClusterConfiguration
+			}
+			if obs.DBClusters[0].PendingModifiedValues.StorageType != nil {
+				obs.DBClusters[0].StorageType = obs.DBClusters[0].PendingModifiedValues.StorageType
+			}
+		}
+	}
+}
+
+func applyInstancePendingCloudwatchLogsExports(cr *svcsdk.DescribeDBInstancesOutput) { //nolint:gocyclo
+	if len(cr.DBInstances) == 0 || cr.DBInstances[0].PendingModifiedValues == nil {
+		return
+	}
+
+	pending := cr.DBInstances[0].PendingModifiedValues.PendingCloudwatchLogsExports
+	if pending == nil {
+		return
+	}
+
+	// Handle LogTypesToDisable
+	if pending.LogTypesToDisable != nil {
+		disableSet := make(map[string]struct{}, len(pending.LogTypesToDisable))
+		for _, logType := range pending.LogTypesToDisable {
+			disableSet[pointer.StringValue(logType)] = struct{}{}
+		}
+
+		filtered := make([]*string, 0)
+		for _, enabled := range cr.DBInstances[0].EnabledCloudwatchLogsExports {
+			if _, shouldDisable := disableSet[pointer.StringValue(enabled)]; !shouldDisable {
+				filtered = append(filtered, enabled)
+			}
+		}
+		cr.DBInstances[0].EnabledCloudwatchLogsExports = filtered
+	}
+
+	// Handle LogTypesToEnable
+	if pending.LogTypesToEnable != nil {
+		for _, toEnable := range pending.LogTypesToEnable {
+			enableStr := pointer.StringValue(toEnable)
+			found := false
+			for _, enabled := range cr.DBInstances[0].EnabledCloudwatchLogsExports {
+				if pointer.StringValue(enabled) == enableStr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				cr.DBInstances[0].EnabledCloudwatchLogsExports = append(cr.DBInstances[0].EnabledCloudwatchLogsExports, toEnable)
+			}
+		}
+	}
+}
+
+func applyClusterPendingCloudwatchLogsExports(cr *svcsdk.DescribeDBClustersOutput) { //nolint:gocyclo
+	if len(cr.DBClusters) == 0 || cr.DBClusters[0].PendingModifiedValues == nil {
+		return
+	}
+
+	pending := cr.DBClusters[0].PendingModifiedValues.PendingCloudwatchLogsExports
+	if pending == nil {
+		return
+	}
+
+	// Handle LogTypesToDisable
+	if pending.LogTypesToDisable != nil {
+		disableSet := make(map[string]struct{}, len(pending.LogTypesToDisable))
+		for _, logType := range pending.LogTypesToDisable {
+			disableSet[pointer.StringValue(logType)] = struct{}{}
+		}
+
+		filtered := make([]*string, 0)
+		for _, enabled := range cr.DBClusters[0].EnabledCloudwatchLogsExports {
+			if _, shouldDisable := disableSet[pointer.StringValue(enabled)]; !shouldDisable {
+				filtered = append(filtered, enabled)
+			}
+		}
+		cr.DBClusters[0].EnabledCloudwatchLogsExports = filtered
+	}
+
+	// Handle LogTypesToEnable
+	if pending.LogTypesToEnable != nil {
+		for _, toEnable := range pending.LogTypesToEnable {
+			enableStr := pointer.StringValue(toEnable)
+			found := false
+			for _, enabled := range cr.DBClusters[0].EnabledCloudwatchLogsExports {
+				if pointer.StringValue(enabled) == enableStr {
+					found = true
+					break
+				}
+			}
+			if !found {
+				cr.DBClusters[0].EnabledCloudwatchLogsExports = append(cr.DBClusters[0].EnabledCloudwatchLogsExports, toEnable)
+			}
+		}
+	}
+}


### PR DESCRIPTION

### Summary

This PR fixes several perpetual-drift / infinite-reconcile bugs in the RDS DBCluster and DBInstance controllers, and adds pendingModifiedValues observation to DBCluster (mirroring the existing DBInstance behavior). The bugs surfaced in real Aurora PostgreSQL clusters where the controller would loop forever reporting differences it could never resolve, blocking legitimate updates.

### Motivation

On live Aurora clusters we observed the controller repeatedly logging Found observed difference(s) and issuing Modify calls that never converged. Root causes were a mix of: cluster-managed fields being late-initialized into instance specs, and write-only fields being compared against values AWS never echoes back.

### Changes

#### 1. New feature — `DBCluster.status.atProvider.pendingModifiedValues`
- Un-ignored `DBCluster.PendingModifiedValues` in `generator-config.yaml` and regenerated the ACK types/CRD/conversions so pending AWS modifications are now surfaced on `DBCluster`, consistent with `DBInstance`.
- Added `pkg/controller/rds/utils/pending_modified_values.go` with `SetPmvDBCluster` / `SetPmvDBInstance`, which fold pending values into the observed state when `applyImmediately: false`, so the controller doesn't report redundant diffs for changes AWS has already accepted but not yet applied.

#### 2. Fix — perpetual drift on `AutoMinorVersionUpgrade` / `MultiAZ`
- For Aurora, AWS returns `AutoMinorVersionUpgrade` (cluster) and `AutoMinorVersionUpgrade` / `MultiAZ` (cluster-member instances) as `nil`, while the spec (often populated by a composition) carries a value. Because `cmpopts.EquateEmpty()` does **not** equate `&false` / `&true` to `nil`, this produced a permanent diff and a `Modify*` call AWS ignores.
- These fields are now ignored in the structural `cmp.Diff` and compared explicitly only when meaningful: for `DBCluster` only when AWS returns a non-nil value; for `DBInstance` only for standalone instances (`DBClusterIdentifier == nil`).

#### 3. Fix — `DBInstance` lateInitialize planting cluster-managed values
- `lateInitialize` was copying cluster-owned values (`IOPS`, `MaxAllocatedStorage`, `StorageThroughput`, `MultiAZ`, `Port`, `AutoMinorVersionUpgrade`) from the AWS response into the instance spec for cluster members, which were then resent on every `ModifyDBInstance`, causing perpetual updates. These are now guarded behind `DBClusterIdentifier == nil` (standalone-only).

#### 4. Fix — `EnablePerformanceInsights` infinite drift on `DBCluster`
- `GenerateDBCluster` routes `PerformanceInsightsEnabled` into `Status.AtProvider`, so `isUpToDate` never detected PI enable/disable, and the `PerformanceInsightsRetentionPeriod` / `KMSKeyID` comparison looped when PI was disabled.
- Added explicit `EnablePerformanceInsights` detection, gated retention/KMS comparison (only when PI is enabled), and `preUpdate` stripping of retention/KMS when PI is disabled. The equivalent PI "trap" in `DBInstance.lateInitialize` (retention/KMS filled while PI disabled) is also fixed.

#### 5. Fix — misspelled transient status guard on `DBCluster`
- The `isUpToDate` early-return guard checked for `"prepairing-data-migration"` (typo), so it never matched AWS's `preparing-data-migration` status. Corrected the spelling so the controller correctly skips diffing while the cluster is in that transient state.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #2327

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- `go build ./...` — green.
- `go test ./pkg/controller/rds/... -count=1` — green.
- Added table-driven cases for: `AutoMinorVersionUpgrade` mapped/unmapped, cluster-member `MultiAZ` / `AutoMinorVersionUpgrade` ignored, standalone change detection, and the PI enable/disable/retention scenarios.
- Validated against a live Aurora PostgreSQL cluster reproducing the original loops.

