### PR TITLE
fix(vpcendpoint): apply tags on create and reconcile drift

### DIFF
--- a/pkg/clients/ec2/fake/vpcendpoint.go
+++ b/pkg/clients/ec2/fake/vpcendpoint.go
@@ -17,6 +17,8 @@ type MockVPCEndpointClient struct {
 	MockModifyVpcEndpointWithContext    func(context.Context, *ec2.ModifyVpcEndpointInput, ...request.Option) (*ec2.ModifyVpcEndpointOutput, error)
 	MockDescribeVpcEndpoints            func(*ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error)
 	MockDescribeVpcEndpointsWithContext func(context.Context, *ec2.DescribeVpcEndpointsInput, ...request.Option) (*ec2.DescribeVpcEndpointsOutput, error)
+	MockCreateTagsWithContext           func(context.Context, *ec2.CreateTagsInput, ...request.Option) (*ec2.CreateTagsOutput, error)
+	MockDeleteTagsWithContext           func(context.Context, *ec2.DeleteTagsInput, ...request.Option) (*ec2.DeleteTagsOutput, error)
 }
 
 // CreateVpcEndpointWithContext mocks CreateVpcEndpointWithContext
@@ -42,4 +44,14 @@ func (m *MockVPCEndpointClient) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpo
 // DescribeVpcEndpointsWithContext mocks DescribeVpcEndpointsWithContext
 func (m *MockVPCEndpointClient) DescribeVpcEndpointsWithContext(ctx context.Context, input *ec2.DescribeVpcEndpointsInput, req ...request.Option) (*ec2.DescribeVpcEndpointsOutput, error) {
 	return m.MockDescribeVpcEndpointsWithContext(ctx, input)
+}
+
+// CreateTagsWithContext mocks CreateTagsWithContext
+func (m *MockVPCEndpointClient) CreateTagsWithContext(ctx context.Context, input *ec2.CreateTagsInput, req ...request.Option) (*ec2.CreateTagsOutput, error) {
+	return m.MockCreateTagsWithContext(ctx, input)
+}
+
+// DeleteTagsWithContext mocks DeleteTagsWithContext
+func (m *MockVPCEndpointClient) DeleteTagsWithContext(ctx context.Context, input *ec2.DeleteTagsInput, req ...request.Option) (*ec2.DeleteTagsOutput, error) {
+	return m.MockDeleteTagsWithContext(ctx, input)
 }

--- a/pkg/controller/ec2/vpcendpoint/setup.go
+++ b/pkg/controller/ec2/vpcendpoint/setup.go
@@ -26,6 +26,43 @@ import (
 	custommanaged "github.com/crossplane-contrib/provider-aws/pkg/utils/reconciler/managed"
 )
 
