### PR TITLE
fix(cache): allow ReplicationGroup to reference both subnet group and security groups

### DIFF
--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -261,6 +261,7 @@ func LateInitialize(s *v1beta1.ReplicationGroupParameters, rg elasticachetypes.R
 		s.NotificationTopicStatus = pointer.LateInitialize(s.NotificationTopicStatus, cc.NotificationConfiguration.TopicStatus)
 	}
 	s.PreferredMaintenanceWindow = pointer.LateInitialize(s.PreferredMaintenanceWindow, cc.PreferredMaintenanceWindow)
+	s.CacheSubnetGroupName = pointer.LateInitialize(s.CacheSubnetGroupName, cc.CacheSubnetGroupName)
 	if len(s.SecurityGroupIDs) == 0 && len(cc.SecurityGroups) != 0 {
 		s.SecurityGroupIDs = make([]string, len(cc.SecurityGroups))
 		for i, val := range cc.SecurityGroups {
@@ -445,6 +446,10 @@ func cacheClusterNeedsUpdate(kube v1beta1.ReplicationGroupParameters, cc elastic
 }
 
 func sgIDsNeedUpdate(kube []string, cc []elasticachetypes.SecurityGroupMembership) bool {
+	// Empty desired list: field is unspecified/unresolved, not a request to clear groups.
+	if len(kube) == 0 {
+		return false
+	}
 	if len(kube) != len(cc) {
 		return true
 	}
@@ -461,6 +466,9 @@ func sgIDsNeedUpdate(kube []string, cc []elasticachetypes.SecurityGroupMembershi
 }
 
 func sgNamesNeedUpdate(kube []string, cc []elasticachetypes.CacheSecurityGroupMembership) bool {
+	if len(kube) == 0 {
+		return false
+	}
 	if len(kube) != len(cc) {
 		return true
 	}

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -556,6 +556,69 @@ func TestLateInitialize(t *testing.T) {
 				CacheSecurityGroupNames:    []string{cacheSecurityGroupNames[0]},
 			},
 		},
+		{
+			name: "LateInitSecurityGroupIDsKeepsResolvedSubnetGroupName",
+			params: &v1beta1.ReplicationGroupParameters{
+				CacheSubnetGroupName: &cacheSubnetGroupName,
+			},
+			cc: elasticachetypes.CacheCluster{
+				CacheSubnetGroupName: pointer.ToOrNilIfZeroValue(cacheSubnetGroupName),
+				SecurityGroups: []elasticachetypes.SecurityGroupMembership{
+					{SecurityGroupId: pointer.ToOrNilIfZeroValue(securityGroupIDs[0])},
+				},
+			},
+			want: &v1beta1.ReplicationGroupParameters{
+				CacheSubnetGroupName: &cacheSubnetGroupName,
+				SecurityGroupIDs:     []string{securityGroupIDs[0]},
+			},
+		},
+		{
+			name: "LateInitSubnetGroupNameKeepsResolvedSecurityGroupIDs",
+			params: &v1beta1.ReplicationGroupParameters{
+				SecurityGroupIDs: []string{securityGroupIDs[0]},
+			},
+			cc: elasticachetypes.CacheCluster{
+				CacheSubnetGroupName: pointer.ToOrNilIfZeroValue(cacheSubnetGroupName),
+				SecurityGroups: []elasticachetypes.SecurityGroupMembership{
+					{SecurityGroupId: pointer.ToOrNilIfZeroValue(securityGroupIDs[0])},
+				},
+			},
+			want: &v1beta1.ReplicationGroupParameters{
+				CacheSubnetGroupName: &cacheSubnetGroupName,
+				SecurityGroupIDs:     []string{securityGroupIDs[0]},
+			},
+		},
+		{
+			name:   "LateInitBothSubnetGroupNameAndSecurityGroupIDs",
+			params: &v1beta1.ReplicationGroupParameters{},
+			cc: elasticachetypes.CacheCluster{
+				CacheSubnetGroupName: pointer.ToOrNilIfZeroValue(cacheSubnetGroupName),
+				SecurityGroups: []elasticachetypes.SecurityGroupMembership{
+					{SecurityGroupId: pointer.ToOrNilIfZeroValue(securityGroupIDs[0])},
+				},
+			},
+			want: &v1beta1.ReplicationGroupParameters{
+				CacheSubnetGroupName: &cacheSubnetGroupName,
+				SecurityGroupIDs:     []string{securityGroupIDs[0]},
+			},
+		},
+		{
+			name: "DoesNotOverwriteResolvedSubnetAndSecurityGroups",
+			params: &v1beta1.ReplicationGroupParameters{
+				CacheSubnetGroupName: &cacheSubnetGroupName,
+				SecurityGroupIDs:     []string{securityGroupIDs[0]},
+			},
+			cc: elasticachetypes.CacheCluster{
+				CacheSubnetGroupName: pointer.ToOrNilIfZeroValue("other-subnet"),
+				SecurityGroups: []elasticachetypes.SecurityGroupMembership{
+					{SecurityGroupId: pointer.ToOrNilIfZeroValue("sg-other")},
+				},
+			},
+			want: &v1beta1.ReplicationGroupParameters{
+				CacheSubnetGroupName: &cacheSubnetGroupName,
+				SecurityGroupIDs:     []string{securityGroupIDs[0]},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -867,6 +930,41 @@ func TestReplicationGroupNeedsUpdate(t *testing.T) {
 			ccList: []elasticachetypes.CacheCluster{},
 			want:   true,
 		},
+		{
+			name: "NoUpdateWhenBothSubnetAndSecurityGroupsResolved",
+			kube: replicationGroupParams(),
+			rg: elasticachetypes.ReplicationGroup{
+				AutomaticFailover:      elasticachetypes.AutomaticFailoverStatusEnabling,
+				CacheNodeType:          pointer.ToOrNilIfZeroValue(cacheNodeType),
+				MultiAZ:                elasticachetypes.MultiAZStatusEnabled,
+				SnapshotRetentionLimit: pointer.ToIntAsInt32Ptr(&snapshotRetentionLimit),
+				SnapshotWindow:         pointer.ToOrNilIfZeroValue(snapshotWindow),
+			},
+			ccList: []elasticachetypes.CacheCluster{
+				{
+					EngineVersion:              pointer.ToOrNilIfZeroValue(engineVersion),
+					CacheParameterGroup:        &elasticachetypes.CacheParameterGroupStatus{CacheParameterGroupName: pointer.ToOrNilIfZeroValue(cacheParameterGroupName)},
+					NotificationConfiguration:  &elasticachetypes.NotificationConfiguration{TopicArn: pointer.ToOrNilIfZeroValue(notificationTopicARN), TopicStatus: pointer.ToOrNilIfZeroValue(notificationTopicStatus)},
+					PreferredMaintenanceWindow: pointer.ToOrNilIfZeroValue(maintenanceWindow),
+					CacheSubnetGroupName:       pointer.ToOrNilIfZeroValue(cacheSubnetGroupName),
+					SecurityGroups: func() []elasticachetypes.SecurityGroupMembership {
+						ids := make([]elasticachetypes.SecurityGroupMembership, len(securityGroupIDs))
+						for i, id := range securityGroupIDs {
+							ids[i] = elasticachetypes.SecurityGroupMembership{SecurityGroupId: pointer.ToOrNilIfZeroValue(id)}
+						}
+						return ids
+					}(),
+					CacheSecurityGroups: func() []elasticachetypes.CacheSecurityGroupMembership {
+						names := make([]elasticachetypes.CacheSecurityGroupMembership, len(cacheSecurityGroupNames))
+						for i, n := range cacheSecurityGroupNames {
+							names[i] = elasticachetypes.CacheSecurityGroupMembership{CacheSecurityGroupName: pointer.ToOrNilIfZeroValue(n)}
+						}
+						return names
+					}(),
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1044,6 +1142,50 @@ func TestCacheClusterNeedsUpdate(t *testing.T) {
 				CacheParameterGroup:        &elasticachetypes.CacheParameterGroupStatus{CacheParameterGroupName: pointer.ToOrNilIfZeroValue(cacheParameterGroupName)},
 				NotificationConfiguration:  &elasticachetypes.NotificationConfiguration{TopicArn: pointer.ToOrNilIfZeroValue(notificationTopicARN), TopicStatus: pointer.ToOrNilIfZeroValue(notificationTopicStatus)},
 				PreferredMaintenanceWindow: pointer.ToOrNilIfZeroValue(maintenanceWindow),
+				SecurityGroups: func() []elasticachetypes.SecurityGroupMembership {
+					ids := make([]elasticachetypes.SecurityGroupMembership, len(securityGroupIDs))
+					for i, id := range securityGroupIDs {
+						ids[i] = elasticachetypes.SecurityGroupMembership{SecurityGroupId: pointer.ToOrNilIfZeroValue(id)}
+					}
+					return ids
+				}(),
+				CacheSecurityGroups: func() []elasticachetypes.CacheSecurityGroupMembership {
+					names := make([]elasticachetypes.CacheSecurityGroupMembership, len(cacheSecurityGroupNames))
+					for i, n := range cacheSecurityGroupNames {
+						names[i] = elasticachetypes.CacheSecurityGroupMembership{CacheSecurityGroupName: pointer.ToOrNilIfZeroValue(n)}
+					}
+					return names
+				}(),
+			},
+			want: false,
+		},
+		{
+			name: "NoUpdateWhenSecurityGroupIDsUnspecified",
+			kube: replicationGroupParams(func(p *v1beta1.ReplicationGroupParameters) {
+				p.SecurityGroupIDs = nil
+				p.CacheSecurityGroupNames = nil
+			}),
+			cc: elasticachetypes.CacheCluster{
+				EngineVersion:              pointer.ToOrNilIfZeroValue(engineVersion),
+				CacheParameterGroup:        &elasticachetypes.CacheParameterGroupStatus{CacheParameterGroupName: pointer.ToOrNilIfZeroValue(cacheParameterGroupName)},
+				NotificationConfiguration:  &elasticachetypes.NotificationConfiguration{TopicArn: pointer.ToOrNilIfZeroValue(notificationTopicARN), TopicStatus: pointer.ToOrNilIfZeroValue(notificationTopicStatus)},
+				PreferredMaintenanceWindow: pointer.ToOrNilIfZeroValue(maintenanceWindow),
+				CacheSubnetGroupName:       pointer.ToOrNilIfZeroValue(cacheSubnetGroupName),
+				SecurityGroups: []elasticachetypes.SecurityGroupMembership{
+					{SecurityGroupId: pointer.ToOrNilIfZeroValue(securityGroupIDs[0])},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "NoUpdateWhenBothSubnetAndSecurityGroupsResolved",
+			kube: replicationGroupParams(),
+			cc: elasticachetypes.CacheCluster{
+				EngineVersion:              pointer.ToOrNilIfZeroValue(engineVersion),
+				CacheParameterGroup:        &elasticachetypes.CacheParameterGroupStatus{CacheParameterGroupName: pointer.ToOrNilIfZeroValue(cacheParameterGroupName)},
+				NotificationConfiguration:  &elasticachetypes.NotificationConfiguration{TopicArn: pointer.ToOrNilIfZeroValue(notificationTopicARN), TopicStatus: pointer.ToOrNilIfZeroValue(notificationTopicStatus)},
+				PreferredMaintenanceWindow: pointer.ToOrNilIfZeroValue(maintenanceWindow),
+				CacheSubnetGroupName:       pointer.ToOrNilIfZeroValue(cacheSubnetGroupName),
 				SecurityGroups: func() []elasticachetypes.SecurityGroupMembership {
 					ids := make([]elasticachetypes.SecurityGroupMembership, len(securityGroupIDs))
 					for i, id := range securityGroupIDs {

--- a/pkg/controller/cache/replicationgroup/managed_test.go
+++ b/pkg/controller/cache/replicationgroup/managed_test.go
@@ -170,6 +170,14 @@ func withLogDeliveryConfiguration(config v1beta1.LogDeliveryConfiguration) repli
 	return func(r *v1beta1.ReplicationGroup) { r.Spec.ForProvider.LogDeliveryConfiguration = config }
 }
 
+func withSecurityGroupIDs(ids ...string) replicationGroupModifier {
+	return func(r *v1beta1.ReplicationGroup) { r.Spec.ForProvider.SecurityGroupIDs = ids }
+}
+
+func withCacheSubnetGroupName(n string) replicationGroupModifier {
+	return func(r *v1beta1.ReplicationGroup) { r.Spec.ForProvider.CacheSubnetGroupName = &n }
+}
+
 func replicationGroup(rm ...replicationGroupModifier) *v1beta1.ReplicationGroup {
 	r := &v1beta1.ReplicationGroup{
 		ObjectMeta: objectMeta,
@@ -543,6 +551,123 @@ func TestObserve(t *testing.T) {
 				withReplicationGroupID(name),
 				withAuthEnabled(true)),
 			returnsErr: true,
+		},
+		{
+			name: "SuccessfulObserveLateInitSubnetKeepsSecurityGroupIDs",
+			e: &external{
+				cache: &cache{},
+				client: &fake.MockClient{
+					MockDescribeReplicationGroups: func(ctx context.Context, _ *elasticache.DescribeReplicationGroupsInput, opts []func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []types.ReplicationGroup{{
+								Status:                 aws.String(v1beta1.StatusAvailable),
+								AutomaticFailover:      types.AutomaticFailoverStatusEnabled,
+								CacheNodeType:          aws.String(cacheNodeType),
+								SnapshotRetentionLimit: aws.Int32(int32(snapshotRetentionLimit)),
+								SnapshotWindow:         aws.String(snapshotWindow),
+								ClusterEnabled:         aws.Bool(true),
+								MemberClusters:         []string{cacheClusterID},
+								ARN:                    aws.String("arn:aws:elasticache:us-east-1:123:replicationgroup:" + name),
+							}},
+						}, nil
+					},
+					MockDescribeCacheClusters: func(ctx context.Context, _ *elasticache.DescribeCacheClustersInput, opts []func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{
+							CacheClusters: []types.CacheCluster{{
+								EngineVersion:              aws.String(engineVersion),
+								CacheParameterGroup:        &types.CacheParameterGroupStatus{CacheParameterGroupName: aws.String(cacheParameterGroupName)},
+								PreferredMaintenanceWindow: aws.String(maintenanceWindow),
+								CacheSubnetGroupName:       aws.String("coolSubnet"),
+								SecurityGroups: []types.SecurityGroupMembership{
+									{SecurityGroupId: aws.String("sg-123")},
+								},
+							}},
+						}, nil
+					},
+					MockListTagsForResource: func(ctx context.Context, _ *elasticache.ListTagsForResourceInput, opts []func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error) {
+						return &elasticache.ListTagsForResourceOutput{}, nil
+					},
+				},
+				kube: &test.MockClient{
+					MockGet:    test.NewMockGetFn(nil),
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			r: replicationGroup(
+				withReplicationGroupID(name),
+				withClusterEnabled(true),
+				withMemberClusters([]string{cacheClusterID}),
+				withSecurityGroupIDs("sg-123"),
+			),
+			want: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withAutomaticFailover(types.AutomaticFailoverStatusEnabled),
+				withClusterEnabled(true),
+				withMemberClusters([]string{cacheClusterID}),
+				withConditions(xpv1.Available()),
+				withSecurityGroupIDs("sg-123"),
+				withCacheSubnetGroupName("coolSubnet"),
+			),
+		},
+		{
+			name: "SuccessfulObserveBothSubnetAndSecurityGroupsResolved",
+			e: &external{
+				cache: &cache{},
+				client: &fake.MockClient{
+					MockDescribeReplicationGroups: func(ctx context.Context, _ *elasticache.DescribeReplicationGroupsInput, opts []func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []types.ReplicationGroup{{
+								Status:                 aws.String(v1beta1.StatusAvailable),
+								AutomaticFailover:      types.AutomaticFailoverStatusEnabled,
+								CacheNodeType:          aws.String(cacheNodeType),
+								SnapshotRetentionLimit: aws.Int32(int32(snapshotRetentionLimit)),
+								SnapshotWindow:         aws.String(snapshotWindow),
+								ClusterEnabled:         aws.Bool(true),
+								MemberClusters:         []string{cacheClusterID},
+								ARN:                    aws.String("arn:aws:elasticache:us-east-1:123:replicationgroup:" + name),
+							}},
+						}, nil
+					},
+					MockDescribeCacheClusters: func(ctx context.Context, _ *elasticache.DescribeCacheClustersInput, opts []func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{
+							CacheClusters: []types.CacheCluster{{
+								EngineVersion:              aws.String(engineVersion),
+								CacheParameterGroup:        &types.CacheParameterGroupStatus{CacheParameterGroupName: aws.String(cacheParameterGroupName)},
+								PreferredMaintenanceWindow: aws.String(maintenanceWindow),
+								CacheSubnetGroupName:       aws.String("coolSubnet"),
+								SecurityGroups: []types.SecurityGroupMembership{
+									{SecurityGroupId: aws.String("sg-123")},
+								},
+							}},
+						}, nil
+					},
+					MockListTagsForResource: func(ctx context.Context, _ *elasticache.ListTagsForResourceInput, opts []func(*elasticache.Options)) (*elasticache.ListTagsForResourceOutput, error) {
+						return &elasticache.ListTagsForResourceOutput{}, nil
+					},
+				},
+				kube: &test.MockClient{
+					MockGet:    test.NewMockGetFn(nil),
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			r: replicationGroup(
+				withReplicationGroupID(name),
+				withClusterEnabled(true),
+				withMemberClusters([]string{cacheClusterID}),
+				withSecurityGroupIDs("sg-123"),
+				withCacheSubnetGroupName("coolSubnet"),
+			),
+			want: replicationGroup(
+				withReplicationGroupID(name),
+				withProviderStatus(v1beta1.StatusAvailable),
+				withAutomaticFailover(types.AutomaticFailoverStatusEnabled),
+				withClusterEnabled(true),
+				withMemberClusters([]string{cacheClusterID}),
+				withConditions(xpv1.Available()),
+				withSecurityGroupIDs("sg-123"),
+				withCacheSubnetGroupName("coolSubnet"),
+			),
 		},
 		{
 			name: "FailedDescribeReplicationGroups",
@@ -1021,6 +1146,57 @@ func TestIsUpToDate(t *testing.T) {
 						Enabled:   aws.Bool(true),
 					},
 				}),
+			),
+			want: wantIsUpToDate{
+				isUpToDate: true,
+				err:        nil,
+			},
+		},
+		{
+			name: "BothSubnetAndSecurityGroupsResolved",
+			e: &external{
+				cache: &cache{},
+				client: &fake.MockClient{
+					MockDescribeReplicationGroups: func(ctx context.Context, _ *elasticache.DescribeReplicationGroupsInput, opts []func(*elasticache.Options)) (*elasticache.DescribeReplicationGroupsOutput, error) {
+						return &elasticache.DescribeReplicationGroupsOutput{
+							ReplicationGroups: []types.ReplicationGroup{
+								{
+									Status:                 aws.String(v1beta1.StatusModifying),
+									AutomaticFailover:      types.AutomaticFailoverStatusEnabled,
+									CacheNodeType:          aws.String(cacheNodeType),
+									SnapshotRetentionLimit: aws.Int32(int32(snapshotRetentionLimit)),
+									SnapshotWindow:         aws.String(snapshotWindow),
+									ClusterEnabled:         aws.Bool(true),
+									MemberClusters:         []string{cacheClusterID},
+								},
+							},
+						}, nil
+					},
+					MockDescribeCacheClusters: func(ctx context.Context, _ *elasticache.DescribeCacheClustersInput, opts []func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error) {
+						return &elasticache.DescribeCacheClustersOutput{
+							CacheClusters: []types.CacheCluster{
+								{
+									EngineVersion:              aws.String(engineVersion),
+									CacheParameterGroup:        &types.CacheParameterGroupStatus{CacheParameterGroupName: aws.String(cacheParameterGroupName)},
+									PreferredMaintenanceWindow: aws.String(maintenanceWindow),
+									CacheSubnetGroupName:       aws.String("coolSubnet"),
+									SecurityGroups: []types.SecurityGroupMembership{
+										{SecurityGroupId: aws.String("sg-123")},
+									},
+								},
+							},
+						}, nil
+					},
+				},
+				kube: &test.MockClient{
+					MockGet:    test.NewMockGetFn(nil),
+					MockUpdate: test.NewMockUpdateFn(nil),
+				},
+			},
+			cr: replicationGroup(
+				withReplicationGroupID(name),
+				withSecurityGroupIDs("sg-123"),
+				withCacheSubnetGroupName("coolSubnet"),
 			),
 			want: wantIsUpToDate{
 				isUpToDate: true,


### PR DESCRIPTION
### Description

Fixes #2264.

When a `ReplicationGroup` referenced both `cacheSubnetGroupNameRef` and `securityGroupIdRefs`, the reconciler oscillated — describing the resource showed only one of `securityGroupIds` / `cacheSubnetGroupName` populated at a time, flipping every few seconds.

### Root cause

Server-Side Apply: the reference resolver owned both fields. An SSA apply carrying only `cacheSubnetGroupName` dropped `securityGroupIds`, and `sgIDsNeedUpdate` then saw an empty desired list and issued a spurious `ModifyReplicationGroup`. The cycle repeated on every reconcile.

### Fix

- Late-initialize `cacheSubnetGroupName` from the member CacheCluster (alongside the other cluster-sourced fields) so a single observe restores both fields before persist.
- Treat an empty desired security-group list as *unspecified/unresolved* rather than a request to clear groups, avoiding the spurious update while refs are still filling the sibling field.

No change to the deprecated `cacheSubnetGroupNameRefs` path; single-ref and no-ref behavior is unchanged.

### Tests

- `go test ./pkg/clients/elasticache/... ./pkg/controller/cache/replicationgroup/... -count=1` — pass.
