### PR TITLE
fix(kms): skip key rotation APIs for non-AWS_KMS origins

### DIFF
--- a/pkg/controller/kms/key/setup.go
+++ b/pkg/controller/kms/key/setup.go
@@ -132,19 +132,24 @@ func (u *updater) update(ctx context.Context, cr *svcapitypes.Key) (managed.Exte
 		return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
 	}
 
-	if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) {
-		// EnableKeyRotation
-		if _, err := u.client.EnableKeyRotationWithContext(ctx, &svcsdk.EnableKeyRotationInput{
-			KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
-		}); err != nil {
-			return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
-		}
-	} else {
-		// DisableKeyRotation
-		if _, err := u.client.DisableKeyRotationWithContext(ctx, &svcsdk.DisableKeyRotationInput{
-			KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
-		}); err != nil {
-			return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
+	// Key rotation is only supported for AWS_KMS keys. Skip it for CloudHSM
+	// (AWS_CLOUDHSM), external (EXTERNAL), and external key store keys, where
+	// the rotation APIs return UnsupportedOperationException.
+	if origin := pointer.StringValue(cr.Spec.ForProvider.Origin); origin == "" || origin == svcsdk.OriginTypeAwsKms {
+		if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) {
+			// EnableKeyRotation
+			if _, err := u.client.EnableKeyRotationWithContext(ctx, &svcsdk.EnableKeyRotationInput{
+				KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
+			}); err != nil {
+				return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
+			}
+		} else {
+			// DisableKeyRotation
+			if _, err := u.client.DisableKeyRotationWithContext(ctx, &svcsdk.DisableKeyRotationInput{
+				KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
+			}); err != nil {
+				return managed.ExternalUpdate{}, errorutils.Wrap(err, errUpdate)
+			}
 		}
 	}
 
@@ -316,15 +321,18 @@ func (o *observer) isUpToDate(_ context.Context, cr *svcapitypes.Key, obj *svcsd
 		return false, "spec.forProvider.policy: " + diff, nil
 	}
 
-	// EnableKeyRotation
-	resRotation, err := o.client.GetKeyRotationStatus(&svcsdk.GetKeyRotationStatusInput{
-		KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
-	})
-	if err != nil {
-		return false, "", errorutils.Wrap(err, "cannot get key rotation status")
-	}
-	if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) != pointer.BoolValue(resRotation.KeyRotationEnabled) {
-		return false, "", nil
+	// Key rotation status is only supported for AWS_KMS keys. Skip it for
+	// CloudHSM (AWS_CLOUDHSM), external (EXTERNAL), and external key store keys.
+	if origin := pointer.StringValue(obj.KeyMetadata.Origin); origin == "" || origin == svcsdk.OriginTypeAwsKms {
+		resRotation, err := o.client.GetKeyRotationStatus(&svcsdk.GetKeyRotationStatusInput{
+			KeyId: pointer.ToOrNilIfZeroValue(meta.GetExternalName(cr)),
+		})
+		if err != nil {
+			return false, "", errorutils.Wrap(err, "cannot get key rotation status")
+		}
+		if pointer.BoolValue(cr.Spec.ForProvider.EnableKeyRotation) != pointer.BoolValue(resRotation.KeyRotationEnabled) {
+			return false, "", nil
+		}
 	}
 
 	// Tags

--- a/pkg/controller/kms/key/setup_test.go
+++ b/pkg/controller/kms/key/setup_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package key
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	svcsdk "github.com/aws/aws-sdk-go/service/kms"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/golang/mock/gomock"
+
+	svcapitypes "github.com/crossplane-contrib/provider-aws/apis/kms/v1alpha1"
+	mockkms "github.com/crossplane-contrib/provider-aws/pkg/clients/mock/kmsiface"
+)
+
+const testPolicy = `{"Version":"2012-10-17","Statement":[]}`
+
+func keyWithOrigin(origin string) *svcapitypes.Key {
+	cr := &svcapitypes.Key{}
+	meta.SetExternalName(cr, "test-key")
+	cr.Spec.ForProvider.Policy = aws.String(testPolicy)
+	cr.Spec.ForProvider.Origin = aws.String(origin)
+	cr.Spec.ForProvider.EnableKeyRotation = aws.Bool(false)
+	return cr
+}
+
+// TestObserverIsUpToDateSkipsRotationForNonKmsOrigin verifies GetKeyRotationStatus
+// is not called for keys whose origin is not AWS_KMS (e.g. AWS_CLOUDHSM or EXTERNAL),
+// where the rotation APIs return UnsupportedOperationException.
+func TestObserverIsUpToDateSkipsRotationForNonKmsOrigin(t *testing.T) {
+	for _, origin := range []string{"AWS_CLOUDHSM", "EXTERNAL", "EXTERNAL_KEY_STORE"} {
+		t.Run(origin, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mock := mockkms.NewMockKMSAPI(ctrl)
+			o := &observer{client: mock}
+
+			cr := keyWithOrigin(origin)
+			obj := &svcsdk.DescribeKeyOutput{
+				KeyMetadata: &svcsdk.KeyMetadata{
+					KeyId:      aws.String("test-key"),
+					KeyState:   aws.String("Enabled"),
+					Origin:     aws.String(origin),
+					Enabled:    aws.Bool(true),
+					KeyManager: aws.String("CUSTOMER"),
+				},
+			}
+
+			mock.EXPECT().GetKeyPolicy(gomock.Any()).Return(&svcsdk.GetKeyPolicyOutput{Policy: aws.String(testPolicy)}, nil)
+			mock.EXPECT().ListResourceTags(gomock.Any()).Return(&svcsdk.ListResourceTagsOutput{}, nil)
+			// GetKeyRotationStatus is intentionally NOT expected: gomock fails the
+			// test if it is called.
+
+			upToDate, _, err := o.isUpToDate(context.Background(), cr, obj)
+			if err != nil {
+				t.Fatalf("isUpToDate() unexpected error: %v", err)
+			}
+			if !upToDate {
+				t.Errorf("isUpToDate() = %v, want true", upToDate)
+			}
+		})
+	}
+}
+
+// TestUpdaterUpdateSkipsRotationForNonKmsOrigin verifies EnableKeyRotation /
+// DisableKeyRotation are not called for non-AWS_KMS origin keys.
+func TestUpdaterUpdateSkipsRotationForNonKmsOrigin(t *testing.T) {
+	for _, origin := range []string{"AWS_CLOUDHSM", "EXTERNAL", "EXTERNAL_KEY_STORE"} {
+		t.Run(origin, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mock := mockkms.NewMockKMSAPI(ctrl)
+			u := &updater{client: mock}
+
+			cr := keyWithOrigin(origin)
+
+			mock.EXPECT().PutKeyPolicyWithContext(gomock.Any(), gomock.Any()).Return(&svcsdk.PutKeyPolicyOutput{}, nil)
+			mock.EXPECT().ListResourceTagsWithContext(gomock.Any(), gomock.Any()).Return(&svcsdk.ListResourceTagsOutput{}, nil)
+			// EnableKeyRotation / DisableKeyRotation are intentionally NOT expected.
+
+			if _, err := u.update(context.Background(), cr); err != nil {
+				t.Fatalf("update() unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2310.

GetKeyRotationStatus, EnableKeyRotation, and DisableKeyRotation are only supported for AWS_KMS keys. For AWS_CLOUDHSM, EXTERNAL, and external key store keys AWS returns UnsupportedOperationException, which caused the reconciler to fail permanently.

Guard both call sites with an origin check:
- `isUpToDate` skips GetKeyRotationStatus unless `KeyMetadata.Origin` is `AWS_KMS` (or unset).
- `update` skips Enable/DisableKeyRotation unless `spec.forProvider.origin` is `AWS_KMS` (or unset).

Tests: added `setup_test.go` covering AWS_CLOUDHSM, EXTERNAL, and EXTERNAL_KEY_STORE origins for both observe and update paths (asserting the rotation APIs are never called).

`go test ./pkg/controller/kms/key/...` passes.