+const vpcEndpointTagResource = "vpc-endpoint"
+
+// generateVPCEndpointTagSpecifications converts the CR tags to AWS TagSpecifications.
+func generateVPCEndpointTagSpecifications(tags map[string]string) []*svcsdk.TagSpecification {
+	ec2Tags := make([]*svcsdk.Tag, 0, len(tags))
+	for k, v := range tags {
+		ec2Tags = append(ec2Tags, &svcsdk.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
+	}
+	return []*svcsdk.TagSpecification{{
+		ResourceType: aws.String(vpcEndpointTagResource),
+		Tags:         ec2Tags,
+	}}
+}
+
+// diffVPCEndpointTags returns the tags that should be added and removed.
+func diffVPCEndpointTags(spec map[string]string, current []*svcsdk.Tag) (addTags, removeTags []*svcsdk.Tag) {
+	addMap := make(map[string]string, len(spec))
+	for k, v := range spec {
+		addMap[k] = v
+	}
+	removeMap := make(map[string]string)
+	for _, t := range current {
+		if addMap[pointer.StringValue(t.Key)] == pointer.StringValue(t.Value) {
+			delete(addMap, pointer.StringValue(t.Key))
+			continue
+		}
+		removeMap[pointer.StringValue(t.Key)] = pointer.StringValue(t.Value)
+	}
+	for k, v := range addMap {
+		addTags = append(addTags, &svcsdk.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
+	}
+	for k, v := range removeMap {
+		removeTags = append(removeTags, &svcsdk.Tag{Key: pointer.ToOrNilIfZeroValue(k), Value: pointer.ToOrNilIfZeroValue(v)})
+	}
+	return addTags, removeTags
+}
+
 // SetupVPCEndpoint adds a controller that reconciles VPCEndpoint.
 func SetupVPCEndpoint(mgr ctrl.Manager, o controller.Options) error {
 	name := managed.ControllerName(svcapitypes.VPCEndpointGroupKind)
@@ -101,6 +138,10 @@ func preCreate(_ context.Context, cr *svcapitypes.VPCEndpoint, obj *svcsdk.Creat
 		obj.SubnetIds = cr.Spec.ForProvider.SubnetIDs
 	}
 
+	if cr.Spec.ForProvider.Tags != nil {
+		obj.TagSpecifications = generateVPCEndpointTagSpecifications(cr.Spec.ForProvider.Tags)
+	}
+
 	return nil
 }
 
@@ -144,6 +185,11 @@ func postObserve(_ context.Context, cr *svcapitypes.VPCEndpoint, resp *svcsdk.De
 
 // isUpToDate checks for the following mutable fields for the VPCEndpoint in upstream AWS
 func isUpToDate(_ context.Context, cr *svcapitypes.VPCEndpoint, obj *svcsdk.DescribeVpcEndpointsOutput) (bool, string, error) {
+	// Check tags
+	if add, remove := diffVPCEndpointTags(cr.Spec.ForProvider.Tags, obj.VpcEndpoints[0].Tags); len(add) > 0 || len(remove) > 0 {
+		return false, "", nil
+	}
+
 	// Check subnets
 	if !listCompareStringPtrIsSame(obj.VpcEndpoints[0].SubnetIds, cr.Spec.ForProvider.SubnetIDs) {
 		return false, "", nil
@@ -217,6 +263,25 @@ sgCompare:
 	obj.SetRemoveSubnetIds(removeSubnets)
 	obj.SetRemoveSecurityGroupIds(removeSGs)
 	obj.SetRemoveRouteTableIds(removeRTs)
+
+	// Reconcile tags
+	addTags, removeTags := diffVPCEndpointTags(cr.Spec.ForProvider.Tags, upstream.VpcEndpoints[0].Tags)
+	if len(removeTags) > 0 {
+		if _, err := e.client.DeleteTagsWithContext(ctx, &svcsdk.DeleteTagsInput{
+			Resources: []*string{obj.VpcEndpointId},
+			Tags:      removeTags,
+		}); err != nil {
+			return err
+		}
+	}
+	if len(addTags) > 0 {
+		if _, err := e.client.CreateTagsWithContext(ctx, &svcsdk.CreateTagsInput{
+			Resources: []*string{obj.VpcEndpointId},
+			Tags:      addTags,
+		}); err != nil {
+			return err
+		}
+	}
 
 	formatModifyVpcEndpointInput(obj)
 	return nil

--- a/pkg/controller/ec2/vpcendpoint/setup_tags_test.go
+++ b/pkg/controller/ec2/vpcendpoint/setup_tags_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpcendpoint
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane-contrib/provider-aws/apis/ec2/v1alpha1"
+	"github.com/crossplane-contrib/provider-aws/pkg/clients/ec2/fake"
+)
+
+func TestGenerateVPCEndpointTagSpecifications(t *testing.T) {
+	cases := map[string]struct {
+		tags map[string]string
+		want []*ec2.TagSpecification
+	}{
+		"Empty": {
+			tags: map[string]string{},
+			want: []*ec2.TagSpecification{{ResourceType: aws.String(vpcEndpointTagResource), Tags: []*ec2.Tag{}}},
+		},
+		"SingleTag": {
+			tags: map[string]string{"Name": "my-endpoint"},
+			want: []*ec2.TagSpecification{{ResourceType: aws.String(vpcEndpointTagResource), Tags: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("my-endpoint")}}}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.want, generateVPCEndpointTagSpecifications(tc.tags)); diff != "" {
+				t.Errorf("generateVPCEndpointTagSpecifications() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDiffVPCEndpointTags(t *testing.T) {
+	cases := map[string]struct {
+		spec       map[string]string
+		current    []*ec2.Tag
+		wantAdd    []*ec2.Tag
+		wantRemove []*ec2.Tag
+	}{
+		"NoChange": {
+			spec:       map[string]string{"Name": "my-endpoint"},
+			current:    []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("my-endpoint")}},
+			wantAdd:    nil,
+			wantRemove: nil,
+		},
+		"AddTag": {
+			spec:       map[string]string{"Name": "my-endpoint"},
+			current:    nil,
+			wantAdd:    []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("my-endpoint")}},
+			wantRemove: nil,
+		},
+		"RemoveTag": {
+			spec:       map[string]string{},
+			current:    []*ec2.Tag{{Key: aws.String("Old"), Value: aws.String("gone")}},
+			wantAdd:    nil,
+			wantRemove: []*ec2.Tag{{Key: aws.String("Old"), Value: aws.String("gone")}},
+		},
+		"ValueChanged": {
+			spec:       map[string]string{"Name": "new"},
+			current:    []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("old")}},
+			wantAdd:    []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("new")}},
+			wantRemove: []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("old")}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotAdd, gotRemove := diffVPCEndpointTags(tc.spec, tc.current)
+			if diff := cmp.Diff(tc.wantAdd, gotAdd); diff != "" {
+				t.Errorf("addTags mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantRemove, gotRemove); diff != "" {
+				t.Errorf("removeTags mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCreateWithTags(t *testing.T) {
+	var gotInput *ec2.CreateVpcEndpointInput
+	mock := &fake.MockVPCEndpointClient{
+		MockCreateVpcEndpointWithContext: func(_ context.Context, input *ec2.CreateVpcEndpointInput, _ ...request.Option) (*ec2.CreateVpcEndpointOutput, error) {
+			gotInput = input
+			return &ec2.CreateVpcEndpointOutput{VpcEndpoint: &ec2.VpcEndpoint{VpcEndpointId: aws.String(testVPCEndpointID)}}, nil
+		},
+	}
+
+	cr := vpcEndpoint(withSpec(v1alpha1.VPCEndpointParameters{
+		CustomVPCEndpointParameters: v1alpha1.CustomVPCEndpointParameters{
+			VPCID: aws.String(testVPCID),
+			Tags:  map[string]string{"Name": "my-endpoint"},
+		},
+	}))
+
+	e := newExternal(nil, mock, []option{setupExternal})
+	if _, err := e.Create(context.Background(), cr); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	want := []*ec2.TagSpecification{{
+		ResourceType: aws.String(vpcEndpointTagResource),
+		Tags:         []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("my-endpoint")}},
+	}}
+	if diff := cmp.Diff(want, gotInput.TagSpecifications); diff != "" {
+		t.Errorf("Create() TagSpecifications mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateTags(t *testing.T) {
+	type captured struct {
+		createTags *ec2.CreateTagsInput
+		deleteTags *ec2.DeleteTagsInput
+	}
+
+	cases := map[string]struct {
+		specTags     map[string]string
+		observedTags []*ec2.Tag
+		wantCreate   []*ec2.Tag
+		wantDelete   []*ec2.Tag
+	}{
+		"AddTag": {
+			specTags:     map[string]string{"Name": "my-endpoint"},
+			observedTags: nil,
+			wantCreate:   []*ec2.Tag{{Key: aws.String("Name"), Value: aws.String("my-endpoint")}},
+		},
+		"RemoveTag": {
+			specTags:     map[string]string{},
+			observedTags: []*ec2.Tag{{Key: aws.String("Old"), Value: aws.String("gone")}},
+			wantDelete:   []*ec2.Tag{{Key: aws.String("Old"), Value: aws.String("gone")}},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &captured{}
+			mock := &fake.MockVPCEndpointClient{
+				MockDescribeVpcEndpoints: func(*ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
+					return &ec2.DescribeVpcEndpointsOutput{VpcEndpoints: []*ec2.VpcEndpoint{{
+						VpcEndpointId: aws.String(testVPCEndpointID),
+						Tags:          tc.observedTags,
+					}}}, nil
+				},
+				MockModifyVpcEndpointWithContext: func(_ context.Context, _ *ec2.ModifyVpcEndpointInput, _ ...request.Option) (*ec2.ModifyVpcEndpointOutput, error) {
+					return &ec2.ModifyVpcEndpointOutput{}, nil
+				},
+				MockCreateTagsWithContext: func(_ context.Context, input *ec2.CreateTagsInput, _ ...request.Option) (*ec2.CreateTagsOutput, error) {
+					c.createTags = input
+					return &ec2.CreateTagsOutput{}, nil
+				},
+				MockDeleteTagsWithContext: func(_ context.Context, input *ec2.DeleteTagsInput, _ ...request.Option) (*ec2.DeleteTagsOutput, error) {
+					c.deleteTags = input
+					return &ec2.DeleteTagsOutput{}, nil
+				},
+			}
+
+			cr := vpcEndpoint(
+				withExternalName(testVPCEndpointID),
+				withSpec(v1alpha1.VPCEndpointParameters{
+					CustomVPCEndpointParameters: v1alpha1.CustomVPCEndpointParameters{
+						Tags: tc.specTags,
+					},
+				}),
+			)
+
+			e := newExternal(nil, mock, []option{setupExternal})
+			if _, err := e.Update(context.Background(), cr); err != nil {
+				t.Fatalf("Update() error = %v", err)
+			}
+
+			var gotCreate []*ec2.Tag
+			if c.createTags != nil {
+				gotCreate = c.createTags.Tags
+			}
+			if diff := cmp.Diff(tc.wantCreate, gotCreate); diff != "" {
+				t.Errorf("CreateTags mismatch (-want +got):\n%s", diff)
+			}
+
+			var gotDelete []*ec2.Tag
+			if c.deleteTags != nil {
+				gotDelete = c.deleteTags.Tags
+			}
+			if diff := cmp.Diff(tc.wantDelete, gotDelete); diff != "" {
+				t.Errorf("DeleteTags mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

VPCEndpoint's `tags` field was not being applied to the AWS resource (issue #2330). This PR adds tag support:

- **Create**: `preCreate` now sets `TagSpecifications` on the `CreateVpcEndpoint` call.
- **Reconcile**: `isUpToDate` detects tag drift, and `preUpdate` reconciles it via `CreateTags`/`DeleteTags`.

### Changes

- `pkg/controller/ec2/vpcendpoint/setup.go` — tag handling in `preCreate`, `isUpToDate`, and `preUpdate`, plus `generateVPCEndpointTagSpecifications` and `diffVPCEndpointTags` helpers.
- `pkg/controller/ec2/vpcendpoint/setup_tags_test.go` — unit tests covering tag generation, tag diff (add/remove/no-change/value-change), create-with-tags, and update reconciliation.
- `pkg/clients/ec2/fake/vpcendpoint.go` — added `CreateTagsWithContext`/`DeleteTagsWithContext` mocks.

### How has this been tested?

- `go test ./pkg/controller/ec2/vpcendpoint/...` — all tests pass
- `go build ./pkg/controller/ec2/vpcendpoint/...` — builds cleanly
- `gofmt` clean

Fixes #2330